### PR TITLE
Fixed dependencies, removed directional contexts, and prevent duplication from functions included in den.default. 

### DIFF
--- a/modules/aspects/definition.nix
+++ b/modules/aspects/definition.nix
@@ -5,12 +5,14 @@
   ...
 }:
 let
+  inherit (den.lib) parametric;
+
   # creates den.aspects.${home.aspect}
   homeAspect = home: {
     ${home.aspect} = {
       ${home.class} = { };
       includes = [ den.default ];
-      __functor = den.lib.parametric { inherit home; };
+      __functor = HM: parametric { inherit HM home; } HM;
     };
   };
 
@@ -19,7 +21,7 @@ let
     ${host.aspect} = {
       ${host.class} = { };
       includes = [ den.default ];
-      __functor = den.lib.parametric { OS = { inherit host; }; };
+      __functor = OS: parametric { inherit OS host; } OS;
     };
   };
 
@@ -28,7 +30,7 @@ let
     ${user.aspect} = {
       ${user.class} = { };
       includes = [ den.default ];
-      __functor = den.lib.parametric true;
+      __functor = parametric.expands { inherit user; };
     };
   };
 

--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -44,11 +44,11 @@ in
               inherit aspect-chain;
               class = hmClass;
             };
-            aspect = den.aspects.${user.aspect} {
-              HM = { inherit host user; };
-            };
+            HM = den.aspects.${user.aspect};
+            aspect = HM { inherit HM host; };
+            module = aspect.resolve ctx;
           in
