### PR TITLE
perf(core): Hyperfine benchmark and perf improvements

### DIFF
--- a/nix/ctx-apply.nix
+++ b/nix/ctx-apply.nix
@@ -2,19 +2,19 @@
 let
   inherit (den.lib) parametric;
 
-  cleanCtx =
-    self:
-    builtins.removeAttrs self [
-      "name"
-      "description"
-      "into"
-      "provides"
-      "__functor"
-      "modules"
-      "resolve"
-      "_module"
-      "_"
-    ];
+  ctxKeys = [
+    "name"
+    "description"
+    "into"
+    "provides"
+    "__functor"
+    "modules"
+    "resolve"
+    "_module"
+    "_"
+  ];
+
+  cleanCtx = self: builtins.removeAttrs self ctxKeys;
 
   transformAll =
     source: self: ctx:
@@ -41,13 +41,7 @@ let
 
   noop = _: { };
 
-  crossProvider =
-    p:
-    let
-      src = p.source;
-      name = p.ctxDef.name;
-    in
-    if src == null then noop else src.provides.${name} or noop;
+  crossProvider = p: if p.source == null then noop else p.source.provides.${p.ctxDef.name} or noop;
 
   dedupIncludes =
     let

--- a/nix/fn-can-take.nix
+++ b/nix/fn-can-take.nix
@@ -4,15 +4,11 @@ let
     params: func:
     let
       givenFn = builtins.isFunction func || (builtins.isAttrs func && func ? __functor);
-      givenArgs = builtins.isAttrs params;
       fargs = lib.functionArgs func;
