### PR TITLE
contexts are not strict now

### DIFF
--- a/checkmate/tests/aspect-functor.nix
+++ b/checkmate/tests/aspect-functor.nix
@@ -40,7 +40,7 @@ let
             nixos.user-only = user;
           }
         else
-          { }
+          { nixos.user-only = false; }
       )
       (
         { home, ... }:
@@ -100,6 +100,7 @@ let
     );
     expected = {
       includes = [
+        { nixos.home = 2; }
         { nixos.any = 10; }
       ];
     };
@@ -129,12 +130,15 @@ let
     );
     expected = {
       includes = [
+        { nixos.host = 1; }
         {
           nixos.host-user = [
             1
             2
           ];
         } # host user
+        { nixos.user = 2; }
+        { nixos.user-only = false; }
         { nixos.any = 10; }
       ];
     };

--- a/checkmate/tests/function_can_take.nix
+++ b/checkmate/tests/function_can_take.nix
@@ -62,7 +62,7 @@ let
             user
           ]
         );
-    expected = false;
+    expected = true;
   };
 
 in

--- a/modules/aspects/dependencies.nix
+++ b/modules/aspects/dependencies.nix
@@ -7,19 +7,19 @@ let
 
   dependencies = [
     # owned attributes: <aspect>.<class>
-    ({ home }: owned home.class den.aspects.${home.aspect})
-    ({ host }: owned host.class den.aspects.${host.aspect})
-    ({ user, host }: owned user.class den.aspects.${user.aspect})
+    ({ home, ... }: owned home.class den.aspects.${home.aspect})
+    ({ host, ... }: owned host.class den.aspects.${host.aspect})
+    ({ user, ... }: owned user.class den.aspects.${user.aspect})
 
     # defaults: owned from den.default.<class>
-    ({ home }: owned home.class den.default)
-    ({ host }: owned host.class den.default)
-    ({ user, host }: owned user.class den.default)
+    ({ home, ... }: owned home.class den.default)
+    ({ host, ... }: owned host.class den.default)
+    ({ user, ... }: owned user.class den.default)
 
     # static (non-parametric) from <aspect>.includes
-    ({ home }: statics den.aspects.${home.aspect})
-    ({ host }: statics den.aspects.${host.aspect})
-    ({ user, host }: statics den.aspects.${user.aspect})
+    ({ home, ... }: statics den.aspects.${home.aspect})
+    ({ host, ... }: statics den.aspects.${host.aspect})
+    ({ user, ... }: statics den.aspects.${user.aspect})
 
     # user-to-host context
     ({ fromUser, toHost }: owned toHost.class den.aspects.${fromUser.aspect})
@@ -34,7 +34,7 @@ let
   ];
 
   hostIncludesFromUsers =
-    { host }:
+    { host, ... }:
     {
       includes =
         let

--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -28,7 +28,7 @@
 
     __functor =
       _:
-      { host }:
+      { host, ... }:
       { class, aspect-chain }:
       let
         hmUsers = builtins.filter (u: u.class == "homeManager") (lib.attrValues host.users);

--- a/modules/aspects/provides/import-tree.nix
+++ b/modules/aspects/provides/import-tree.nix
@@ -61,7 +61,8 @@
 
   den._.import-tree.__functor =
     _: root:
-    { class, ... }:
+    # deadnix: skip
+    { class, aspect-chain }:
     let
       path = "${toString root}/_${class}";
       aspect.${class}.imports = [ (inputs.import-tree path) ];
@@ -69,8 +70,8 @@
     if builtins.pathExists path then aspect else { };
 
   den._.import-tree.provides = {
-    host = root: { host }: den._.import-tree "${toString root}/${host.name}";
-    user = root: { host, user }: den._.import-tree "${toString root}/${user.name}@${host.name}";
-    home = root: { home }: den._.import-tree "${toString root}/${home.name}";
+    host = root: { host, ... }: den._.import-tree "${toString root}/${host.name}";
+    home = root: { home, ... }: den._.import-tree "${toString root}/${home.name}";
+    user = root: { host, user, ... }: den._.import-tree "${toString root}/${user.name}@${host.name}";
   };
 }

--- a/nix/fn-can-take.nix
+++ b/nix/fn-can-take.nix
@@ -1,7 +1,6 @@
 lib: param: f:
 let
   args = lib.mapAttrsToList (name: optional: { inherit name optional; }) (lib.functionArgs f);
-  empty = lib.length args == 0;
 
   givenAttrs = (builtins.isAttrs param) && !param ? __functor;
 
@@ -10,7 +9,5 @@ let
 
   intersection = lib.intersectLists required provided;
   satisfied = lib.length required == lib.length intersection;
-
-  noExtas = lib.length required == lib.length provided;
 in
-empty || (givenAttrs && satisfied && noExtas)
+givenAttrs && satisfied

--- a/templates/default/modules/_example/aspects.nix
+++ b/templates/default/modules/_example/aspects.nix
@@ -26,7 +26,7 @@ let
 
   # Example: parametric host aspect to automatically set hostName on any host.
   set-host-name =
-    { host }:
+    { host, ... }:
     {
       ${host.class}.networking.hostName = host.name;
     };

--- a/templates/default/modules/_profile/profiles.nix
+++ b/templates/default/modules/_profile/profiles.nix
@@ -11,7 +11,7 @@
   pro.profiles = {
     __functor = den.lib.parametric true;
     includes = [
-      ({ host }: pro.${host.system} or { })
+      ({ host, ... }: pro.${host.system} or { })
       # add other routes according to context.
     ];
   };


### PR DESCRIPTION
This is a preparation PR for contexts being incremental, 

an aspect can add (merge) additional data to an existing context. 

for example, a host configuration starts with `{ host }` but later for each of it users it merges `currentContext // { user }` leading to `{ host, user }` augmented context.

This allows contexts to be incremental, so parametric-aspects (functions) can specify what is the context they need:

`{ user, ...}` - At least user data in context.
`{ user, host, gaming }` - Need the three of them.



Will invalidate and close #51.

## Breaking Change

Your existing functions taking context like `{ host }` will likely need to be `{ host, ... }` now. See this PR diff for how batteries were updated.