### PR TITLE
feat(batteries): add user-shell.

### DIFF
--- a/modules/aspects/provides/user-shell.nix
+++ b/modules/aspects/provides/user-shell.nix
@@ -1,0 +1,28 @@
+{
+  den._.user-shell = {
+    description = ''
+      Sets a user default shell, enables the shell at OS and home level.
+
+      Usage:
+
+        den.aspects.my-user._.user.includes = [
+          (den._.user-shell { shell = "fish"; })
+        ];
+    '';
+
+    __functor =
+      _:
+      { shell }:
+      { user, ... }:
+      {
+        homeManager.programs.${shell}.enable = true;
+        # Help needed: how to set default shell in darwin?
+        nixos =
+          { pkgs, ... }:
+          {
+            programs.${shell}.enable = true;
+            users.users.${user.userName}.shell = pkgs.${shell};
+          };
+      };
+  };
+}

--- a/templates/default/modules/_example/aspects.nix
+++ b/templates/default/modules/_example/aspects.nix
@@ -101,6 +101,9 @@ in
   den.aspects.cam.homeManager.programs.vscode.enable = true;
   den.aspects.cam.includes = [ (den._.unfree { allow = [ "vscode" ]; }) ];
 
+  # will has always loved red snappers
+  den.aspects.will._.user.includes = [ (den._.user-shell { shell = "fish"; }) ];
+
   # Example: user provides host configuration.
   den.aspects.alice._.user.includes = [ host-conditional ];
 

--- a/templates/default/modules/_example/ci.nix
+++ b/templates/default/modules/_example/ci.nix
@@ -1,5 +1,5 @@
 # Adds some checks for CI
-{ self, ... }:
+{ self, lib, ... }:
 {
   perSystem =
     { pkgs, ... }:
@@ -73,6 +73,10 @@
         );
         alice-os-tmux-enabled-off = checkCond "os tmux for hosts having alice" (
           !honeycrisp.config.programs.tmux.enable
+        );
+
+        will-always-love-you = checkCond "red-snapper fish is default shell" (
+          "fish" == lib.getName adelie.config.users.users.will.shell
         );
 
       };


### PR DESCRIPTION
configures user default shell at OS and home level. 

darwin support is pending. PR welcome!