### PR TITLE
feat(ctx): Allow transformations into nested contexts

### DIFF
--- a/nix/ctx-apply.nix
+++ b/nix/ctx-apply.nix
@@ -16,32 +16,64 @@ let
 
   cleanCtx = self: builtins.removeAttrs self ctxKeys;
 
+  # Flatten nested into result to [ { path = [str]; into = [ctx_value]; } ].
+  # Leaf nodes are lists; intermediate nodes recurse deeper.
+  flattenInto =
+    attrset: prefix:
+    lib.concatLists (
+      lib.mapAttrsToList (
+        name: v:
+        let
+          path = prefix ++ [ name ];
+        in
+        if builtins.isList v then
+          [
+            {
+              inherit path;
+              into = v;
+            }
+          ]
+        else
+          flattenInto v path
+      ) attrset
+    );
+
   transformAll =
-    source: self: ctx:
+    source: self: ctx: key:
     [
       {
-        inherit ctx source;
+        inherit ctx source key;
         ctxDef = self;
       }
     ]
     ++ lib.concatLists (
-      lib.mapAttrsToList (
-        name: into:
-        if den.ctx ? ${name} then
-          lib.concatMap (transformAll self den.ctx.${name}) into
-        else if self.provides ? ${name} then
-          lib.concatMap (transformAll self {
-            inherit name;
-            into = _: { };
-          }) into
+      map (
+        { path, into }:
+        let
+          target = lib.attrByPath path null den.ctx;
+          tkey = lib.concatStringsSep "." path;
+        in
+        if target != null then
+          lib.concatMap (v: transformAll self target v tkey) into
+        else if builtins.length path == 1 && self.provides ? ${lib.head path} then
+          let
+            name = lib.head path;
+          in
+          lib.concatMap (
+            v:
+            transformAll self {
+              inherit name;
+              into = _: { };
+            } v name
+          ) into
         else
           [ ]
-      ) (self.into ctx)
+      ) (flattenInto (self.into ctx) [ ])
     );
 
   noop = _: { };
 
-  crossProvider = p: if p.source == null then noop else p.source.provides.${p.ctxDef.name} or noop;
+  crossProvider = p: if p.source == null then noop else p.source.provides.${p.key} or noop;
 
   dedupIncludes =
     let
@@ -53,10 +85,10 @@ let
           let
             p = builtins.head remaining;
             rest = builtins.tail remaining;
-            name = p.ctxDef.name;
+            key = p.key;
             clean = cleanCtx p.ctxDef;
-            isFirst = !(acc.seen ? ${name});
-            selfFun = p.ctxDef.provides.${name} or noop;
+            isFirst = !(acc.seen ? ${key});
+            selfFun = p.ctxDef.provides.${p.ctxDef.name} or noop;
             crossFun = crossProvider p;
             items = [
               (if isFirst then parametric.fixedTo p.ctx clean else parametric.atLeast clean p.ctx)
@@ -66,7 +98,7 @@ let
           in
           go {
             seen = acc.seen // {
-              ${name} = true;
+              ${key} = true;
             };
             result = acc.result ++ items;
           } rest;
@@ -77,7 +109,7 @@ let
     };
 
   ctxApply = self: ctx: {
-    includes = dedupIncludes (transformAll null self ctx);
+    includes = dedupIncludes (transformAll null self ctx self.name);
   };
 
 in

--- a/nix/nixModule/ctx.nix
+++ b/nix/nixModule/ctx.nix
@@ -2,29 +2,34 @@
 let
   inherit (config) den;
   inherit (den.lib.aspects.types) aspectSubmodule;
-  inherit (den.lib) ctxApply;
+  inherit (den.lib) ctxApply take;
 
   intoType =
     let
-      # into = { x = {ctx}: []; y = {ctx}: []}; }
-      intoAttrsType = lib.types.lazyAttrsOf (lib.types.functionTo (lib.types.listOf lib.types.raw));
+      # into = { x = ctx→[]; y = ctx→[]; }
+      # Also supports nested namespace keys: into."foo.bar" = fn
+      intoAttrsType = lib.types.lazyAttrsOf lib.types.raw;
 
