### PR TITLE
fix wrong location issue of option definied in den.default

### DIFF
--- a/modules/aspects/defaults.nix
+++ b/modules/aspects/defaults.nix
@@ -1,8 +1,8 @@
+{ den, lib, ... }:
 {
-  den =
-    { lib, ... }:
-    {
-      imports = [ (lib.mkAliasOptionModule [ "default" ] [ "ctx" "default" ]) ];
-      ctx.default = { };
-    };
+  options.den.default = lib.mkOption {
+    description = "Default aspect";
+    type = den.lib.aspects.types.aspectSubmodule;
+  };
+  config.den.ctx.default = den.default;
 }


### PR DESCRIPTION
Set den.default as separate option with aspect type (similar to before context feature).