### PR TITLE
BREAKING. New Intent-oriented and Incremental contexts.

### DIFF
--- a/checkmate/tests/function_can_take.nix
+++ b/checkmate/tests/function_can_take.nix
@@ -5,7 +5,21 @@
   ...
 }:
 let
-  takes = (inputs.target.lib { inherit inputs lib config; }).canTake;
+  den.lib = inputs.target.lib { inherit inputs lib config; };
+  takes = den.lib.canTake;
+
+  flake.tests."test exactly fails" = {
+    expr = takes.exactly {
+      a = 1;
+      b = 2;
+    } ({ a }: a);
+    expected = false;
+  };
+
+  flake.tests."test exactly succeeds" = {
+    expr = takes.exactly { a = 1; } ({ a }: a);
+    expected = true;
+  };
 
   flake.tests."test function with no named arguments can take anything" = {
     expr = takes { } (x: x);

--- a/modules/aspects/definition.nix
+++ b/modules/aspects/definition.nix
@@ -19,7 +19,7 @@ let
     ${host.aspect} = {
       ${host.class} = { };
       includes = [ den.default ];
-      __functor = den.lib.parametric { inherit host; };
+      __functor = den.lib.parametric { OS = { inherit host; }; };
     };
   };
 

--- a/modules/aspects/provides/define-user.nix
+++ b/modules/aspects/provides/define-user.nix
@@ -22,22 +22,14 @@ let
     host: user:
     if lib.hasSuffix "darwin" host.system then "/Users/${user.userName}" else "/home/${user.userName}";
 
