### PR TITLE
Fix nix-maid link in noflake tutorial

### DIFF
--- a/docs/src/content/docs/tutorials/noflake.md
+++ b/docs/src/content/docs/tutorials/noflake.md
@@ -93,7 +93,7 @@ This file resolves npins sources into a flake-compatible `inputs` attrset. It re
 ```
 
 Notable differences from the flake templates:
-- Uses [nix-maid](https://github.com/vic/nix-maid) instead of Home-Manager (lighter alternative)
+- Uses [nix-maid](https://github.com/viperML/nix-maid) instead of Home-Manager (lighter alternative)
 - User config is done directly in `nixos` class (no HM class needed)
 
 ## Build


### PR DESCRIPTION
Corrected the GitHub link for nix-maid in the tutorial.