### PR TITLE
add base module for user/host/home configs

### DIFF
--- a/modules/_types.nix
+++ b/modules/_types.nix
@@ -26,6 +26,8 @@ let
       { name, config, ... }:
       {
         freeformType = lib.types.attrsOf lib.types.anything;
+        imports = [ den.base.host ];
+        config._module.args.host = config;
         options = {
           name = strOpt "host configuration name" name;
           hostName = strOpt "Network hostname" config.name;
@@ -99,6 +101,8 @@ let
     { name, config, ... }:
     {
       freeformType = lib.types.attrsOf lib.types.anything;
+      imports = [ den.base.user ];
+      config._module.args.user = config;
       options = {
         name = strOpt "user configuration name" name;
         userName = strOpt "user account name" config.name;
@@ -134,6 +138,8 @@ let
       { name, config, ... }:
       {
         freeformType = lib.types.attrsOf lib.types.anything;
+        imports = [ den.base.home ];
+        config._module.args.home = config;
         options = {
           name = strOpt "home configuration name" name;
           userName = strOpt "user account name" config.name;

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -6,8 +6,23 @@
 }:
 let
   types = import ./_types.nix { inherit inputs lib config; };
+  baseMod = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+  };
 in
 {
   options.den.hosts = types.hostsOption;
   options.den.homes = types.homesOption;
+  options.den.base = {
+    conf = baseMod;
+    host = baseMod;
+    user = baseMod;
+    home = baseMod;
+  };
+  config.den.base = {
+    host.imports = [ config.den.base.conf ];
+    user.imports = [ config.den.base.conf ];
+    home.imports = [ config.den.base.conf ];
+  };
 }

--- a/templates/examples/modules/_example/ci/base-conf-modules.nix
+++ b/templates/examples/modules/_example/ci/base-conf-modules.nix
@@ -1,0 +1,76 @@
+# tests for extending `den.base.*` modules with capabilities (options).
+# these allow you to expend all hosts/users/homes with custom option
+# that can later be used by aspects for providing features.
+#
+{ lib, ... }:
+{
+
+  # This module is base for all host configs.
+  den.base.host =
+    { host, ... }:
+    {
+      options.capabilities.ssh-server = lib.mkEnableOption "Does host ${host.name} provides ssh?";
+    };
+
+  # This module is base for all user configs.
+  den.base.user =
+    { user, ... }:
+    {
+      options.isAdmin = lib.mkOption {
+        type = lib.types.bool;
+        default = user.name == "alice"; # only alice is always admin
+      };
+    };
+
+  # This module is base for all home configs.
+  # den.base.home = { home, ... }: { };
+
+  # This one is included on each host/user/home
+  # it cannot access host/user/home values since this conf is generic.
+  den.base.conf = {
+    options.foo = lib.mkOption {
+      type = lib.types.str;
+      default = "bar";
+    };
+  };
+
+  # Now hosts and users can set any option defined in base modules.
+  den.hosts.x86_64-linux.rockhopper = {
+    capabilities.ssh-server = true;
+    foo = "boo";
+    users.alice = {
+      # isAdmin = true;  # alice is admin by default, nothing explicit here.
+      foo = "moo";
+    };
+  };
+
+  den.aspects.rockhopper.includes =
+    let
+      # An aspect can make use of these options to provide configuration.
+      sshCapable =
+        { host, ... }:
+        {
+          nixos.services.sshd.enable = host.capabilities.ssh-server;
+          homeManager.services.ssh-agent.enable = host.capabilities.ssh-server;
+        };
+    in
+    [ sshCapable ];
+
+  # CI checks
+  perSystem =
+    {
+      checkCond,
+      rockhopper,
+      alice-at-rockhopper,
+      ...
+    }:
+    {
+      checks.host-conf-rockhopper-sshd = checkCond "sshd enabled" (
+        rockhopper.config.services.sshd.enable == true
+      );
+      checks.host-conf-alice-sshd = checkCond "ssh-agent enabled" (
+        alice-at-rockhopper.services.ssh-agent.enable == true
+      );
+    };
+
+}


### PR DESCRIPTION
Allows users to have a base module for home/host/user definitions:

```nix

den.base.host = {
  # applies to all den.hosts.<system>.<name>
  # use it to define options all hosts might have.
};

den.base.user = { ... } # included in all den.hosts.<system>.<name>.users.<user>

den.base.home = { ... } # included in all den.homes.<system>.<name>

den.base.conf = { ... } # included in ANY host / user / home config.
```

Checkout tests for a working example of this feature.