### PR TITLE
fix(tests): Fix typo in ssh-server capability description

### DIFF
--- a/templates/examples/modules/_example/ci/base-conf-modules.nix
+++ b/templates/examples/modules/_example/ci/base-conf-modules.nix
@@ -9,7 +9,7 @@
   den.base.host =
     { host, ... }:
     {
-      options.capabilities.ssh-server = lib.mkEnableOption "Does host ${host.name} provides ssh?";
+      options.capabilities.ssh-server = lib.mkEnableOption "Does host ${host.name} provide ssh?";
     };
 
   # This module is base for all user configs.


### PR DESCRIPTION
This PR fixes a typo in an option description.