### PR TITLE
user class modules can take os-level pkgs and osConfig.

### DIFF
--- a/modules/aspects/provides/os-user.nix
+++ b/modules/aspects/provides/os-user.nix
@@ -41,6 +41,7 @@ let
         user.userName
       ];
       fromAspect = _: den.aspects.${user.aspect};
+      adaptArgs = args: args // { osConfig = args.config; };
     };
 
 in

--- a/templates/ci/modules/features/os-user-class.nix
+++ b/templates/ci/modules/features/os-user-class.nix
@@ -14,5 +14,75 @@
       }
     );
 
+    test-forwards-os-args = denTest (
+      {
+        den,
+        igloo,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tux.user =
+          { pkgs, ... }:
+          {
+            description = lib.getName pkgs.hello;
+          };
+
+        expr = igloo.users.users.tux.description;
+        expected = "hello";
+      }
+    );
+
+    test-forwards-mergeable-option = denTest (
+      {
+        den,
+        igloo,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # via user class
+        den.aspects.tux.user =
+          { pkgs, ... }:
+          {
+            packages = [ pkgs.hello ];
+          };
+
+        # via user nixos
+        den.aspects.tux.nixos =
+          { pkgs, ... }:
+          {
+            users.users.tux.packages = [ pkgs.vim ];
+          };
+
+        # via host nixos
+        den.aspects.igloo.nixos =
+          { pkgs, ... }:
+          {
+            users.users.tux.packages = [ pkgs.tmux ];
+          };
+
+        expr = lib.sort (a: b: a < b) (
+          lib.filter (
+            name:
+            lib.elem name [
+              "hello"
+              "vim"
+              "tmux"
+            ]
+          ) (map lib.getName igloo.users.users.tux.packages)
+        );
+        expected = [
+          "hello"
+          "tmux"
+          "vim"
+        ];
+      }
+    );
+
   };
 }


### PR DESCRIPTION
This is made possible via den.provides.forward now being able to use an adapter module and args adapter.