### PR TITLE
Use `{ userToHost }` and `{ hostToUser }` contexts.

### DIFF
--- a/checkmate/tests/aspect-functor.nix
+++ b/checkmate/tests/aspect-functor.nix
@@ -19,11 +19,20 @@ let
         }
       )
       (
-        { host, user }:
+        { host, user, ... }:
         {
           nixos.host-user = [
             host
             user
+          ];
+        }
+      )
+      (
+        { userToHost, ... }:
+        {
+          nixos.user-to-host = [
+            userToHost.host
+            userToHost.user
           ];
         }
       )
@@ -136,9 +145,31 @@ let
             1
             2
           ];
-        } # host user
+        }
         { nixos.user = 2; }
         { nixos.user-only = false; }
+        { nixos.any = 10; }
+      ];
+    };
+  };
+
+  flake.tests."test functor applied with userToHost" = {
+    expr = (
+      aspect-example {
+        userToHost = {
+          user = 2;
+          host = 1;
+        };
+      }
+    );
+    expected = {
+      includes = [
+        {
+          nixos.user-to-host = [
+            1
+            2
+          ];
+        }
         { nixos.any = 10; }
       ];
     };

--- a/modules/aspects/dependencies.nix
+++ b/modules/aspects/dependencies.nix
@@ -22,14 +22,14 @@ let
     ({ user, ... }: statics den.aspects.${user.aspect})
 
     # user-to-host context
-    ({ fromUser, toHost }: owned toHost.class den.aspects.${fromUser.aspect})
+    ({ userToHost, ... }: owned userToHost.host.class den.aspects.${userToHost.user.aspect})
     # host-to-user context
-    ({ fromHost, toUser }: owned toUser.class den.aspects.${fromHost.aspect})
+    ({ hostToUser, ... }: owned hostToUser.user.class den.aspects.${hostToUser.host.aspect})
 
-    # { host } => [ { fromUser, toHost } ]
+    # { host } => [ { userToHost } ]
     (hostIncludesFromUsers)
 
-    # { user, host } => { fromHost, toUser }
+    # { user, host } => { hostToUser }
     (userIncludesFromHost)
   ];
 
@@ -40,8 +40,9 @@ let
         let
           users = builtins.attrValues host.users;
           context = user: {
-            fromUser = user;
-            toHost = host;
+            userToHost = {
+              inherit user host;
+            };
           };
           contrib = user: den.aspects.${user.aspect} (context user);
         in
@@ -53,8 +54,9 @@ let
     {
       includes = den.aspects.${host.aspect}.includes;
       __functor = den.lib.parametric {
-        fromHost = host;
-        toUser = user;
+        hostToUser = {
+          inherit host user;
+        };
       };
     };
 

--- a/modules/aspects/provides/define-user.nix
+++ b/modules/aspects/provides/define-user.nix
@@ -23,12 +23,15 @@ let
     if lib.hasSuffix "darwin" host.system then "/Users/${user.userName}" else "/home/${user.userName}";
 
   userToHostContext =