-  userToHostContext =
-    { userToHost, ... }:
-    let
-      inherit (userToHost) host user;
-    in
+  userContext =
+    { host, user, ... }:
     {
       nixos.users.users.${user.userName}.isNormalUser = true;
       darwin.users.users.${user.userName} = {
         name = user.userName;
         home = homeDir host user;
       };
-    };
-
-  userContext =
-    { host, user }:
-    {
       homeManager = {
         home.username = user.userName;
         home.homeDirectory = homeDir host user;
@@ -45,7 +37,7 @@ let
     };
 
   hmContext =
-    { home }:
+    { home, ... }:
     userContext {
       host.system = home.system;
       user.userName = home.userName;
@@ -55,7 +47,6 @@ in
   den.provides.define-user = {
     inherit description;
     includes = [
-      userToHostContext
       userContext
       hmContext
     ];

--- a/modules/aspects/provides/import-tree.nix
+++ b/modules/aspects/provides/import-tree.nix
@@ -50,7 +50,7 @@
           # load from ./hosts/<host>/_nixos
           den.default.includes = [ (den._.import-tree._.host ./hosts) ];
 
-          # load from ./users/<user>@<host>/{_homeManager, _nixos}
+          # load from ./users/<user>/{_homeManager, _nixos}
           den.default.includes = [ (den._.import-tree._.user ./users) ];
 
           # load from ./homes/<home>/_homeManager
@@ -72,6 +72,6 @@
   den._.import-tree.provides = {
     host = root: { host, ... }: den._.import-tree "${toString root}/${host.name}";
     home = root: { home, ... }: den._.import-tree "${toString root}/${home.name}";
-    user = root: { host, user, ... }: den._.import-tree "${toString root}/${user.name}@${host.name}";
+    user = root: { user, ... }: den._.import-tree "${toString root}/${user.name}";
   };
 }

--- a/modules/aspects/provides/primary-user.nix
+++ b/modules/aspects/provides/primary-user.nix
@@ -14,9 +14,8 @@ let
   '';
 
   userToHostContext =
-    { userToHost, ... }:
+    { user, host, ... }:
     let
-      inherit (userToHost) host user;
       on-wsl.nixos.wsl.defaultUser = user.userName;
     in
     {

--- a/modules/aspects/provides/user-shell.nix
+++ b/modules/aspects/provides/user-shell.nix
@@ -12,18 +12,9 @@ let
       ];
   '';
 
-  userContext =
-    { shell }:
-    { host }:
-    {
-      homeManager.programs.${shell}.enable = true;
-    };
-
-  userToHostContext =
-    { shell }:
-    { userToHost, ... }:
+  userShell =
+    shell: user:
     let
-      inherit (userToHost) user;
       nixos =
         { pkgs, ... }:
         {
@@ -31,9 +22,10 @@ let
           users.users.${user.userName}.shell = pkgs.${shell};
         };
       darwin = nixos;
+      homeManager.programs.${shell}.enable = true;
     in
     {
-      inherit nixos darwin;
+      inherit nixos darwin homeManager;
     };
 
 in
@@ -41,9 +33,9 @@ in
   den.provides.user-shell = shell: {
     inherit description;
     __functor = den.lib.parametric true;
-    includes = map (f: f { inherit shell; }) [
-      userContext
-      userToHostContext
+    includes = [
+      ({ user, ... }: userShell shell user)
+      ({ home, ... }: userShell shell home)
     ];
   };
 }

--- a/nix/fn-can-take.nix
+++ b/nix/fn-can-take.nix
@@ -1,13 +1,24 @@
-lib: param: f:
+lib:
 let
-  args = lib.mapAttrsToList (name: optional: { inherit name optional; }) (lib.functionArgs f);
-
-  givenAttrs = (builtins.isAttrs param) && !param ? __functor;
-
-  required = map (x: x.name) (lib.filter (x: !x.optional) args);
-  provided = lib.attrNames param;
-
-  intersection = lib.intersectLists required provided;
-  satisfied = lib.length required == lib.length intersection;
+  check =
+    params: func:
+    let
+      givenArgs = builtins.isAttrs params;
+      fargs = lib.functionArgs func;
+      provided = builtins.attrNames params;
+      args = lib.mapAttrsToList (name: optional: { inherit name optional; }) fargs;
+      required = map (x: x.name) (lib.filter (x: !x.optional) args);
+      intersection = lib.intersectLists required provided;
+      satisfied = givenArgs && lib.length required == lib.length intersection;
+      noExtras = lib.length required == lib.length provided;
+      exactly = satisfied && noExtras;
+    in
+    {
+      inherit satisfied exactly;
+    };
 in
-givenAttrs && satisfied
+{
+  __functor = self: self.atLeast;
+  atLeast = params: func: (check params func).satisfied;
+  exactly = params: func: (check params func).exactly;
+}

--- a/templates/bogus/modules/bug.nix
+++ b/templates/bogus/modules/bug.nix
@@ -16,10 +16,13 @@
       tux = inputs.self.nixosConfigurations.igloo.config.users.users.tux;
 
       expr.len = lib.length tux.packages;
-      expr.name = lib.getName (lib.head tux.packages);
+      expr.names = map lib.getName tux.packages;
 
-      expected.len = 1;
-      expected.name = "hello";
+      expected.len = 2;
+      expected.names = [
+        "hello"
+        "hello"
+      ];
     in
     {
       inherit expr expected;


### PR DESCRIPTION
( Closes #56, #55 ) -- (Pending #58)

This PR introduces a fundamental refactoring of the aspect dependency and context management system. The primary goal is to provide a more robust, explicit, and powerful way to handle how different parts of the configuration (hosts, users, home-manager) interact with each other. This leads to clearer and more predictable evaluations, but also introduces significant breaking changes from previous unified context `userToHost` and `hostToUser`.

> [!IMPORTANT]
> The previous context objects `userToHost` and `hostToUser` prove to be harder to use and have been **completely removed**.

Now contexts are incremental and context now are used for **configuration intent**. For example, a NixOS configuration starts with context `{ OS }` but later expands to `{ OS, user, host }` as soon as the OS has information of which users and hosts it is being applied to. See the examples on aspects.nix for how this replaces `userToHost` and `hostToUser`.

> [!IMPORTANT]
> Since contexts are now _incremental_, they are also no longer _exact_ by default.

What this means: In previous releases, a function `{ host }: { }` context had to match exactly. For example if applied to `{ host = ...; foo = ... }` it would not apply since `foo` is unexpected. This was as to avoid `function called with unexpectd "foo"` errors. However now contexts can be incremental.

A function `{ host, ... }: { }` provides anytime a `host` is in context.
A function `{ host, user, ... }: { }` provides when at least both are in context.

For example, you can use `{ user, ... }: ...` to provide configurations based on user data anytime  it is in context.

**OS/HM Intent Contexts**

OS and HM configurations now start with a single `{ OS }` and `{ HM }` contexts. They are higher-level contexts used to describe the **Intent** of the configuration being produced. This, in hand with incremental contexts, allows to get rid of `hostToUser` and `userToHost`. 

For example a context `{ OS, user, host }` is explicit about it being a configuration depending on host/user data but also that it is **being used** for providing NixOS/Darwin configuration specifically.

`OS`/`HM` are not used in our provided batteries at all. Instead the batteries rely only on `host`/`user`/`home` data being in context, fixing the complexity that was introduced by previous `hostToUser` and `userToHost`.

`OS`/`HM` are useful for opt-in bi-directional dependencies, this is how we avoid duplicating settings now. Since a function `{ user, host, ...}: { }` can be installed in `den.default`, and `den.default` is included for any User and Host. That function would produce duplicate configurations - this is correct since the function is **explicitly set in den.default** which is included twice: once for the user and once for the host. To avoid this, either install the function on a specific `den.aspect.<host/user>.includes` or use a higher **intent context** like `OS`/`HM`. See how our aspects.nix examples were updated for this.


## refactor: Dependency Resolution Engine

The core dependency resolution logic in `modules/aspects/dependencies.nix` has been rewritten to be more explicit and prevent recursion.

- It now uses `take.exactly` with the new `OS` and `HM` contexts to ensure that dependency-gathering functions run only once at the appropriate level, preventing evaluation loops.
- The logic for how users contribute to a host's configuration (`osIncludesFromUsers`) and how a host contributes to a user's home-manager configuration (`hmIncludesFromHost`) is now clearly defined and separated.
- The new engine correctly passes the intent `OS` and `HM` contexts down to the aspects being resolved.

## refactor: `provides` Modules Updated for New Context

All built-in `provides` modules have been updated to use the new intent-based context system.

- `provides/define-user`: Now uses generic data-specific `{ host, user, ... }` and `{ home, ... }` contexts directly, removing the need for the intermediate `userToHostContext`.
- `provides/home-manager`: Now passes the `{ HM }` **intent** context when resolving a user's `homeManager` aspect.
- `provides/primary-user`: Logic simplified to expect `{ user, host, ... }` instead of `userToHost`.
- `provides/user-shell`: The logic has been unified. A single `userShell` function now correctly applies shell configuration to `nixos`, `darwin`, and `homeManager` attributes based on the context it receives (`{ user, ... }` or `{ home, ... }`).

## test: Enhanced `canTake` Tests

The test suite for `function_can_take.nix` has been expanded to include assertions for the new `takes.exactly` functionality, ensuring that it correctly identifies functions that take an exact set of arguments.

## feat: Granular Context Control with `take` and `parametric`

A new set of library functions, `den.lib.take` and a redesigned `den.lib.parametric`, have been introduced to give aspect authors fine-grained control over how and when their functions are applied.

- **`den.lib.take`**: This is a new functor that allows a function to declare precisely what context it expects.
  - `take.atLeast`: The function is applied if the context provides *at least* the required arguments. This is the default behavior for most parametric functions.
  - `take.exactly`: The function is applied only if the context provides the *exact* set of required arguments, with no extras. This is crucial for preventing infinite recursion in dependency resolution.
  - `take.unused`: A utility to signal which arguments from the context are "consumed" by the function, allowing for clearer composition.

- **`den.lib.parametric`**: The `parametric` functor has been completely overhauled to leverage `take`.
  - It now offers `atLeast` and `exactly` variants to create aspects that apply their includes based on these context matching rules.
  - The syntax `parametric true` is now an alias for `parametric.atLeast`.

This new system replaces the older, less precise `canTake` logic, providing a more declarative and safer way to write parametric aspects.

## BREAKING CHANGE: Intent Context (`OS` and `HM`)

The context passed to parametric aspects is no longer a flat attribute set. It has been restructured into namespaced contexts to clearly separate concerns between operating system configuration and home-manager configuration.

- **`OS` Context**: When evaluating for a host's operating system configuration (NixOS or `nix-darwin`), aspects now receive an `OS` attribute in their context. The original `host` object is available as `OS.host`.
- **`HM` Context**: When evaluating for a user's `home-manager` configuration, aspects receive an `HM` attribute. This context contains both the `user` and the `host` they belong to (`HM.user` and `HM.host`).

The previous context objects `userToHost` and `hostToUser` proven to be harder to use and have been **completely removed**. And now contexts are incremental. For example, a NixOS configuration starts with context `{ OS }` but later expands to `{ OS, user, host }` as soon as the OS has information of which users and hosts it is being applied to. See the examples on aspects.nix for how this replaces `userToHost` and `hostToUser`.

### Migration Guide

All parametric aspects must be updated to expect the new context structure.

**Before:**
```nix
my-aspect = { userToHost, ... }: {
  ${userToHost.host.class}.services.foo.enable = true;
};

my-other-aspect = { hostToUser, ... }: {
  homeManager.programs.bar.enable = true;
};
```

**After:**
```nix
# OS context is needed only if my-aspect is installed at den.default
my-aspect = { OS, user, host, ... }: {
  ${host.class}.services.foo.enable = true;
};

# HM intent context is needed only if installed into den.default.
my-other-aspect = { HM, user, host, ... }: {
  homeManager.programs.bar.enable = true;
};
```