### PR TITLE
Provide a parametric combinator that is atLeast but preserves owned configs

### DIFF
--- a/modules/aspects/dependencies.nix
+++ b/modules/aspects/dependencies.nix
@@ -60,6 +60,14 @@ let
     }:
     let
       inherit (OS-HM) OS HM;
+      context = {
+        inherit
+          OS
+          HM
+          user
+          host
+          ;
+      };
     in
     {
       includes = [
@@ -69,14 +77,7 @@ let
         (statics HM)
         (owned OS)
         (statics OS)
-        (parametric {
-          inherit
-            OS
-            HM
-            user
-            host
-            ;
-        } OS)
+        (parametric.fixedTo context OS)
       ];
     };
 

--- a/templates/examples/modules/_example/ci/parametric-with-owned.nix
+++ b/templates/examples/modules/_example/ci/parametric-with-owned.nix
@@ -1,0 +1,58 @@
+{ den, lib, ... }:
+let
+  # a test module to check context was forwarded
+  fwdModule.nixos.options.fwd = {
+    a = strOpt;
+    b = strOpt;
+    c = strOpt;
+    d = strOpt;
+  };
+  strOpt = lib.mkOption { type = lib.types.str; };
+in
+{
+
+  den.aspects.rockhopper.includes = [
+    fwdModule
+    den.aspects.fwd._.first
+  ];
+  den.aspects.rockhopper.nixos.fwd.c = "host owned C";
+
+  # this is an `atLeast` parametric aspect that also includes
+  # its owned configs and static (non-functional) includes.
+  # Usage: just call `parametric` with an aspect.
+  # or alternatively, set `__functor = den.lib.parametric;`
+  den.aspects.fwd._.first = den.lib.parametric {
+    nixos.fwd.a = "First owned A";
+    includes = [
+      den.aspects.fwd._.second
+      { nixos.fwd.d = "First static includes D"; }
+      den.aspects.fwd._.never
+    ];
+  };
+
+  # Note that second has named arguments, while first does not.
+  # the first aspect forwards whatever context it receives.
+  den.aspects.fwd._.second =
+    { host, ... }:
+    {
+      nixos.fwd.b = "Second owned B for ${host.name}";
+    };
+
+  den.aspects.fwd._.never =
+    { never-matches }:
+    {
+      nixos.fwd.a = "Imposibru! should never be included ${never-matches}";
+    };
+
+  perSystem =
+    { checkCond, rockhopper, ... }:
+    {
+      checks.parametric-fwd = checkCond "forwarding ctx with owned" (
+        rockhopper.config.fwd.a == "First owned A"
+        && rockhopper.config.fwd.b == "Second owned B for rockhopper"
+        && rockhopper.config.fwd.c == "host owned C"
+        && rockhopper.config.fwd.d == "First static includes D"
+      );
+    };
+
+}


### PR DESCRIPTION
This introduces `parametric.withOwn` that is just a `parametric.atLeast` that also includes the aspect owned configs.

See discussion: https://github.com/vic/den/discussions/91#discussioncomment-14985716

Calling `parametric x` itself is an alias for `parametric.withOwn x`. 

So that both syntax do the same:

```
den.aspects.foo = {
  __functor = den.lib.parametric;
  nixos.foo = 1;
  includes = [ bar ];
};
```

and also, **this is the preferred* syntax that will be documented, since it is more intuitive and does not surfaces `__functor`:

```

den.aspects.foo = den.lib.parametric {
  nixos.foo = 1;
  includes = [ bar ];
};
```

Still have to update documentation about this combinator.

Fixes #97.