-      provided = builtins.attrNames params;
-      args = lib.mapAttrsToList (name: optional: { inherit name optional; }) fargs;
-      required = map (x: x.name) (lib.filter (x: !x.optional) args);
-      intersection = lib.intersectLists required provided;
-      satisfied = givenFn && givenArgs && lib.length required == lib.length intersection;
-      noExtras = lib.length required == lib.length provided;
-      exactly = satisfied && noExtras;
+      required = lib.filterAttrs (_: optional: !optional) fargs;
+      reqNames = builtins.attrNames required;
+      satisfied = givenFn && builtins.isAttrs params && builtins.all (n: params ? ${n}) reqNames;
+      exactly = satisfied && builtins.length reqNames == builtins.length (builtins.attrNames params);
     in
     {
       inherit satisfied exactly;

--- a/nix/types.nix
+++ b/nix/types.nix
@@ -220,9 +220,8 @@ let
     from: intent: name:
     let
       asp = intent { ${name} = from; };
-      mod = asp.resolve { inherit (from) class; };
     in
-    mod;
+    den.lib.aspects.resolve (from.class) [ ] asp;
 in
 {
   inherit hostsOption homesOption;

--- a/templates/bogus/flake.lock
+++ b/templates/bogus/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773126960,
-        "narHash": "sha256-+UUijboPjAjGDgCpR8h5ji6/K4ashlpcNZPfI/UK1hc=",
+        "lastModified": 1773131302,
+        "narHash": "sha256-74bgLrcTvbL2A6NabH8wbU9OLmOCieF4oW4RscP0kBA=",
         "owner": "vic",
         "repo": "den",
-        "rev": "49ce965b8501208986b6d1382f913fbd0881a043",
+        "rev": "69682fffa09d57fb8a8dbf367252dbedca023207",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-aspects": {
       "locked": {
-        "lastModified": 1772999207,
-        "narHash": "sha256-dzZpKU1wS/9oMsgK9dqCD+wblBMj1EAhInQtvY2dLUI=",
+        "lastModified": 1773185256,
+        "narHash": "sha256-e3YqMwdQ2EpVTuWRkK2rkrHywp8QCpkj7x2U53SNoIA=",
         "owner": "vic",
         "repo": "flake-aspects",
-        "rev": "778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6",
+        "rev": "81a51a8997abe392b9d0794424a4823adc9bd3af",
         "type": "github"
       },
       "original": {

--- a/templates/ci/flake.lock
+++ b/templates/ci/flake.lock
@@ -22,11 +22,11 @@
     },
     "den": {
       "locked": {
-        "lastModified": 1773126960,
-        "narHash": "sha256-+UUijboPjAjGDgCpR8h5ji6/K4ashlpcNZPfI/UK1hc=",
+        "lastModified": 1773131302,
+        "narHash": "sha256-74bgLrcTvbL2A6NabH8wbU9OLmOCieF4oW4RscP0kBA=",
         "owner": "vic",
         "repo": "den",
-        "rev": "49ce965b8501208986b6d1382f913fbd0881a043",
+        "rev": "69682fffa09d57fb8a8dbf367252dbedca023207",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "flake-aspects": {
       "locked": {
-        "lastModified": 1772999207,
-        "narHash": "sha256-dzZpKU1wS/9oMsgK9dqCD+wblBMj1EAhInQtvY2dLUI=",
+        "lastModified": 1773185256,
+        "narHash": "sha256-e3YqMwdQ2EpVTuWRkK2rkrHywp8QCpkj7x2U53SNoIA=",
         "owner": "vic",
         "repo": "flake-aspects",
-        "rev": "778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6",
+        "rev": "81a51a8997abe392b9d0794424a4823adc9bd3af",
         "type": "github"
       },
       "original": {

--- a/templates/ci/modules/features/deadbugs/dup-functors-issue-216.nix
+++ b/templates/ci/modules/features/deadbugs/dup-functors-issue-216.nix
@@ -21,7 +21,8 @@ let
         x = 0;
         y = 1;
       };
-      fooModule = fooAspect.resolve { class = "foo"; };
+      resolve = ev.config.den.lib.aspects.resolve;
+      fooModule = resolve "foo" [ ] fooAspect;
 
       namesModule.options.names = lib.mkOption { type = lib.types.listOf lib.types.str; };
       ev2 = lib.evalModules {

--- a/templates/ci/modules/features/perf/ctx-chain.nix
+++ b/templates/ci/modules/features/perf/ctx-chain.nix
@@ -1,0 +1,92 @@
+{ denTest, lib, ... }:
+let
+  mkCtxModules =
+    n:
+    lib.genList (
+      i:
+      let
+        name = "ctx-${toString i}";
+        next = "ctx-${toString (i + 1)}";
+        base = {
+          description = name;
+          _.${name} =
+            { x }:
+            {
+              funny.names = [ "${name}-${x}" ];
+            };
+        };
+        withInto =
+          if i + 1 < n then
+            {
+              into.${next} = { x }: [ { x = "${x}+${toString i}"; } ];
+            }
+          else
+            { };
+      in
+      { den, ... }:
+      {
+        den.ctx.${name} = base // withInto;
+      }
+    ) n;
+in
+{
+  flake.tests.perf-ctx = {
+
+    test-ctx-chain-5 = denTest (
+      { den, funnyNames, ... }:
+      {
+        imports = mkCtxModules 5;
+        expr = builtins.length (funnyNames (den.ctx.ctx-0 { x = "v"; }));
+        expected = 5;
+      }
+    );
+
+    test-ctx-chain-10 = denTest (
+      { den, funnyNames, ... }:
+      {
+        imports = mkCtxModules 10;
+        expr = builtins.length (funnyNames (den.ctx.ctx-0 { x = "v"; }));
+        expected = 10;
+      }
+    );
+
+    test-ctx-chain-20 = denTest (
+      { den, funnyNames, ... }:
+      {
+        imports = mkCtxModules 20;
+        expr = builtins.length (funnyNames (den.ctx.ctx-0 { x = "v"; }));
+        expected = 20;
+      }
+    );
+
+    test-ctx-fan-out-20 = denTest (
+      { den, funnyNames, ... }:
+      {
+        imports = [
+          (
+            { den, ... }:
+            {
+              den.ctx.root = {
+                description = "root";
+                _.root =
+                  { x }:
+                  {
+                    funny.names = [ "root-${x}" ];
+                  };
+                into.leaf = { x }: lib.genList (i: { x = "${x}-${toString i}"; }) 20;
+              };
+              den.ctx.leaf._.leaf =
+                { x }:
+                {
+                  funny.names = [ "leaf-${x}" ];
+                };
+            }
+          )
+        ];
+        expr = builtins.length (funnyNames (den.ctx.root { x = "v"; }));
+        expected = 21;
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/perf/depth.nix
+++ b/templates/ci/modules/features/perf/depth.nix
@@ -1,0 +1,90 @@
+{ denTest, lib, ... }:
+let
+  mkChain =
+    n:
+    let
+      go =
+        i:
+        if i >= n then
+          { funny.names = [ "leaf" ]; }
+        else
+          {
+            funny.names = [ "level-${toString i}" ];
+            includes = [ (go (i + 1)) ];
+          };
+    in
+    go 0;
+
+  mkWide = n: {
+    funny.names = [ "root" ];
+    includes = lib.genList (i: { funny.names = [ "branch-${toString i}" ]; }) n;
+  };
+
+  mkDeepWide =
+    depth: width:
+    let
+      go =
+        d:
+        if d >= depth then
+          {
+            funny.names = [ "leaf-d${toString d}" ];
+            includes = lib.genList (i: { funny.names = [ "wide-d${toString d}-${toString i}" ]; }) width;
+          }
+        else
+          {
+            funny.names = [ "level-${toString d}" ];
+            includes = [ (go (d + 1)) ];
+          };
+    in
+    go 0;
+in
+{
+  flake.tests.perf-depth = {
+
+    test-deep-10 = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.aspects.deep = mkChain 10;
+        expr = builtins.length (funnyNames den.aspects.deep);
+        expected = 11;
+      }
+    );
+
+    test-deep-50 = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.aspects.deep = mkChain 50;
+        expr = builtins.length (funnyNames den.aspects.deep);
+        expected = 51;
+      }
+    );
+
+    test-wide-50 = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.aspects.wide = mkWide 50;
+        expr = builtins.length (funnyNames den.aspects.wide);
+        expected = 51;
+      }
+    );
+
+    test-wide-100 = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.aspects.wide = mkWide 100;
+        expr = builtins.length (funnyNames den.aspects.wide);
+        expected = 101;
+      }
+    );
+
+    test-deep-wide-10x10 = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.aspects.dw = mkDeepWide 10 10;
+        expr = builtins.length (funnyNames den.aspects.dw);
+        expected = 21;
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/test-support/eval-den.nix
+++ b/templates/ci/modules/test-support/eval-den.nix
@@ -51,7 +51,8 @@ let
       funnyNames =
         aspect:
         let
-          mod = aspect.resolve { class = "funny"; };
+          resolve = config.den.lib.aspects.resolve;
+          mod = resolve "funny" [ ] aspect;
           namesMod = {
             options.names = lib.mkOption {
               type = lib.types.listOf lib.types.str;

--- a/templates/default/flake.lock
+++ b/templates/default/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773126960,
-        "narHash": "sha256-+UUijboPjAjGDgCpR8h5ji6/K4ashlpcNZPfI/UK1hc=",
+        "lastModified": 1773131302,
+        "narHash": "sha256-74bgLrcTvbL2A6NabH8wbU9OLmOCieF4oW4RscP0kBA=",
         "owner": "vic",
         "repo": "den",
-        "rev": "49ce965b8501208986b6d1382f913fbd0881a043",
+        "rev": "69682fffa09d57fb8a8dbf367252dbedca023207",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-aspects": {
       "locked": {
-        "lastModified": 1772999207,
-        "narHash": "sha256-dzZpKU1wS/9oMsgK9dqCD+wblBMj1EAhInQtvY2dLUI=",
+        "lastModified": 1773185256,
+        "narHash": "sha256-e3YqMwdQ2EpVTuWRkK2rkrHywp8QCpkj7x2U53SNoIA=",
         "owner": "vic",
         "repo": "flake-aspects",
-        "rev": "778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6",
+        "rev": "81a51a8997abe392b9d0794424a4823adc9bd3af",
         "type": "github"
       },
       "original": {

--- a/templates/example/flake.lock
+++ b/templates/example/flake.lock
@@ -22,11 +22,11 @@
     },
     "den": {
       "locked": {
-        "lastModified": 1773126960,
-        "narHash": "sha256-+UUijboPjAjGDgCpR8h5ji6/K4ashlpcNZPfI/UK1hc=",
+        "lastModified": 1773131302,
+        "narHash": "sha256-74bgLrcTvbL2A6NabH8wbU9OLmOCieF4oW4RscP0kBA=",
         "owner": "vic",
         "repo": "den",
-        "rev": "49ce965b8501208986b6d1382f913fbd0881a043",
+        "rev": "69682fffa09d57fb8a8dbf367252dbedca023207",
         "type": "github"
       },
       "original": {
@@ -37,11 +37,11 @@
     },
     "flake-aspects": {
       "locked": {
-        "lastModified": 1772999207,
-        "narHash": "sha256-dzZpKU1wS/9oMsgK9dqCD+wblBMj1EAhInQtvY2dLUI=",
+        "lastModified": 1773185256,
+        "narHash": "sha256-e3YqMwdQ2EpVTuWRkK2rkrHywp8QCpkj7x2U53SNoIA=",
         "owner": "vic",
         "repo": "flake-aspects",
-        "rev": "778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6",
+        "rev": "81a51a8997abe392b9d0794424a4823adc9bd3af",
         "type": "github"
       },
       "original": {

--- a/templates/microvm/flake.lock
+++ b/templates/microvm/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773126960,
-        "narHash": "sha256-+UUijboPjAjGDgCpR8h5ji6/K4ashlpcNZPfI/UK1hc=",
+        "lastModified": 1773131302,
+        "narHash": "sha256-74bgLrcTvbL2A6NabH8wbU9OLmOCieF4oW4RscP0kBA=",
         "owner": "vic",
         "repo": "den",
-        "rev": "49ce965b8501208986b6d1382f913fbd0881a043",
+        "rev": "69682fffa09d57fb8a8dbf367252dbedca023207",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-aspects": {
       "locked": {
-        "lastModified": 1772999207,
-        "narHash": "sha256-dzZpKU1wS/9oMsgK9dqCD+wblBMj1EAhInQtvY2dLUI=",
+        "lastModified": 1773185256,
+        "narHash": "sha256-e3YqMwdQ2EpVTuWRkK2rkrHywp8QCpkj7x2U53SNoIA=",
         "owner": "vic",
         "repo": "flake-aspects",
-        "rev": "778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6",
+        "rev": "81a51a8997abe392b9d0794424a4823adc9bd3af",
         "type": "github"
       },
       "original": {

--- a/templates/minimal/flake.lock
+++ b/templates/minimal/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773126960,
-        "narHash": "sha256-+UUijboPjAjGDgCpR8h5ji6/K4ashlpcNZPfI/UK1hc=",
+        "lastModified": 1773131302,
+        "narHash": "sha256-74bgLrcTvbL2A6NabH8wbU9OLmOCieF4oW4RscP0kBA=",
         "owner": "vic",
         "repo": "den",
-        "rev": "49ce965b8501208986b6d1382f913fbd0881a043",
+        "rev": "69682fffa09d57fb8a8dbf367252dbedca023207",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-aspects": {
       "locked": {
-        "lastModified": 1772999207,
-        "narHash": "sha256-dzZpKU1wS/9oMsgK9dqCD+wblBMj1EAhInQtvY2dLUI=",
+        "lastModified": 1773185256,
+        "narHash": "sha256-e3YqMwdQ2EpVTuWRkK2rkrHywp8QCpkj7x2U53SNoIA=",
         "owner": "vic",
         "repo": "flake-aspects",
-        "rev": "778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6",
+        "rev": "81a51a8997abe392b9d0794424a4823adc9bd3af",
         "type": "github"
       },
       "original": {

--- a/templates/noflake/npins/sources.json
+++ b/templates/noflake/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "49ce965b8501208986b6d1382f913fbd0881a043",
-      "url": "https://github.com/vic/den/archive/49ce965b8501208986b6d1382f913fbd0881a043.tar.gz",
-      "hash": "sha256-+UUijboPjAjGDgCpR8h5ji6/K4ashlpcNZPfI/UK1hc="
+      "revision": "69682fffa09d57fb8a8dbf367252dbedca023207",
+      "url": "https://github.com/vic/den/archive/69682fffa09d57fb8a8dbf367252dbedca023207.tar.gz",
+      "hash": "sha256-74bgLrcTvbL2A6NabH8wbU9OLmOCieF4oW4RscP0kBA="
     },
     "flake-aspects": {
       "type": "Git",
@@ -22,9 +22,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6",
-      "url": "https://github.com/vic/flake-aspects/archive/778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6.tar.gz",
-      "hash": "sha256-dzZpKU1wS/9oMsgK9dqCD+wblBMj1EAhInQtvY2dLUI="
+      "revision": "81a51a8997abe392b9d0794424a4823adc9bd3af",
+      "url": "https://github.com/vic/flake-aspects/archive/81a51a8997abe392b9d0794424a4823adc9bd3af.tar.gz",
+      "hash": "sha256-e3YqMwdQ2EpVTuWRkK2rkrHywp8QCpkj7x2U53SNoIA="
     },
     "import-tree": {
       "type": "Git",


### PR DESCRIPTION
cc @Steven-S1020 from https://github.com/vic/den/discussions/249

See also https://github.com/vic/flake-aspects/pull/40


perf is: `den@dd8fac7355be4cfe7a143bce45cbba3d786d8be1` with  `flake-aspects@81a51a8997abe392b9d0794424a4823adc9bd3af`


main was: `den@69682fffa09d57fb8a8dbf367252dbedca023207` with `flake-aspects@778d8d7c1352c3b173cdcb9fd0f65acbaf4744a6`


And this benchmark is not that accurate because perf had [additional tests](https://github.com/vic/den/tree/main/templates/ci/modules/features/perf) than old main .


```shell
hyperfine -m 20 -w 10  -n perf "cd perf && just ci" -n main "cd main && just ci"
Benchmark 1: perf
  Time (mean ± σ):     25.840 s ±  0.931 s    [User: 24.157 s, System: 0.670 s]
  Range (min … max):   24.236 s … 27.626 s    20 runs

Benchmark 2: main
  Time (mean ± σ):     39.205 s ±  2.053 s    [User: 37.377 s, System: 0.711 s]
  Range (min … max):   36.156 s … 43.566 s    20 runs

Summary
  perf ran
    1.52 ± 0.10 times faster than main
```