### PR TITLE
Rename `parametric.context` to `parametric.fixedTo`

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -68,7 +68,7 @@ let
 
   parametric.atLeast = funk (lib.flip take.atLeast);
   parametric.exactly = funk (lib.flip take.exactly);
-  parametric.context = lib.flip parametric.atLeast;
+  parametric.fixedTo = lib.flip parametric.atLeast;
   parametric.expands = attrs: funk (ctx: (lib.flip take.atLeast) (ctx // attrs));
   parametric.__functor =
     self: ctx:
@@ -79,7 +79,7 @@ let
     else if isFn ctx then
       funk ctx
     else
-      self.context ctx;
+      self.fixedTo ctx;
 
   aspects = inputs.flake-aspects.lib lib;
 

--- a/templates/default/modules/aspects/eg/routes.nix
+++ b/templates/default/modules/aspects/eg/routes.nix
@@ -1,7 +1,14 @@
 # This example implements an aspect "routing" pattern.
 #
-# Unlike `den.default` which is `parametric.atLeast` we use `parametric.exactly` here
-# to be more strict and prevent multiple values inclusion.
+# Unlike `den.default` which is `parametric.atLeast`
+# we use `parametric.fixedTo` here, which help us
+# propagate an already computed context to all includes.
+#
+# This aspect, when installed in a `parametric.atLeast`
+# will just forward the same context.
+# The `mutual` helper returns an static configuration which
+# is ignored by parametric aspects, thus allowing
+# non-existing aspects to be just ignored.
 #
 # Be sure to read: https://vic.github.io/den/dependencies.html
 # See usage at: defaults.nix, alice.nix, igloo.nix
@@ -19,7 +26,7 @@
       routes =
         { host, user, ... }@ctx:
         {
-          __functor = parametric ctx;
+          __functor = parametric.fixedTo ctx;
           includes = [
             (mutual user host)
             (mutual host user)


### PR DESCRIPTION
to be more precise about it providing a fixed context to all its included functions.