### PR TITLE
Remove OS from example defaults.nix

### DIFF
--- a/templates/example/modules/aspects/defaults.nix
+++ b/templates/example/modules/aspects/defaults.nix
@@ -34,8 +34,8 @@
     #
     #  # Instead try to be explicit if a function is intended for ONLY { host }.
     (den.lib.take.exactly (
-      { OS, host }:
-      den.lib.take.unused OS {
+      { host }:
+      {
         nixos.networking.hostName = host.hostName;
       }
     ))


### PR DESCRIPTION
Per the v0.9.0 upgrade instructions, taking `OS` as a parameter is no longer a thing. I noticed this instance when checking out the examples template to see how `den.ctx` affected it.