### PR TITLE
Use den.aspects/den.modules instead of flake.aspects/flake.modules

### DIFF
--- a/nix/aspects.nix
+++ b/nix/aspects.nix
@@ -114,9 +114,9 @@ let
 
 in
 {
-  config.flake.aspects = lib.mkMerge (lib.flatten (defaults ++ deps));
+  config.den.aspects = lib.mkMerge (lib.flatten (defaults ++ deps));
 
-  options.flake.aspects.default = lib.mkOption {
+  options.den.aspects.default = lib.mkOption {
     description = "defaults";
     default = { };
     type = lib.types.submodule {

--- a/nix/flakeModule.nix
+++ b/nix/flakeModule.nix
@@ -1,12 +1,19 @@
-{ inputs, lib, ... }:
+{
+  inputs,
+  lib,
+  config,
+  ...
+}:
 let
-  types = import ./types.nix { inherit inputs lib; };
+  types = import ./types.nix { inherit inputs lib config; };
 in
 {
   imports = [
+    ./scope.nix
     ./config.nix
     ./aspects.nix
   ];
   options.den.hosts = types.hostsOption;
   options.den.homes = types.homesOption;
+  config._module.args.den = config.den;
 }

--- a/nix/scope.nix
+++ b/nix/scope.nix
@@ -1,0 +1,14 @@
+{
+  inputs,
+  lib,
+  config,
+  ...
+}:
+inputs.flake-aspects.lib.newAspects lib (option: modules: {
+  options.den.aspects = option;
+  options.den.modules = lib.mkOption {
+    readOnly = true;
+    type = lib.types.attrsOf (lib.types.attrsOf lib.types.deferredModule);
+    default = modules;
+  };
+}) config.den.aspects

--- a/nix/types.nix
+++ b/nix/types.nix
@@ -1,9 +1,12 @@
 {
   inputs,
   lib,
+  config,
   ...
 }:
 let
+  den = config.den;
+
   hostsOption = lib.mkOption {
     description = "den hosts definition";
     default = { };
@@ -83,11 +86,11 @@ let
           };
           mainModule = lib.mkOption {
             description = ''
-              Defaults to: self.modules.<class>.<aspect>
+              Defaults to: den.modules.<class>.<aspect>
               Can be set in order to access a module in a different place.
             '';
             type = lib.types.deferredModule;
-            default = inputs.self.modules.${config.class}.${config.aspect};
+            default = den.modules.${config.class}.${config.aspect};
           };
         };
       }
@@ -177,11 +180,11 @@ let
           };
           mainModule = lib.mkOption {
             description = ''
-              Defaults to: self.modules.<class>.<aspect>
+              Defaults to: den.modules.<class>.<aspect>
               Can be set in order to access a module in a different place.
             '';
             type = lib.types.deferredModule;
-            default = inputs.self.modules.${config.class}.${config.aspect};
+            default = den.modules.${config.class}.${config.aspect};
           };
         };
       }

--- a/templates/default/flake.lock
+++ b/templates/default/flake.lock
@@ -22,11 +22,11 @@
     },
     "den": {
       "locked": {
-        "lastModified": 1761530965,
-        "narHash": "sha256-ieTMY6bsJbl87/XugjWFid6EN9q1C0rFdaPoYCfm1Kk=",
+        "lastModified": 1761584763,
+        "narHash": "sha256-C6bSwc2dBobqO28ggSwY8RWkhxBAIBvCyM9l3APakaI=",
         "owner": "vic",
         "repo": "den",
-        "rev": "ef58a62952eaf82f391dbe24ec693996d5abc505",
+        "rev": "b1b229f767f64f577e381803bd3802f4688b480e",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "flake-aspects": {
       "locked": {
-        "lastModified": 1761515738,
-        "narHash": "sha256-uW/vyyZDt9UvJbC0xghkjZhuuSnJui/fevMbKsvXV6k=",
+        "lastModified": 1761558021,
+        "narHash": "sha256-RI+i/zIsceZgAlo8hJE/zT48rbQg1S6aSYwMFJxCMYI=",
         "owner": "vic",
         "repo": "flake-aspects",
-        "rev": "0fb045faceaeefa83a85173fd0c4ebf4d47a6d9d",
+        "rev": "c9425a919198f75fd46a4944367a7b7f8ea4eb92",
         "type": "github"
       },
       "original": {
@@ -92,11 +92,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761530345,
-        "narHash": "sha256-+9+YCK9Lh6GThkXu/8JTxMFUnImIdZpb8ElUh6/F5Y8=",
+        "lastModified": 1761584077,
+        "narHash": "sha256-dISPEZahlfs5K6d58zR4akRRyogfE9P4WSyPPNT7HiE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bbaeb9f1c29e79bb1653b32c3d73244cdf4bd888",
+        "rev": "e82585308aef3d4cc2c36c7b6946051c8cdf24ef",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1761450649,
-        "narHash": "sha256-l20QOQZYjmGq3PK0gZ8NJOi3GMKjLd6iwwk54MKwkbk=",
+        "lastModified": 1761563673,
+        "narHash": "sha256-d+1TpVAmRjcNBfjZsh2yQSdwUfN7Xgz1blJ185g73+A=",
         "owner": "nix-community",
         "repo": "nixos-wsl",
-        "rev": "86f85079c8d896b1903c70a919fa3d43c92d6f7f",
+        "rev": "a518cf710e5ebb935518dc7ac98e07e7ee5014c3",
         "type": "github"
       },
       "original": {
@@ -163,11 +163,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761349956,
-        "narHash": "sha256-tH3wHnOJms+U4k/rK2Nn1RfBrhffX92jLP/2VndSn0w=",
+        "lastModified": 1761440988,
+        "narHash": "sha256-2qsow3cQIgZB2g8Cy8cW+L9eXDHP6a1PsvOschk5y+E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "02f2cb8e0feb4596d20cc52fda73ccee960e3538",
+        "rev": "de69d2ba6c70e747320df9c096523b623d3a4c35",
         "type": "github"
       },
       "original": {
@@ -179,11 +179,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1761173472,
-        "narHash": "sha256-m9W0dYXflzeGgKNravKJvTMR4Qqa2MVD11AwlGMufeE=",
+        "lastModified": 1761468971,
+        "narHash": "sha256-vY2OLVg5ZTobdroQKQQSipSIkHlxOTrIF1fsMzPh8w8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c8aa8cc00a5cb57fada0851a038d35c08a36a2bb",
+        "rev": "78e34d1667d32d8a0ffc3eba4591ff256e80576e",
         "type": "github"
       },
       "original": {

--- a/templates/default/modules/_example/aspects.nix
+++ b/templates/default/modules/_example/aspects.nix
@@ -3,7 +3,7 @@
 { inputs, lib, ... }:
 {
 
-  flake.aspects =
+  den.aspects =
     { aspects, ... }:
     {
       # rockhopper.nixos = { };  # config for rockhopper host


### PR DESCRIPTION
Using den scope allows cleaner separation of aspects, so we dont polute generic flake.modules.