### PR TITLE
feat: forward classes

### DIFF
--- a/modules/aspects/provides/forward.nix
+++ b/modules/aspects/provides/forward.nix
@@ -1,0 +1,33 @@
+{ lib, ... }:
+let
+
+  description = ''
+    WIP: Creates a class-forwarding aspect.
+  '';
+
+  forward =
+    cb:
+    { class, aspect-chain }:
+    let
+      fwd = cb { inherit class aspect-chain; };
+      include =
+        item:
+        let
+          from = fwd.from item;
+          into = fwd.into item;
+          aspect = fwd.aspect item;
+          module = aspect.resolve { class = from; };
+        in
+        lib.setAttrByPath into { imports = [ module ]; };
+    in
+    {
+      includes = map include fwd.each;
+    };
+
+in
+{
+  den.provides.forward = {
+    inherit description;
+    __functor = _self: forward;
+  };
+}

--- a/templates/ci/flake.lock
+++ b/templates/ci/flake.lock
@@ -205,17 +205,14 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 1770843696,
-        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
+        "narHash": "sha256-9SFCZkVcpDOV6unH5hVEy4+dB0rxMuUoBnDAO6vshac=",
         "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre944764.2343bbb58f99/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-stable": {

--- a/templates/ci/flake.nix
+++ b/templates/ci/flake.nix
@@ -39,7 +39,7 @@
       };
       url = "github:nix-community/nixos-wsl";
     };
-    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixpkgs-unstable/nixexprs.tar.xz";
     nixpkgs-lib.follows = "nixpkgs";
     nixpkgs-stable.url = "github:nixos/nixpkgs/release-25.05";
     provider = {


### PR DESCRIPTION
The functionality of `homeManager` itself was generalized into `den.provides.forward`, this will pave the road for easily having `hjem`, `nix-maid` and most importantly, allow the user to have custom defined forward classes.

See discussion at #160 