### PR TITLE
Home integration now enabled via host config for hm, nix-maid, hjem

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -62,11 +62,11 @@ export default defineConfig({
 					items: [
 						{ label: 'Declare Hosts & Users', slug: 'guides/declare-hosts' },
 						{ label: 'Configure Aspects', slug: 'guides/configure-aspects' },
-						{ label: 'Home-Manager Integration', slug: 'guides/home-manager' },
+						{ label: 'Custom Nix Classes', slug: 'guides/custom-classes' },
+						{ label: 'Homes Integration', slug: 'guides/home-manager' },
 						{ label: 'Use Batteries', slug: 'guides/batteries' },
 						{ label: 'Share with Namespaces', slug: 'guides/namespaces' },
 						{ label: 'Angle Brackets Syntax', slug: 'guides/angle-brackets' },
-						{ label: 'Custom Nix Classes', slug: 'guides/custom-classes' },
 						{ label: 'Migrate to Den', slug: 'guides/migrate' },
 						{ label: 'Debug Configurations', slug: 'guides/debug' },
 					],

--- a/docs/src/content/docs/guides/custom-classes.mdx
+++ b/docs/src/content/docs/guides/custom-classes.mdx
@@ -45,6 +45,35 @@ in {
 }
 ```
 
+Example: A git class that forwards to home-manager.
+
+```nix
+gitClass =
+  { class, aspect-chain }:
+  den._.forward {
+    each = lib.singleton true;
+    fromClass = _: "git";
+    intoClass = _: "homeManager";
+    intoPath = _: [
+      "programs"
+      "git"
+    ];
+    fromAspect = _: lib.head aspect-chain;
+    adaptArgs =
+      { config, ... }:
+      {
+	osConfig = config;
+      };
+  };
+
+den.aspects.tux = {
+  includes = [ gitClass ];
+  git.userEmail = "root@linux.com";
+};
+```
+
+This will set at host: `igloo.home-manager.users.tux.programs.git.userEmail`
+
 
 ## Use Cases
 

--- a/docs/src/content/docs/guides/home-manager.mdx
+++ b/docs/src/content/docs/guides/home-manager.mdx
@@ -1,5 +1,5 @@
 ---
-title: Home-Manager Integration
+title: Homes Integration (hm / hjem / nix-maid, etc)
 description: Integrate Home-Manager into NixOS/Darwin hosts or use standalone.
 ---
 
@@ -8,36 +8,70 @@ import { Aside } from '@astrojs/starlight/components';
 
 <Aside title="Use the Source, Luke" icon="github">
 [`hm-os.nix`](https://github.com/vic/den/blob/main/modules/aspects/provides/home-manager/hm-os.nix) · [`hm-integration.nix`](https://github.com/vic/den/blob/main/modules/aspects/provides/home-manager/hm-integration.nix)
+
+[`hjem-os.nix`](https://github.com/vic/den/blob/main/modules/aspects/provides/hjem/hjem-os.nix) · [`hjem-integration.nix`](https://github.com/vic/den/blob/main/modules/aspects/provides/hjem/hjem-integration.nix)
+
+[`maid-os.nix`](https://github.com/vic/den/blob/main/modules/aspects/provides/maid/maid-os.nix) · [`maid-integration.nix`](https://github.com/vic/den/blob/main/modules/aspects/provides/maid/maid-integration.nix)
+
 </Aside>
 
-## Automatic HM Detection
+Den supports different Nix libraries for managing user home files.
+All of them have Nix classes implemented using `den.provides.forward` 
+and you can create custom home-like classes following the same pattern.
 
-Den automatically detects hosts that need Home-Manager. When a host has
-users with `"homeManager"` in their `classes` list (the default), Den:
+- `user` class. NixOS and nix-Darwin builtin `users.users.<userName>` submodule.
+- `homeManager` class. Enabled via `host.home-manager.enable`
+- `hjem` class. Enabled via `host.hjem.enable`
+- `maid` class. Enabled via `host.nix-maid.enable`.
 
-1. Imports the Home-Manager NixOS/Darwin module
-2. Creates a `homeManager` class for each user
-3. Forwards `homeManager` configs into `home-manager.users.<name>`
+Class names follow the Nix class used by the module system of these projects
+not the project name, e.g: [`homeManager`](https://github.com/nix-community/home-manager/blob/f140aa04d7d14f8a50ab27f3691b5766b17ae961/modules/default.nix#L32).
 
-No explicit opt-in needed — just declare users.
+Except for the `user` class which is always enabled, other home classes
+are opt-in features, enabled via the host configuration:
 
-```mermaid
-graph LR
-  Host["{host}"] -->|"hm-detect"| Check{"class ∈ nixos,darwin?<br/>HM users exist?<br/>HM module available?"}
-  Check -->|"yes"| HM["ctx.hm-host<br/>imports HM module"]
-  HM -->|"per user"| FW["forward homeManager<br/>→ home-manager.users.‹name›"]
-  Check -->|"no"| Skip["HM pipeline skipped"]
+```nix
+# per host:
+den.hosts.x86_64-linux.igloo.home-manager = {
+  enable = true;
+
+  # optionally with custom stable/unstable HM input
+  module = inputs.home-manager-unstable.nixosModules.default;
+};
+
+# Globally (or conditionally on host)
+den.base.host = { host, ... }: {
+   home-manager.enable = host.name == "igloo";
+};
 ```
+
+## Multi Home support.
+
+User can choose to manage some files with home-manager instead or in
+addition to nix-maid and hjem. For example, when migrating away from home-manager into other libraries, you might want to keep your stuff working as you move progressively.
+
+Users define a `<user>.classes = [ "homeManager" ]` (default) where they
+explicitly enable the different home libraries they use.
 
 ## Host-Managed Users
 
 ```nix
 den.hosts.x86_64-linux.igloo.users.tux = { };
-den.default.homeManager.home.stateVersion = "25.11";
 
+# host meta configuration (capabilities), HM always enabled.
+den.base.host.home-manager.enable = lib.mkDefault true;
+
+# homeManager default settings
+den.default.homeManager.home.stateVersion = lib.mkDefault "25.11";
+
+# NixOS/Nix-Darwin user class.
+den.aspects.tux.user.description = "The Penguin";
+
+# homeManager class
 den.aspects.tux.homeManager.programs.vim.enable = true;
 ```
 
+User description forwarded into `igloo.users.users.tux.description`.
 The vim config is forwarded into `igloo.home-manager.users.tux`.
 
 ## Standalone Home-Manager
@@ -52,38 +86,25 @@ den.aspects.vic.homeManager.programs.fish.enable = true;
 
 Build with `home-manager switch --flake .#vic`.
 
-## The define-user Battery
+## Context types for Home enabled hosts.
 
-Use `den._.define-user` to automatically set username and home directory:
+Each Home integration in Den defines a context 
+transformation from `den.ctx.host -> den.ctx.${name}-host`.
 
-```nix
-den.default.includes = [ den._.define-user ];
-```
+For example, `den.ctx.hm-host` is the aspect for Home-Manager enabled hosts.
+Similarly `den.ctx.maid-host` and `den.ctx.hjem-host`.
 
-This sets `home.username`, `home.homeDirectory`, and
-`users.users.<name>` on both NixOS and Darwin.
+## useGlobalPkgs at Home Manager enabled hosts
 
-## useGlobalPkgs
-
-Configure Home-Manager to use the host's nixpkgs:
+Configure a NixOS option only for Home-Manager hosts 
+so they can use the host's nixpkgs:
 
 ```nix
 den.ctx.hm-host.nixos.home-manager.useGlobalPkgs = true;
 ```
 
 This only activates for hosts that actually have Home-Manager users.
-Hosts without users are unaffected.
-
-## Custom HM Module
-
-Override the Home-Manager module source:
-
-```nix
-den.hosts.x86_64-linux.igloo = {
-  hm-module = inputs.home-manager-unstable.nixosModules.home-manager;
-  users.tux = { };
-};
-```
+Hosts without Home-Manager users are unaffected.
 
 ## Standalone with osConfig
 
@@ -104,16 +125,4 @@ den.aspects.pingu.homeManager = { osConfig, ... }: {
 };
 ```
 
-## Context Hooks
 
-Use `den.ctx.hm-host` to configure things only when HM is active:
-
-```nix
-den.ctx.hm-host.nixos.home-manager.useGlobalPkgs = true;
-den.ctx.hm-host.includes = [
-  { nixos.home-manager.backupFileExtension = "bak"; }
-];
-```
-
-These only apply to hosts that have Home-Manager users with
-a supported OS (NixOS or Darwin).

--- a/docs/src/content/docs/overview.mdx
+++ b/docs/src/content/docs/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Documentation Overview
 description: Everything Den
 ---
 

--- a/modules/aspects/provides/hjem/hjem-os.nix
+++ b/modules/aspects/provides/hjem/hjem-os.nix
@@ -10,26 +10,39 @@ let
     "nixos"
     "darwin"
   ];
-  hjemModule = host: host.hjem-module or inputs.hjem."${host.class}Modules".default;
+
+  hostConf =
+    { host, ... }:
+    {
+      options.hjem = {
+        enable = lib.mkEnableOption "Enable hjem";
+        module = lib.mkOption {
+          type = lib.types.deferredModule;
+          default = inputs.hjem."${host.class}Modules".default;
+        };
+      };
+    };
 
   hjemDetect =
     { host }:
     let
       isOsSupported = builtins.elem host.class hjemOsClasses;
-      hasHjemModule = (host ? hjem-module) || (inputs ? hjem);
       hjemUsers = builtins.filter (u: lib.elem hjemClass u.classes) (lib.attrValues host.users);
       hasHjemUsers = builtins.length hjemUsers > 0;
-      isHjemHost = isOsSupported && hasHjemUsers && hasHjemModule;
+      isHjemHost = host.hjem.enable && isOsSupported && hasHjemUsers;
     in
     lib.optional isHjemHost { inherit host; };
 
-in
-{
-  den.ctx.host.into.hjem-host = hjemDetect;
+  ctx.host.into.hjem-host = hjemDetect;
 
-  den.ctx.hjem-host._.hjem-host =
+  ctx.hjem-host._.hjem-host =
     { host }:
     {
-      ${host.class}.imports = [ (hjemModule host) ];
+      ${host.class}.imports = [ host.hjem.module ];
     };
+
+in
+{
+  den.ctx = ctx;
+  den.base.host.imports = [ hostConf ];
 }

--- a/modules/aspects/provides/home-manager/hm-integration.nix
+++ b/modules/aspects/provides/home-manager/hm-integration.nix
@@ -43,7 +43,29 @@ let
 
 in
 {
-  den.provides.home-manager = { };
+  den.provides.home-manager =
+    _:
+    throw ''
+      NOTICE: den.provides.home-manager aspect is not needed anymore.
+
+      Enabling Home Manager is now made via the host config:
+
+      Per host: 
+
+         den.hosts.x86_64-linux.igloo.home-manager.enable = true;
+
+      On ALL hosts: 
+
+         den.base.host.home-manager.enable = true;
+
+      See <den/home-manager/hm-os.nix>
+
+      If you had includes at den._.home-manager, you can use:
+
+         den.ctx.hm-host.includes = [ ... ];
+
+      For attaching aspects to home-manager enabled hosts.
+    '';
 
   den.ctx.home.description = "Standalone Home-Manager config provided by home aspect";
   den.ctx.home._.home = { home }: parametric.fixedTo { inherit home; } den.aspects.${home.aspect};

--- a/modules/aspects/provides/home-manager/hm-os.nix
+++ b/modules/aspects/provides/home-manager/hm-os.nix
@@ -9,16 +9,16 @@ let
     Detects hosts that have an HM supported OS and
     that have at least one user with ${hm-class} class.
 
-    When this occurs it produces a context `den.ctx.hm-os`
+    When this occurs it produces a context `den.ctx.hm-host`
 
     This `den.ctx.hm-os` context includes the OS-level
     homeManager module and is used by hm-integration.nix to then
-    produce a `den.ctx.hm` for each user.
+    produce a `den.ctx.hm-user` for each user.
 
     This same context can be used to include aspects
     ONLY for hosts having HM enabled.
 
-       den.ctx.hm-os.includes = [ den.aspects.foo ];
+       den.ctx.hm-host.includes = [ den.aspects.foo ];
   '';
 
   hm-class = "homeManager";
@@ -26,27 +26,40 @@ let
     "nixos"
     "darwin"
   ];
-  hm-module = host: host.hm-module or inputs.home-manager."${host.class}Modules".home-manager;
+
+  hostConf =
+    { host, ... }:
+    {
+      options.home-manager = {
+        enable = lib.mkEnableOption "Enable Home Manager integration";
+        module = lib.mkOption {
+          type = lib.types.deferredModule;
+          default = inputs.home-manager."${host.class}Modules".home-manager;
+        };
+      };
+    };
 
   hm-detect =
     { host }:
     let
       is-os-supported = builtins.elem host.class hm-os-classes;
-      has-hm-module = (host ? hm-module) || (inputs ? home-manager);
       hm-users = builtins.filter (u: lib.elem hm-class u.classes) (lib.attrValues host.users);
       has-hm-users = builtins.length hm-users > 0;
-      is-hm-host = is-os-supported && has-hm-users && has-hm-module;
+      is-hm-host = host.home-manager.enable && is-os-supported && has-hm-users;
     in
     lib.optional is-hm-host { inherit host; };
 
-in
-{
-  den.ctx.host.into.hm-host = hm-detect;
+  ctx.host.into.hm-host = hm-detect;
 
-  den.ctx.hm-host.description = description;
-  den.ctx.hm-host._.hm-host =
+  ctx.hm-host.description = description;
+  ctx.hm-host.provides.hm-host =
     { host }:
     {
-      ${host.class}.imports = [ (hm-module host) ];
+      ${host.class}.imports = [ host.home-manager.module ];
     };
+
+in
+{
+  den.ctx = ctx;
+  den.base.host.imports = [ hostConf ];
 }

--- a/modules/aspects/provides/maid/maid-os.nix
+++ b/modules/aspects/provides/maid/maid-os.nix
@@ -9,26 +9,38 @@ let
   maidOsClasses = [
     "nixos"
   ];
-  maidModule = host: host.maid-module or inputs.nix-maid.nixosModules.default;
+
+  hostConf =
+    { host, ... }:
+    {
+      options.nix-maid = {
+        enable = lib.mkEnableOption "Enable nix-maid";
+        module = lib.mkOption {
+          type = lib.types.deferredModule;
+          default = inputs.nix-maid.nixosModules.default;
+        };
+      };
+    };
 
   maidDetect =
     { host }:
     let
       isOsSupported = builtins.elem host.class maidOsClasses;
-      hasMaidModule = (host ? maid-module) || (inputs ? nix-maid);
       maidUsers = builtins.filter (u: lib.elem maidClass u.classes) (lib.attrValues host.users);
       hasMaidUsers = builtins.length maidUsers > 0;
-      isMaidHost = isOsSupported && hasMaidUsers && hasMaidModule;
+      isMaidHost = host.nix-maid.enable && isOsSupported && hasMaidUsers;
     in
     lib.optional isMaidHost { inherit host; };
 
-in
-{
-  den.ctx.host.into.maid-host = maidDetect;
+  ctx.host.into.maid-host = maidDetect;
 
-  den.ctx.maid-host._.maid-host =
+  ctx.maid-host._.maid-host =
     { host }:
     {
-      ${host.class}.imports = [ (maidModule host) ];
+      ${host.class}.imports = [ host.nix-maid.module ];
     };
+in
+{
+  den.ctx = ctx;
+  den.base.host.imports = [ hostConf ];
 }

--- a/templates/bogus/modules/test-base.nix
+++ b/templates/bogus/modules/test-base.nix
@@ -28,6 +28,7 @@ let
 
   denModule = {
     imports = [ inputs.den.flakeModule ];
+    den.base.host.home-manager.enable = true;
     den.default.homeManager.home.stateVersion = "26.05";
     den.default.nixos = {
       system.stateVersion = "26.05";

--- a/templates/ci/modules/features/hjem-class.nix
+++ b/templates/ci/modules/features/hjem-class.nix
@@ -25,7 +25,8 @@ in
       {
         den.hosts.x86_64-linux.igloo = {
           users.tux.classes = [ "hjem" ];
-          hjem-module = mockHjemModule;
+          hjem.enable = true;
+          hjem.module = mockHjemModule;
         };
 
         den.aspects.tux.hjem.theme = "nord";
@@ -45,7 +46,8 @@ in
       {
         den.hosts.x86_64-linux.igloo = {
           users.tux.classes = [ "hjem" ];
-          hjem-module = mockHjemModule;
+          hjem.enable = true;
+          hjem.module = mockHjemModule;
         };
 
         den.aspects.tux.hjem.tags = [ "from-hjem" ];
@@ -64,11 +66,12 @@ in
       {
         den.hosts.x86_64-linux.igloo = {
           users.tux = { };
-          hjem-module = mockHjemModule;
+          hjem.enable = false;
+          hjem.module = mockHjemModule;
         };
 
-        expr = igloo.networking.hostName;
-        expected = "nixos";
+        expr = igloo ? hjem;
+        expected = false;
       }
     );
 

--- a/templates/ci/modules/features/maid-class.nix
+++ b/templates/ci/modules/features/maid-class.nix
@@ -29,7 +29,8 @@ in
       {
         den.hosts.x86_64-linux.igloo = {
           users.tux.classes = [ "maid" ];
-          maid-module = mockMaidModule;
+          nix-maid.enable = true;
+          nix-maid.module = mockMaidModule;
         };
 
         den.aspects.tux.maid.description = "maid-tux";
@@ -49,7 +50,8 @@ in
       {
         den.hosts.x86_64-linux.igloo = {
           users.tux.classes = [ "maid" ];
-          maid-module = mockMaidModule;
+          nix-maid.enable = true;
+          nix-maid.module = mockMaidModule;
         };
 
         den.aspects.tux.maid.tags = [ "from-maid" ];
@@ -68,11 +70,12 @@ in
       {
         den.hosts.x86_64-linux.igloo = {
           users.tux = { };
-          maid-module = mockMaidModule;
+          nix-maid.enable = false;
+          nix-maid.module = mockMaidModule;
         };
 
-        expr = igloo.networking.hostName;
-        expected = "nixos";
+        expr = igloo ? users.tux.maid;
+        expected = false;
       }
     );
 

--- a/templates/ci/modules/test-support/eval-den.nix
+++ b/templates/ci/modules/test-support/eval-den.nix
@@ -31,6 +31,8 @@ let
     options.flake.packages = lib.mkOption { };
     options.expr = lib.mkOption { };
     options.expected = lib.mkOption { };
+
+    config.den.base.host.home-manager.enable = lib.mkDefault true;
   };
 
   helpersModule =

--- a/templates/default/modules/hosts.nix
+++ b/templates/default/modules/hosts.nix
@@ -2,7 +2,10 @@
 # then config their aspects in as many files you want
 {
   # tux user at igloo host.
-  den.hosts.x86_64-linux.igloo.users.tux = { };
+  den.hosts.x86_64-linux.igloo = {
+    users.tux = { };
+    home-manager.enable = true;
+  };
 
   # define an standalone home-manager for tux
   # den.homes.x86_64-linux.tux = { };

--- a/templates/example/modules/den.nix
+++ b/templates/example/modules/den.nix
@@ -2,4 +2,7 @@
   den.hosts.x86_64-linux.igloo.users.alice = { };
   den.hosts.aarch64-darwin.apple.users.alice = { };
   den.homes.x86_64-linux.alice = { };
+
+  # Enable HM on all hosts
+  den.base.host.home-manager.enable = true;
 }

--- a/templates/minimal/modules/den.nix
+++ b/templates/minimal/modules/den.nix
@@ -19,5 +19,6 @@
 
   den.aspects.tux = {
     includes = [ den.provides.primary-user ];
+    user.extraGroups = [ "audio" ];
   };
 }

--- a/templates/noflake/modules/den.nix
+++ b/templates/noflake/modules/den.nix
@@ -10,8 +10,9 @@
   };
 
   # tux user on igloo host, using nix-maid
-  den.hosts.x86_64-linux.igloo.users.tux = {
-    classes = [ "maid" ];
+  den.hosts.x86_64-linux.igloo = {
+    nix-maid.enable = true;
+    users.tux.classes = [ "maid" ];
   };
 
   # host aspect


### PR DESCRIPTION
This deprecates the `den.provides.home-manager` aspect.