### PR TITLE
Fix home-manager integration. Use `takes.exactly` instead of just `{ host, ...}` context.

### DIFF
--- a/modules/aspects/dependencies.nix
+++ b/modules/aspects/dependencies.nix
@@ -30,7 +30,7 @@ let
           includes =
             let
               users = builtins.attrValues host.users;
-              contrib = osUserDependencies OS host;
+              contrib = osUserDependencies { inherit OS host; };
             in
             map contrib users;
         }
@@ -38,54 +38,45 @@ let
     };
 
   osUserDependencies =
-    OS: host: user:
+    { OS, host }:
+    user:
     let
       USR = den.aspects.${user.aspect};
-      ctx = { inherit OS host user; };
     in
     {
       includes = [
         (owned USR)
         (statics USR)
-        (USR ctx)
+        (USR { inherit OS host; })
       ];
     };
 
-  # from home-manager integration.
+  # from OS home-managed integration.
   hmUserDependencies =
     {
-      HM,
+      OS-HM,
       host,
       user,
     }:
+    let
+      inherit (OS-HM) OS HM;
+    in
     {
       includes = [
         (owned den.default)
         (statics den.default)
         (owned HM)
         (statics HM)
-        (hmOsDependencies HM host user)
-      ];
-    };
-
-  hmOsDependencies =
-    HM: host: user:
-    let
-      OS = den.aspects.${host.aspect};
-      newCtx = {
-        inherit
-          HM
-          OS
-          host
-          user
-          ;
-      };
-    in
-    {
-      includes = [
         (owned OS)
         (statics OS)
-        (parametric newCtx OS)
+        (parametric {
+          inherit
+            OS
+            HM
+            user
+            host
+            ;
+        } OS)
       ];
     };
 

--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -24,49 +24,53 @@ let
 
     For each user resolves den.aspects.''${user.aspect} and imports its homeManager class module.
   '';
+
+  homeManager =
+    { OS, host }:
+    { class, aspect-chain }:
+    let
+      hmClass = "homeManager";
+      hmUsers = builtins.filter (u: u.class == hmClass) (lib.attrValues host.users);
+
+      hmUserModule =
+        user:
+        let
+          ctx = {
+            inherit aspect-chain;
+            class = hmClass;
+          };
+          HM = den.aspects.${user.aspect};
+          aspect = HM {
+            inherit host;
+            OS-HM = { inherit OS HM; };
+          };
+          module = aspect.resolve ctx;
+        in
+        module;
+
+      users = map (user: {
+        name = user.userName;
+        value.imports = [ (hmUserModule user) ];
+      }) hmUsers;
+
+      hmModule = host.hm-module or inputs.home-manager."${class}Modules".home-manager;
+      aspect.${class} = {
+        imports = [ hmModule ];
+        home-manager.users = lib.listToAttrs users;
+      };
+
+      supportedOS = builtins.elem class [
+        "nixos"
+        "darwin"
+      ];
+      enabled = supportedOS && builtins.length hmUsers > 0;
+    in
+    if enabled then aspect else { };
+
 in
 {
   den.provides.home-manager = {
     inherit description;
-
-    __functor =
-      _:
-      { host, ... }:
-      { class, aspect-chain }:
-      let
-        hmClass = "homeManager";
-        hmUsers = builtins.filter (u: u.class == hmClass) (lib.attrValues host.users);
-
-        hmUserModule =
-          user:
-          let
-            ctx = {
-              inherit aspect-chain;
-              class = hmClass;
-            };
-            HM = den.aspects.${user.aspect};
-            aspect = HM { inherit HM host; };
-            module = aspect.resolve ctx;
-          in
-          module;
-
-        users = map (user: {
-          name = user.userName;
-          value.imports = [ (hmUserModule user) ];
-        }) hmUsers;
-
-        hmModule = host.hm-module or inputs.home-manager."${class}Modules".home-manager;
-        aspect.${class} = {
-          imports = [ hmModule ];
-          home-manager.users = lib.listToAttrs users;
-        };
-
-        supportedOS = builtins.elem class [
-          "nixos"
-          "darwin"
-        ];
-        enabled = supportedOS && builtins.length hmUsers > 0;
-      in
-      if enabled then aspect else { };
+    __functor = _: den.lib.take.exactly homeManager;
   };
 }

--- a/templates/default/modules/aspects/alice.nix
+++ b/templates/default/modules/aspects/alice.nix
@@ -7,8 +7,16 @@
       let
         # deadnix: skip # demo: enable <> on lexical scope
         inherit (den.lib) __findFile;
