### PR TITLE
Fix the method `host-provides-host-config` name in readme to correct name `host-provides-user-config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ let
   user-provides-host-config = { user, host }:
     vix.${user.aspect}._.${host.aspect} or noop;
 
-  host-provides-host-config = { user, host }:
+  host-provides-user-config = { user, host }:
     vix.${host.aspect}._.${user.aspect} or noop;
 
   route = locator: { user, host }@ctx: 


### PR DESCRIPTION
Very small spelling fix. Noticed an error in the README for the following code snippet:

```nix
# modules/routes.nix
{ den, ... }:
let
  noop = _: { };

  by-platform-config = { host }:
    vix.${host.system} or noop;

  user-provides-host-config = { user, host }:
    vix.${user.aspect}._.${host.aspect} or noop;

  host-provides-host-config = { user, host }:
    vix.${host.aspect}._.${user.aspect} or noop;

  route = locator: { user, host }@ctx: 
    (locator ctx) ctx;
in 
{
  den.aspects.routes.__functor = 
    den.lib.parametric true;
  den.aspects.routes.includes = 
    map route [
      user-provides-host-config
      host-provides-user-config
      by-platform-config
    ];
}
```

The method in this example is `host-provides-host-config`, but should be ` host-provides-user-config `; the second host should be user.
