### PR TITLE
fix(battery): den._.hostname strictness

### DIFF
--- a/modules/aspects/provides/hostname.nix
+++ b/modules/aspects/provides/hostname.nix
@@ -11,13 +11,13 @@ let
   '';
 
   setHostname =
-    { host }:
+    { host, ... }:
     {
       ${host.class}.networking.hostName = host.hostName;
     };
 in
 {
-  den.provides.hostname = den.lib.parametric.exactly {
+  den.provides.hostname = den.lib.parametric.atLeast {
     inherit description;
     includes = [ setHostname ];
   };

--- a/templates/ci/modules/features/batteries/hostname.nix
+++ b/templates/ci/modules/features/batteries/hostname.nix
@@ -29,5 +29,63 @@
       }
     );
 
+    test-included-in-host = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den._.hostname ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo";
+      }
+    );
+
+    test-included-in-user = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tux.includes = [ den._.hostname ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo";
+      }
+    );
+
+    test-included-in-host-includes = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # NOTE: foo needs parametric to pass over `{host}` context into den._.hostname
+        den.aspects.foo = den.lib.parametric {
+          includes = [ den._.hostname ];
+        };
+
+        den.aspects.igloo.includes = [ den.aspects.foo ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo";
+      }
+    );
+
+    test-included-in-user-includes = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # NOTE: foo needs parametric to pass over `{host}` context into den._.hostname
+        den.aspects.foo = den.lib.parametric {
+          includes = [ den._.hostname ];
+        };
+
+        den.aspects.tux.includes = [ den.aspects.foo ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo";
+      }
+    );
+
   };
 }


### PR DESCRIPTION
This changes `den._.hostname` from `take.exactly {host}` to `take.atLeast {host,...}`, to make it also work on user aspects because they have no `{host}` context, only a `{host, user}` one.

Also added tests that including `den._.hostname` in a second order include works. NOTE: the aspect using `includes = [ den._.hostname ]` needs to be `parametric {}` to be able to forward context.

Might be of interest @drupol