+
+        customVim.homeManager =
+          { pkgs, ... }:
+          {
+            programs.vim.enable = true;
+            programs.vim.package = pkgs.neovim;
+          };
       in
       [
+        customVim
         <eg/autologin>
         <den/primary-user> # alice is admin always.
         (<den/user-shell> "fish") # default user shell

--- a/templates/default/modules/aspects/alice.nix
+++ b/templates/default/modules/aspects/alice.nix
@@ -8,15 +8,15 @@
         # deadnix: skip # demo: enable <> on lexical scope
         inherit (den.lib) __findFile;
 
-        customVim.homeManager =
+        customEmacs.homeManager =
           { pkgs, ... }:
           {
-            programs.vim.enable = true;
-            programs.vim.package = pkgs.neovim;
+            programs.emacs.enable = true;
+            programs.emacs.package = pkgs.emacs30-nox;
           };
       in
       [
-        customVim
+        customEmacs
         <eg/autologin>
         <den/primary-user> # alice is admin always.
         (<den/user-shell> "fish") # default user shell

--- a/templates/default/modules/den.nix
+++ b/templates/default/modules/den.nix
@@ -1,5 +1,5 @@
 {
   den.hosts.x86_64-linux.igloo.users.alice = { };
   den.hosts.aarch64-darwin.apple.users.alice = { };
-  den.homes.x86_64-linux.alice = { };
+  # den.homes.x86_64-linux.alice = { };
 }

--- a/templates/default/modules/tests.nix
+++ b/templates/default/modules/tests.nix
@@ -3,7 +3,7 @@
 { inputs, ... }:
 {
   perSystem =
-    { pkgs, self', ... }:
+    { pkgs, self', lib, ... }:
     let
       checkCond = name: cond: pkgs.runCommandLocal name { } (if cond then "touch $out" else "");
       apple = inputs.self.darwinConfigurations.apple.config;
@@ -21,5 +21,9 @@
       checks."alice enabled igloo nh" = checkCond "alice.provides.igloo" igloo.programs.nh.enable;
       checks."igloo enabled alice helix" =
         checkCond "igloo.provides.alice" alice-at-igloo.programs.helix.enable;
+
+      # checks."alice custom emacs in hm" = checkCond "hm.programs.emacs.package" (
+      #   "emacs-nox" == lib.getName alice-at-igloo.programs.emacs.package
+      # );
     };
 }

--- a/templates/default/modules/tests.nix
+++ b/templates/default/modules/tests.nix
@@ -3,7 +3,12 @@
 { inputs, ... }:
 {
   perSystem =
-    { pkgs, self', lib, ... }:
+    {
+      pkgs,
+      self',
+      lib,
+      ...
+    }:
     let
       checkCond = name: cond: pkgs.runCommandLocal name { } (if cond then "touch $out" else "");
       apple = inputs.self.darwinConfigurations.apple.config;
@@ -22,8 +27,8 @@
       checks."igloo enabled alice helix" =
         checkCond "igloo.provides.alice" alice-at-igloo.programs.helix.enable;
 
-      # checks."alice custom emacs in hm" = checkCond "hm.programs.emacs.package" (
-      #   "emacs-nox" == lib.getName alice-at-igloo.programs.emacs.package
-      # );
+      checks."alice-custom-emacs" = checkCond "hm.programs.emacs.package" (
+        "emacs-nox" == lib.getName alice-at-igloo.programs.emacs.package
+      );
     };
 }

--- a/templates/examples/modules/_example/ci/custom-home-managed-package.nix
+++ b/templates/examples/modules/_example/ci/custom-home-managed-package.nix
@@ -1,0 +1,30 @@
+{
+  # Including an static aspect should not cause duplicate definitions
+  den.aspects.alice.includes = [
+    {
+      homeManager =
+        { pkgs, ... }:
+        {
+          programs.emacs.enable = true;
+          programs.emacs.package = pkgs.emacs30-nox;
+        };
+    }
+  ];
+
+  perSystem =
+    {
+      checkCond,
+      alice-at-rockhopper,
+      lib,
+      ...
+    }:
+    {
+      checks.alice-custom-emacs = checkCond "set uniquely via a static includes" (
+        let
+          expr = lib.getName alice-at-rockhopper.programs.emacs.package;
+          expected = builtins.break "emacs-nox";
+        in
+        expr == expected
+      );
+    };
+}

--- a/templates/examples/modules/_example/ci/custom-home-managed-package.nix
+++ b/templates/examples/modules/_example/ci/custom-home-managed-package.nix
@@ -22,7 +22,7 @@
       checks.alice-custom-emacs = checkCond "set uniquely via a static includes" (
         let
           expr = lib.getName alice-at-rockhopper.programs.emacs.package;
-          expected = builtins.break "emacs-nox";
+          expected = "emacs-nox";
         in
         expr == expected
       );


### PR DESCRIPTION
Fixes #87 

I fixed and added a test, the test ran ok in isolation. but later when runnig the whole flake the bug persists. 

Turns out I have the following: 

```nix
  den.aspects.alice.includes = [
    ({ pkgs, ... }: { programs.emacs.package = pkgs.emacs30-nox; })
  ]
```

and 

```nix
  den.hosts.x86_64-linux.igloo.users.alice = { };
  den.homes.x86_64-linux.alice = { };
```

commenting the second line, the standalone home makes the system build.

this is probably related to both sharing the same aspect object `alice`.

a workaround is to specify an `aspect` attribute in one of them. but I don't want to, I'm supposed to be able to share between standalone and os-managed. 