-    { fromUser, toHost }:
+    { userToHost, ... }:
+    let
+      inherit (userToHost) host user;
+    in
     {
-      nixos.users.users.${fromUser.userName}.isNormalUser = true;
-      darwin.users.users.${fromUser.userName} = {
-        name = fromUser.userName;
-        home = homeDir toHost fromUser;
+      nixos.users.users.${user.userName}.isNormalUser = true;
+      darwin.users.users.${user.userName} = {
+        name = user.userName;
+        home = homeDir host user;
       };
     };
 

--- a/modules/aspects/provides/primary-user.nix
+++ b/modules/aspects/provides/primary-user.nix
@@ -14,15 +14,16 @@ let
   '';
 
   userToHostContext =
-    { fromUser, toHost }:
+    { userToHost, ... }:
     let
-      on-wsl.nixos.wsl.defaultUser = fromUser.userName;
+      inherit (userToHost) host user;
+      on-wsl.nixos.wsl.defaultUser = user.userName;
     in
     {
       inherit description;
-      includes = lib.optionals (toHost ? wsl) [ on-wsl ];
-      darwin.system.primaryUser = fromUser.userName;
-      nixos.users.users.${fromUser.userName} = {
+      includes = lib.optionals (host ? wsl) [ on-wsl ];
+      darwin.system.primaryUser = user.userName;
+      nixos.users.users.${user.userName} = {
         isNormalUser = true;
         extraGroups = [
           "wheel"

--- a/modules/aspects/provides/user-shell.nix
+++ b/modules/aspects/provides/user-shell.nix
@@ -21,13 +21,14 @@ let
 
   userToHostContext =
     { shell }:
-    { fromUser, toHost }:
+    { userToHost, ... }:
     let
+      inherit (userToHost) user;
       nixos =
         { pkgs, ... }:
         {
           programs.${shell}.enable = true;
-          users.users.${fromUser.userName}.shell = pkgs.${shell};
+          users.users.${user.userName}.shell = pkgs.${shell};
         };
       darwin = nixos;
     in

--- a/templates/default/modules/_example/aspects.nix
+++ b/templates/default/modules/_example/aspects.nix
@@ -33,19 +33,19 @@ let
 
   # Example: installed on den.defaults for each user contribute into host.
   one-hello-package-for-each-user =
-    { fromUser, toHost }:
+    { userToHost, ... }:
     {
-      ${toHost.class} =
+      ${userToHost.host.class} =
         { pkgs, ... }:
         {
-          users.users.${fromUser.userName}.packages = [ pkgs.hello ];
+          users.users.${userToHost.user.userName}.packages = [ pkgs.hello ];
         };
     };
 
   # Example: configuration that depends on both host and user. provides to the host.
   user-to-host-conditional =
-    { fromUser, toHost }:
-    if fromUser.userName == "alice" && !lib.hasSuffix "darwin" toHost.system then
+    { userToHost, ... }:
+    if userToHost.user.userName == "alice" && !lib.hasSuffix "darwin" userToHost.host.system then
       {
         nixos.programs.tmux.enable = true;
       }
@@ -54,8 +54,8 @@ let
 
   # Example: configuration that depends on both host and user. provides to the host.
   host-to-user-conditional =
-    { fromHost, toUser }:
-    if toUser.userName == "alice" && !lib.hasSuffix "darwin" fromHost.system then
+    { hostToUser, ... }:
+    if hostToUser.user.userName == "alice" && !lib.hasSuffix "darwin" hostToUser.host.system then
       {
         homeManager.programs.git.enable = true;
       }

--- a/templates/default/modules/_profile/hosts/bones/common-user-env.nix
+++ b/templates/default/modules/_profile/hosts/bones/common-user-env.nix
@@ -4,8 +4,8 @@ let
   # private aspects can be let-bindings
   # more re-usable ones are better defined inside the `pro` namespace.
   host-contrib-to-user =
-    { fromHost, toUser }:
-    if fromHost.name == "bones" || toUser.name == "fido" then
+    { hostToUser, ... }:
+    if hostToUser.host.name == "bones" || hostToUser.user.name == "fido" then
       {
         homeManager.programs.vim.enable = true;
       }

--- a/templates/default/modules/_profile/profiles/single-user-is-admin.nix
+++ b/templates/default/modules/_profile/profiles/single-user-is-admin.nix
@@ -3,14 +3,15 @@
 
   # When a host includes *ONLY* one user, make that user the admin.
   pro.single-user-is-admin =
-    { fromUser, toHost }@context:
+    { userToHost, ... }@context:
     let
-      single = 1 == builtins.length (builtins.attrValues toHost.users);
-      exists = single && builtins.hasAttr fromUser.name toHost.users;
+      inherit (userToHost) user host;
+      single = 1 == builtins.length (builtins.attrValues host.users);
+      exists = single && builtins.hasAttr user.name host.users;
       admin = lib.optionals exists [ den._.primary-user ];
-      define = [ den._.define-user ];
     in
     {
-      includes = map (f: f context) (define ++ admin);
+      __functor = den.lib.parametric context;
+      includes = [ den._.define-user ] ++ admin;
     };
 }

--- a/templates/default/modules/_profile/users/fido/common-host-env.nix
+++ b/templates/default/modules/_profile/users/fido/common-host-env.nix
@@ -3,7 +3,8 @@
 { pro, ... }:
 let
   fido-at-host =
-    { fromUser, toHost }: if fromUser.name != "fido" then { } else pro.fido._.${toHost.name};
+    { userToHost, ... }:
+    if userToHost.user.name != "fido" then { } else pro.fido._.${userToHost.host.name};
 in
 {
   den.default.includes = [


### PR DESCRIPTION
Instead of previous: `{ fromUser, toHost }` and `{ fromHost, toUser }`.

The reason is detailed at #47.

Closes #47.