### PR TITLE
Update home-manager command to specify master branch

### DIFF
--- a/docs/src/content/docs/guides/from-zero-to-den.mdx
+++ b/docs/src/content/docs/guides/from-zero-to-den.mdx
@@ -60,7 +60,7 @@ npins add github vic import-tree    # for auto-importing ./modules
 npins add github vic flake-aspects  # aspects used by Den
 npins add github vic den            # Den itself, of course
 npins add github vic with-inputs    # flake-like inputs without Nix flakes.
-npins add github nix-community home-manager # OPTIONAL home integration
+npins add github nix-community home-manager --branch master # OPTIONAL home integration
 ```
 
 ### Step 3. Your Den Entry Point


### PR DESCRIPTION
FIX : https://github.com/vic/den/issues/263
home-manager does not have any release tags