-      # into = {ctx}: { x = []; y = []; }
+      # into = ctx → { x = []; y = []; }
       intoFnType = lib.types.functionTo (lib.types.lazyAttrsOf lib.types.raw);
     in
     lib.types.either intoFnType intoAttrsType;
 
-  normalizeInto =
-    value:
-    if lib.isFunction value then
-      value
+  # Recrusively apply ctx to leaf functions in a (possibly nested) attrset.
+  applyIntoNode =
+    ctx: v:
+    if lib.isFunction v then
+      (take.atLeast v) ctx
+    else if builtins.isAttrs v then
+      lib.mapAttrs (_: applyIntoNode ctx) v
     else
-      ctx: lib.mapAttrs (n: v: (den.lib.take.atLeast v) ctx) value;
+      v;
 
-  # a context-definiton is an aspect extended with into.* transformations
-  # and a fixed functor to apply them.
+  normalizeInto =
+    value: if lib.isFunction value then value else ctx: lib.mapAttrs (_: applyIntoNode ctx) value;
+
   ctxSubmodule = lib.types.submodule (
-    { config, ... }:
+    { ... }:
     {
       imports = aspectSubmodule.getSubModules;
       options.into = lib.mkOption {
@@ -37,10 +42,29 @@ let
     }
   );
 
+  # A ctx tree node: either a leaf ctx definition (has `into`/`__functor`)
+  # or a namespace container holding more nodes. Detected at merge time,
+  # so the self-reference in the namespace branch is lazily evaluated.
+  ctxTreeType = lib.types.mkOptionType {
+    name = "ctxTree";
+    description = "ctx definition or namespace";
+    check = lib.isAttrs;
+    merge =
+      loc: defs:
+      let
+        hasKey = x: x ? into || x ? provides || x ? _ || x ? includes || x ? __functor || x ? _module;
+        isLeaf = lib.any (d: hasKey d.value) defs;
+      in
+      if isLeaf then ctxSubmodule.merge loc defs else (lib.types.lazyAttrsOf ctxTreeType).merge loc defs;
+    emptyValue = {
+      value = { };
+    };
+  };
+
 in
 {
   options.den.ctx = lib.mkOption {
     default = { };
-    type = lib.types.lazyAttrsOf ctxSubmodule;
+    type = lib.types.lazyAttrsOf ctxTreeType;
   };
 }

--- a/templates/ci/modules/features/context/nested-ctx-providers.nix
+++ b/templates/ci/modules/features/context/nested-ctx-providers.nix
@@ -1,0 +1,88 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.ctx-nested-providers = {
+
+    # Cross-providers for nested ctx should use the FULL PATH, not local name.
+    # root.provides.ns.inner targets ctx at den.ctx.ns.inner specifically.
+    test-nested-cross-provider = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.ns.inner._.inner =
+          { z }:
+          {
+            funny.names = [ "inner-${z}" ];
+          };
+
+        den.ctx.root.into =
+          { z }:
+          {
+            ns.inner = [ { inherit z; } ];
+          };
+
+        den.ctx.root.provides.${"ns.inner"} =
+          { z }:
+          {
+            funny.names = [ "root-for-inner-${z}" ];
+          };
+
+        expr = funnyNames (den.ctx.root { z = "x"; });
+        expected = [
+          "inner-x"
+          "root-for-inner-x"
+        ];
+      }
+    );
+
+    # Two nested contexts with the same local name must get independent cross-providers.
+    test-no-cross-provider-collision = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.a.leaf._.leaf =
+          { v }:
+          {
+            funny.names = [ "a-${v}" ];
+          };
+        den.ctx.b.leaf._.leaf =
+          { v }:
+          {
+            funny.names = [ "b-${v}" ];
+          };
+
+        den.ctx.root.into = _: {
+          a.leaf = [ { v = "x"; } ];
+          b.leaf = [ { v = "y"; } ];
+        };
+
+        den.ctx.root.provides.${"a.leaf"} =
+          { v }:
+          {
+            funny.names = [ "cross-a-${v}" ];
+          };
+
+        expr = funnyNames (den.ctx.root { });
+        expected = [
+          "a-x"
+          "b-y"
+          "cross-a-x"
+        ];
+      }
+    );
+
+    # Attrset-form into with nested keys: into.ns.inner = fn
+    test-nested-attrset-into = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.ns.inner._.inner =
+          { z }:
+          {
+            funny.names = [ "inner-${z}" ];
+          };
+
+        den.ctx.root.into.ns.inner = lib.singleton;
+
+        expr = funnyNames (den.ctx.root { z = "q"; });
+        expected = [ "inner-q" ];
+      }
+    );
+  };
+}

