### PR TITLE
feat: Context for host with home-manager users.

### DIFF
--- a/modules/aspects/dependencies.nix
+++ b/modules/aspects/dependencies.nix
@@ -6,15 +6,11 @@ let
   inherit (den.lib)
     owned
     statics
-    parametric
+    take
     ;
 
-  inherit (den.lib.take) exactly;
-
   dependencies = [
-    (exactly osDependencies)
-    (exactly hmUserDependencies)
-    (exactly hmStandaloneDependencies)
+    (take.exactly osDependencies)
   ];
 
   osDependencies =
@@ -47,45 +43,6 @@ let
         (owned USR)
         (statics USR)
         (USR { inherit OS host user; })
-      ];
-    };
-
-  # from OS home-managed integration.
-  hmUserDependencies =
-    {
-      OS-HM,
-      host,
-      user,
-    }:
-    let
-      inherit (OS-HM) OS HM;
-      context = {
-        inherit
-          OS
-          HM
-          user
-          host
-          ;
-      };
-    in
-    {
-      includes = [
-        (owned den.default)
-        (statics den.default)
-        (owned HM)
-        (statics HM)
-        (parametric.fixedTo context OS)
-      ];
-    };
-
-  hmStandaloneDependencies =
-    { HM, home }:
-    den.lib.take.unused home {
-      includes = [
-        (owned den.default)
-        (statics den.default)
-        (owned HM)
-        (statics HM)
       ];
     };
 

--- a/modules/aspects/provides/home-manager/hm-dependencies.nix
+++ b/modules/aspects/provides/home-manager/hm-dependencies.nix
@@ -1,0 +1,45 @@
+{
+  den,
+  ...
+}:
+let
+  inherit (den.lib)
+    owned
+    statics
+    parametric
+    take
+    ;
+
+  dependencies = [
+    (take.exactly hmUserDependencies)
+    (take.exactly hmStandaloneDependencies)
+  ];
+
+  # from OS home-managed integration.
+  hmUserDependencies =
+    { HM-OS-USER }:
+    {
+      includes = [
+        (owned den.default)
+        (statics den.default)
+        (owned HM-OS-USER.HM)
+        (statics HM-OS-USER.HM)
+        (parametric.fixedTo HM-OS-USER HM-OS-USER.OS)
+      ];
+    };
+
+  hmStandaloneDependencies =
+    { HM, home }:
+    take.unused home {
+      includes = [
+        (owned den.default)
+        (statics den.default)
+        (owned HM)
+        (statics HM)
+      ];
+    };
+
+in
+{
+  den.default.includes = dependencies;
+}

--- a/modules/aspects/provides/home-manager/hm-os-host.nix
+++ b/modules/aspects/provides/home-manager/hm-os-host.nix
@@ -1,0 +1,43 @@
+{ den, lib, ... }:
+let
+  description = ''
+    This is a private aspect always included in den.default.
+
+    This aspect detects hosts that have an HM supported OS and
+    that have at least one user with ${hm-class} class.
+
+    When this occurs it produces a context `HM-OS-HOST`
+    that other host aspects can use.
+
+    When the `den._.home-manager` aspect is enabled by the user,
+    it reacts to this context and configures HM on the host.
+
+    This same context can be used by other aspects to configure
+    OS settings ONLY for hosts having HM enabled.
+  '';
+
+  hm-class = "homeManager";
+  hm-os-classes = [
+    "nixos"
+    "darwin"
+  ];
+
+  hm-detect =
+    { OS, host }:
+    let
+      is-os-supported = builtins.elem host.class hm-os-classes;
+      hm-users = builtins.filter (u: u.class == hm-class) (lib.attrValues host.users);
+      has-hm-users = builtins.length hm-users > 0;
+      is-hm-host = is-os-supported && has-hm-users;
+      ctx.HM-OS-HOST = { inherit OS host; };
+    in
+    if is-hm-host then OS ctx else { };
+
+  aspect = {
+    inherit description;
+    __functor = _: den.lib.take.exactly hm-detect;
+  };
+in
+{
+  den.default.includes = [ aspect ];
+}

--- a/templates/examples/modules/_example/ci/hm-enabled-host.nix
+++ b/templates/examples/modules/_example/ci/hm-enabled-host.nix
@@ -1,0 +1,29 @@
+{ den, inputs, ... }:
+{
+  # The `{ HM-OS-HOST }` context is activated ONLY for hosts that have
+  # a HM supported OS and at least one user with homeManager class.
+  den.aspects.hm-global-pkgs =
+    { HM-OS-HOST }:
+    den.lib.take.unused [ HM-OS-HOST.host ] # access host from context if needed
+      {
+        nixos.home-manager.useGlobalPkgs = true;
+      };
+
+  den.default.includes = [ den.aspects.hm-global-pkgs ];
+
+  den.hosts.x86_64-linux.no-homes = { };
+
+  perSystem =
+    { checkCond, rockhopper, ... }:
+    {
+      checks.rockhopper-hm-global-pkgs = checkCond "rockhopper-hm-global-pkgs" (
+        rockhopper.config.home-manager.useGlobalPkgs
+      );
+
+      checks.no-homes-hm-global-pkgs = checkCond "no-homes-hm-global-pkgs" (
+        # no home-manager enabled nor useGlobalPkgs
+        !inputs.self.nixosConfigurations.no-homes.config ? home-manager.useGlobalPkgs
+      );
+    };
+
+}

--- a/templates/examples/modules/_example/ci/top-level-parametric.nix
+++ b/templates/examples/modules/_example/ci/top-level-parametric.nix
@@ -22,8 +22,11 @@ in
       homeManager.imports = [ (topLevel host.name) ];
     };
 
-  den.aspects.alice.includes = [
+  den.aspects.rockhopper.includes = [
     den.aspects.toplevel-host
+  ];
+
+  den.aspects.alice.includes = [
     den.aspects.toplevel-user
   ];
 


### PR DESCRIPTION
See [#den > Set user unspecific home-manager options](https://oeiuwq.zulipchat.com/#narrow/channel/548534-den/topic/Set.20user.20unspecific.20home-manager.20options/with/563739770)

This changeset introduces a new Den core context: `{ HM-OS-HOST }` invoked on host aspects. This context is used by our home-manager integration but can also be used by any other host aspect to detect when HM is enabled, for example to set `useGlobalPkgs`.

This context is produced by `hm-os-host.nix` when it detects any host that has an OS supported by home-manager AND has at least one user with `homeManager` class.

The aspect from `hm-os-host.nix` is internal, always included in `den.default`.

When `den._.home-manager` integration is enabled, it reacts to the `host-aspect { HM-OS-HOST }` context and setups home-manager integration. For each user it calls `user-aspect { HM-OS-USER }` for hm-dependencies.nix to include the correct dependencies.

home-manager related code has been moved to ./provides/home-manager/.