### PR TITLE
refactor(config): remove deprecated top-level system argument

### DIFF
--- a/nix/config.nix
+++ b/nix/config.nix
@@ -21,8 +21,10 @@ let
   osConfiguration =
     host:
     host.instantiate {
-      inherit (host) system;
-      modules = [ self.modules.${host.class}.${host.aspect} ];
+      modules = [
+        self.modules.${host.class}.${host.aspect}
+        { nixpkgs.hostPlatform = lib.mkDefault host.system; }
+      ];
     };
 
   homeConfiguration =


### PR DESCRIPTION
Removes the deprecated top-level `system` argument from OS configurations.

This change aligns with modern NixOS practice, where the system is defined inside modules (e.g., via `nixpkgs.hostPlatform`). This improves build reproducibility.

If we want to still keep a similar behavior, we could add a module option by default to set: `{ nixpkgs.hostPlatform = lib.mkDefault host.system; }`

Related: NixOS/nixpkgs#177012