--- a/templates/ci/modules/features/context/nested-ctx.nix
+++ b/templates/ci/modules/features/context/nested-ctx.nix
@@ -1,0 +1,125 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.ctx-nested = {
+
+    test-two-level-nesting = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.ns.inner._.inner =
+          { z }:
+          {
+            funny.names = [ "inner-${z}" ];
+          };
+
+        den.ctx.root._.root =
+          { v }:
+          {
+            funny.names = [ v ];
+          };
+        den.ctx.root.into =
+          { v }:
+          {
+            ns.inner = [ { z = v; } ];
+          };
+
+        expr = funnyNames (den.ctx.root { v = "hello"; });
+        expected = [
+          "hello"
+          "inner-hello"
+        ];
+      }
+    );
+
+    test-three-level-nesting = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.a.b.c._.c =
+          { z }:
+          {
+            funny.names = [ "abc-${z}" ];
+          };
+
+        den.ctx.start.into =
+          { z }:
+          {
+            a.b.c = [ { z = z; } ];
+          };
+
+        expr = funnyNames (den.ctx.start { z = "deep"; });
+        expected = [ "abc-deep" ];
+      }
+    );
+
+    test-dedup-by-full-path = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.a.leaf._.leaf =
+          { v }:
+          {
+            funny.names = [ "a-${v}" ];
+          };
+        den.ctx.b.leaf._.leaf =
+          { v }:
+          {
+            funny.names = [ "b-${v}" ];
+          };
+
+        den.ctx.root.into = _: {
+          a.leaf = [ { v = "x"; } ];
+          b.leaf = [ { v = "y"; } ];
+        };
+
+        expr = funnyNames (den.ctx.root { });
+        expected = [
+          "a-x"
+          "b-y"
+        ];
+      }
+    );
+
+    test-flat-still-works = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.flat._.flat =
+          { x }:
+          {
+            funny.names = [ x ];
+          };
+
+        den.ctx.root.into.flat = lib.singleton;
+
+        expr = funnyNames (den.ctx.root { x = "hi"; });
+        expected = [ "hi" ];
+      }
+    );
+
+    test-into-mixed-flat-and-nested = denTest (
+      { den, funnyNames, ... }:
+      {
+        den.ctx.ns.deep._.deep =
+          { k }:
+          {
+            funny.names = [ "deep-${k}" ];
+          };
+        den.ctx.flat._.flat =
+          { k }:
+          {
+            funny.names = [ "flat-${k}" ];
+          };
+
+        den.ctx.root.into =
+          { k }:
+          {
+            flat = [ { inherit k; } ];
+            ns.deep = [ { inherit k; } ];
+          };
+
+        expr = funnyNames (den.ctx.root { k = "v"; });
+        expected = [
+          "deep-v"
+          "flat-v"
+        ];
+      }
+    );
+  };
+}


### PR DESCRIPTION
In preparation for denful nested contexts.


Previously, in `den.ctx`:

We had simple one-flat level transformations:

```nix
den.ctx.foo.into.bar = fooDataTransformIntoBar;

den.ctx.bar._.bar = aspectResponsibleToConfigureBar;

den.ctx.foo._.bar = aspectContributionFromFoo;
```

Denful has nested aspect scopes, since `den.ctx` are an specialized kind of aspect, it
now supports nested context transformations (in adition to flat one we currently use in hm/hjem/maid)

```nix
den.ctx.foo.into = fooCtx: { x.y.z = fooDataTramsformIntoZ fooCtx; };

den.ctx.x.y.z._.z = aspectConfiguringZ;

den.ctx.foo._."x.y.z" = aspectContributionFromFoo;
```