-          aspect.resolve ctx;
+          module;
 
         users = map (user: {
           name = user.userName;

--- a/modules/aspects/provides/user-shell.nix
+++ b/modules/aspects/provides/user-shell.nix
@@ -28,16 +28,14 @@ let
       inherit nixos darwin homeManager;
     };
 
-  inherit (den.lib.take) exactly;
-
 in
 {
   den.provides.user-shell = shell: {
     inherit description;
-    __functor = den.lib.parametric true;
+    __functor = den.lib.parametric.atLeast;
     includes = [
-      (exactly ({ user }: userShell shell user))
-      (exactly ({ home }: userShell shell home))
+      ({ user, ... }: userShell shell user)
+      ({ home, ... }: userShell shell home)
     ];
   };
 }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -69,7 +69,7 @@ let
   parametric.atLeast = funk (lib.flip take.atLeast);
   parametric.exactly = funk (lib.flip take.exactly);
   parametric.context = lib.flip parametric.atLeast;
-  parametric.expands = attrs: funk (ctx: (lib.flip take.atLeast) (attrs // ctx));
+  parametric.expands = attrs: funk (ctx: (lib.flip take.atLeast) (ctx // attrs));
   parametric.__functor =
     self: ctx:
     if ctx == true then

--- a/templates/default/modules/aspects/eg/routes.nix
+++ b/templates/default/modules/aspects/eg/routes.nix
@@ -13,41 +13,18 @@
     let
       inherit (den.lib) parametric;
 
-      os-from-user =
+      # eg, `<user>._.<host>` and `<host>._.<user>`
+      mutual = from: to: den.aspects.${from.aspect}._.${to.aspect} or { };
+
+      routes =
+        { host, user, ... }@ctx:
         {
-          user,
-          host,
-          # deadnix: skip
-          OS,
-          # deadnix: skip
-          fromUser,
-        }:
-        parametric { inherit user host; } (mutual user host);
-
-      hm-from-host =
-        {
-          user,
-          host,
-          # deadnix: skip
-          HM,
-          # deadnix: skip
-          fromHost,
-        }:
-        parametric { inherit user host; } (mutual host user);
-
-      mutual = from: to: {
-        includes = [
-          # eg, `<user>._.<host>` and `<host>._.<user>`
-          (den.aspects.${from.aspect}._.${to.aspect} or { })
-        ];
-      };
-
+          __functor = parametric ctx;
+          includes = [
+            (mutual user host)
+            (mutual host user)
+          ];
+        };
     in
-    {
-      __functor = parametric.exactly;
-      includes = [
-        os-from-user
-        hm-from-host
-      ];
-    };
+    routes;
 }

--- a/templates/examples/modules/_example/ci/custom-nixos-module.nix
+++ b/templates/examples/modules/_example/ci/custom-nixos-module.nix
@@ -2,13 +2,22 @@
 let
   # A custom `nixos` class module that defines an option `names`.
   # Used to test that we are not duplicating values from owned configs.
-  nixosNames.options.names = lib.mkOption { type = lib.types.listOf lib.types.str; };
+  nixosNames = names: { options.${names} = lib.mkOption { type = lib.types.listOf lib.types.str; }; };
 in
 {
+  den.default.nixos.imports = [ (nixosNames "people") ];
+  den.default.includes = [
+    (
+      { user, ... }:
+      {
+        nixos.people = [ user.name ];
+      }
+    )
+  ];
 
   den.aspects.rockhopper.includes = [
     # Example: importing a third-party nixos module.
-    { nixos.imports = [ nixosNames ]; }
+    { nixos.imports = [ (nixosNames "names") ]; }
   ];
 
   den.aspects.rockhopper.nixos.names = [ "tux" ];
@@ -16,6 +25,9 @@ in
   perSystem =
     { checkCond, rockhopper, ... }:
     {
+      checks.rockhopper-default-people = checkCond "set from den.default for each user" (
+        rockhopper.config.people == [ "alice" ]
+      );
       checks.rockhopper-names-single-entry = checkCond "custom nixos array option set once" (
         rockhopper.config.names == [ "tux" ]
       );

--- a/templates/examples/modules/_example/ci/host-user-conditional-hm.nix
+++ b/templates/examples/modules/_example/ci/host-user-conditional-hm.nix
@@ -1,21 +1,18 @@
-{ den, lib, ... }:
+{ lib, ... }:
 let
   # Example: configuration that depends on both host and user. provides only to HM.
   host-to-user-conditional =
     {
-      HM,
       user,
       host,
       ...
     }:
-    den.lib.take.unused [ HM ] (
-      if user.userName == "alice" && !lib.hasSuffix "darwin" host.system then
-        {
-          homeManager.programs.git.enable = true;
-        }
-      else
-        { }
-    );
+    if user.userName == "alice" && !lib.hasSuffix "darwin" host.system then
+      {
+        homeManager.programs.git.enable = true;
+      }
+    else
+      { };
 in
 {
 

--- a/templates/examples/modules/_example/ci/one-os-package-per-user.nix
+++ b/templates/examples/modules/_example/ci/one-os-package-per-user.nix
@@ -1,16 +1,13 @@
-{ den, ... }:
 let
 
   # Example: adds hello into each user. provides only to OS.
   hello-package-for-user =
     {
-      OS,
-      fromUser,
       user,
       host,
       ...
     }:
-    den.lib.take.unused [ OS fromUser ] {
+    {
       ${host.class} =
         { pkgs, ... }:
         {
@@ -21,10 +18,7 @@ let
 in
 {
 
-  den.default.includes = [
-    # Example: parametric { OS, fromUser } aspect.
-    hello-package-for-user
-  ];
+  den.default.includes = [ hello-package-for-user ];
 
   perSystem =
     {

--- a/templates/examples/modules/_example/ci/standalone-hm-special-args-osconfig.nix
+++ b/templates/examples/modules/_example/ci/standalone-hm-special-args-osconfig.nix
@@ -2,7 +2,7 @@ let
 
   # Example: luke standalone home-manager has access to rockhopper osConfig specialArg.
   os-conditional-hm =
-    { home }:
+    { home, ... }:
     {
       # access osConfig, wired via extraSpecialArgs in homes.nix.
       homeManager =


### PR DESCRIPTION
Fixes #84.

This PR removes the directional contexts `fromHost` and `fromUser`. Now people can include funcitons like:

```nix
den.default.includes = [
  ({ user, ...}: { nixos.some-array = [ user.name ]; })
];
```

And values are not duplicated now. Added test based on report from #84.

This also simplified a lot the number of contexts we have. Still have to update documentation about contexts.
