### PR TITLE
fix(docs): Fix tutorial steps on failure

### DIFF
--- a/docs/src/content/docs/guides/from-zero-to-den.mdx
+++ b/docs/src/content/docs/guides/from-zero-to-den.mdx
@@ -76,7 +76,7 @@ let
     (inputs.nixpkgs.lib.evalModules { # (3)
       modules = [ (inputs.import-tree ./modules) ]; # (4)
       specialArgs.inputs = inputs; # (5)
-    }).config; # (6)
+    }).config.flake; # (6)
 in
 with-inputs outputs # (7)
 ```


### PR DESCRIPTION
Hello, 

Issues encountered when doing the tutorial and solution I found to fix it 

https://den.oeiuwq.com/guides/from-zero-to-den/

Each modification is related to a different error message encountered during the tutorial.
sources for fix : 
- this repo
- https://github.com/vic/import-tree#dendritic-nix-non-flakes-stable-nix

Last command is building the config without error.

```console
[ulfbayte@cyrix:~/bugreport]$ nixos-rebuild build --file . -A nixosConfigurations.igloo
building the system configuration...
these 48 derivations will be built:
  /nix/store/xbj7qzz95p0waqsk14rg91lfswcwxwdh-options.json.drv
  /nix/store/37gg7n4asxhzsd436jycinvfihj9kghl-home-configuration-reference-manpage.drv
  /nix/store/1n6xzjvvjprrmxmj0lv4jkjsqskyxy7a-home-manager-path.drv
  /nix/store/1pqsh2rsv71pvv1y6izai6dmpc5b125v-activation-script.drv
  /nix/store/8yaq32m6d4ivh2w8l54v0l6v7hcqlcsh-nixos-manual-html.drv
  /nix/store/25src3midvb5xg8miblb3qqa7zxh3vsa-nixos-help.drv
  /nix/store/g9ld1g7lzn2hi388l8yx16lw48337kqq-firefox-148.0.2.drv
  /nix/store/iw6l9g8x996sb9k9arrsyzi7znylkcb1-nixos-help.drv
  /nix/store/cf9zqna6s281p31dl29l3b37w23kl3nw-system-path.drv
  /nix/store/wm6cidi0m12gmllkgxxx2vsykglpkaf5-set-environment.drv
  /nix/store/3xnl6w81ghq16b83k49kcpslwrwy6f53-etc-profile.drv
  /nix/store/4mhz6rj8lc2wqkfrpldzcs525h9c3qnn-dbus-1.drv
  /nix/store/ghy5k3h7ppqd9bp8z650jsmhas1n623g-firmware.drv
  /nix/store/4r0hvcsjiaz7wxwf14zzqk9w2kjqmc00-etc-modprobe.d-firmware.conf.drv
  /nix/store/bfn4wadrsmjid51nk8psyf6wgqm29w34-etc-pam-environment.drv
  /nix/store/39jj15r74mw0qm29a8n0sbpcrpyb494r-X-Restart-Triggers-dbus.drv
  /nix/store/527mn05vqx547wh95q7lk52al8fd1ahd-unit-dbus.service.drv
  /nix/store/cjakj7rs129a6zl0qk3v5vcx2829j3my-user-units.drv
  /nix/store/pvqdv447x9803dgjcpacsng76qi4vhl1-etc-hostname.drv
  /nix/store/qry99ky4p79fsnfd6pl2f10w22xpg5xq-etc-nix-registry.json.drv
  /nix/store/hmkylq2wisrqzkay1g114d9bn3ldhh21-X-Restart-Triggers-polkit.drv
  /nix/store/5b1dic45z0rvygb84vxcdfisihz61zbx-unit-polkit.service.drv
  /nix/store/a4srg1bfvyr6i4vvwyigky3naiqbbzgm-hm_hometux.cache.keep.drv
  /nix/store/bjy7y3k42c0s7bnkxq3akw6m29d3kb3m-hm_hometux.localstate.keep.drv
  /nix/store/49ibx8xsj6c83l2ps9lvjvr4wi3n0zrj-home-manager-files.drv
  /nix/store/ndzg3wczqzd81ignxlmb6rarnzg98j02-home-manager-generation.drv
  /nix/store/9a95g5a0vq7zgpi7yrq0i50sgpawaksa-unit-home-manager-tux.service.drv
  /nix/store/fqv6mypkklkcn5pdav5hdfms440ahf59-avahi-daemon.conf.drv
  /nix/store/dv7kgpxgni4mybys5s38m2k1r44m4xfk-unit-avahi-daemon.service.drv
  /nix/store/fhv9dfwdsi1msc3y0vm0v77xfp8jypiq-unit-dbus.service.drv
  /nix/store/gmgsk2a12zhim9dszdhgqws3pflk3b45-unit-accounts-daemon.service.drv
  /nix/store/qziy886mckvi4cickbh6f9g0ppzh8agv-system-units.drv
  /nix/store/ldgjmivcylplx1zp1jbpgb0czda1x48g-string-hosts.drv
  /nix/store/m4q68vzrfcv9gcyxd03byhlaaschccw3-extra-hosts.drv
  /nix/store/zlcl91cb4cmy2hz8h5svhbz4vcxynad3-localhost-hosts.drv
  /nix/store/y7q9gw6b4wqsl4bmz0w1l1rfwvwbzaid-hosts.drv
  /nix/store/2p7mz2rmknks8fznzk9yhn6gn538jfa5-etc.drv
  /nix/store/wbzsa038qfg8azrlwhhdassg8a2cyxs0-users-groups.json.drv
  /nix/store/43rq24n1dw3jrhfa39s4whqja4gxwm4f-dry-activate.drv
  /nix/store/bgqcilk08f63imrm2wl9736rrn44c98a-initrd-fsinfo.drv
  /nix/store/npcbxm6g5ipix0f0sq7jrd6hgvs2j1bm-stage-1-init.sh.drv
  /nix/store/skl5k2m3zxxqnlfsdi3n1gw0vsciv7c6-nuke-refs.drv
  /nix/store/vwcz8p5ccm4ay80b00fh7m57n4npw6pw-linux-6.18.16-modules-shrunk.drv
  /nix/store/rb50a5yfj8idsphh29nwqhv6bkh1mq1r-closure-info.drv
  /nix/store/r7zjph3z4rxggkb56qxbbgjkc37b5nc3-initrd-linux-6.18.16.drv
  /nix/store/8ggml26v3fmpk1i2lhrifkiwnpn8694a-boot.json.drv
  /nix/store/igmprqwqchn1qryn1kscd8i351260j2n-activate.drv
  /nix/store/m12jiqvy7kx550xaklvccgv9a4769j6g-nixos-system-igloo-26.05.19700101.dirty.drv
these 10 paths will be fetched (823.87 MiB download, 1131.55 MiB unpacked):
  /nix/store/5wqlx4f9psbgkg0l1plhy570qr7y23ib-amd-ucode-20260309
  /nix/store/2i5nh3zqwm8h03ldllzp27wk0pm63fck-extra-utils
  /nix/store/vdka5wg830sq255gd3rsz3ywd0qv9rk2-firefox-unwrapped-148.0.2
  /nix/store/ka0xf4sy814d0hfn8pcbdfcm8rf0fkhb-keymap
  /nix/store/aq04rlxcjkzswq1mvja3rfvk290srmsi-kmod-31-dev
  /nix/store/b1lvyxik0hbrgxwvaa31wjvvahk4p8m0-link-units
  /nix/store/5y426a9fb2mrczk1ycj81xvhr1n1dm4n-linux-firmware-20260309-zstd
  /nix/store/s032nigpxiry7k929rn9pnqipkrwj9gi-nixos-configuration-reference-manpage
  /nix/store/hhr6ymkjz43qxhzfmc7jf6p9q383b4c2-options.json
  /nix/store/c6m9mxr6kdwf7i9vn4yqzyf86hm1kxxn-udev-rules
copying path '/nix/store/5y426a9fb2mrczk1ycj81xvhr1n1dm4n-linux-firmware-20260309-zstd' from 'https://cache.nixos.org'...
copying path '/nix/store/s032nigpxiry7k929rn9pnqipkrwj9gi-nixos-configuration-reference-manpage' from 'https://cache.nixos.org'...
copying path '/nix/store/5wqlx4f9psbgkg0l1plhy570qr7y23ib-amd-ucode-20260309' from 'https://cache.nixos.org'...
building '/nix/store/pvqdv447x9803dgjcpacsng76qi4vhl1-etc-hostname.drv'...
building '/nix/store/qry99ky4p79fsnfd6pl2f10w22xpg5xq-etc-nix-registry.json.drv'...
building '/nix/store/wbzsa038qfg8azrlwhhdassg8a2cyxs0-users-groups.json.drv'...
copying path '/nix/store/2i5nh3zqwm8h03ldllzp27wk0pm63fck-extra-utils' from 'https://cache.nixos.org'...
copying path '/nix/store/ka0xf4sy814d0hfn8pcbdfcm8rf0fkhb-keymap' from 'https://cache.nixos.org'...
copying path '/nix/store/b1lvyxik0hbrgxwvaa31wjvvahk4p8m0-link-units' from 'https://cache.nixos.org'...
copying path '/nix/store/hhr6ymkjz43qxhzfmc7jf6p9q383b4c2-options.json' from 'https://cache.nixos.org'...
copying path '/nix/store/vdka5wg830sq255gd3rsz3ywd0qv9rk2-firefox-unwrapped-148.0.2' from 'https://cache.nixos.org'...
building '/nix/store/fqv6mypkklkcn5pdav5hdfms440ahf59-avahi-daemon.conf.drv'...
building '/nix/store/m4q68vzrfcv9gcyxd03byhlaaschccw3-extra-hosts.drv'...
building '/nix/store/bgqcilk08f63imrm2wl9736rrn44c98a-initrd-fsinfo.drv'...
building '/nix/store/zlcl91cb4cmy2hz8h5svhbz4vcxynad3-localhost-hosts.drv'...
building '/nix/store/ldgjmivcylplx1zp1jbpgb0czda1x48g-string-hosts.drv'...
copying path '/nix/store/aq04rlxcjkzswq1mvja3rfvk290srmsi-kmod-31-dev' from 'https://cache.nixos.org'...
building '/nix/store/skl5k2m3zxxqnlfsdi3n1gw0vsciv7c6-nuke-refs.drv'...
building '/nix/store/a4srg1bfvyr6i4vvwyigky3naiqbbzgm-hm_hometux.cache.keep.drv'...
building '/nix/store/bjy7y3k42c0s7bnkxq3akw6m29d3kb3m-hm_hometux.localstate.keep.drv'...
building '/nix/store/xbj7qzz95p0waqsk14rg91lfswcwxwdh-options.json.drv'...
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
Running phase: checkPhase
Running phase: installPhase
no Makefile or custom installPhase, doing nothing
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/2rjp8cr896rspqpm23pvp9x5c2jzzns5-nuke-refs
checking for references to /build/ in /nix/store/2rjp8cr896rspqpm23pvp9x5c2jzzns5-nuke-refs...
patching script interpreter paths in /nix/store/2rjp8cr896rspqpm23pvp9x5c2jzzns5-nuke-refs
building '/nix/store/43rq24n1dw3jrhfa39s4whqja4gxwm4f-dry-activate.drv'...
building '/nix/store/49ibx8xsj6c83l2ps9lvjvr4wi3n0zrj-home-manager-files.drv'...
building '/nix/store/y7q9gw6b4wqsl4bmz0w1l1rfwvwbzaid-hosts.drv'...
building '/nix/store/dv7kgpxgni4mybys5s38m2k1r44m4xfk-unit-avahi-daemon.service.drv'...
copying path '/nix/store/c6m9mxr6kdwf7i9vn4yqzyf86hm1kxxn-udev-rules' from 'https://cache.nixos.org'...
building '/nix/store/8yaq32m6d4ivh2w8l54v0l6v7hcqlcsh-nixos-manual-html.drv'...
building '/nix/store/37gg7n4asxhzsd436jycinvfihj9kghl-home-configuration-reference-manpage.drv'...
building '/nix/store/npcbxm6g5ipix0f0sq7jrd6hgvs2j1bm-stage-1-init.sh.drv'...
Running phase: patchPhase
Running phase: updateAutotoolsGnuConfigScriptsPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
Running phase: checkPhase
Running phase: installPhase
no Makefile or custom installPhase, doing nothing
checking syntax
Running phase: fixupPhase
shrinking RPATHs of ELF executables and libraries in /nix/store/2hzhargizdpakbnj0j08ffv57wkz415j-stage-1-init.sh
checking for references to /build/ in /nix/store/2hzhargizdpakbnj0j08ffv57wkz415j-stage-1-init.sh...
patching script interpreter paths in /nix/store/2hzhargizdpakbnj0j08ffv57wkz415j-stage-1-init.sh
building '/nix/store/1n6xzjvvjprrmxmj0lv4jkjsqskyxy7a-home-manager-path.drv'...
created 314 symlinks in user environment
building '/nix/store/1pqsh2rsv71pvv1y6izai6dmpc5b125v-activation-script.drv'...
building '/nix/store/ndzg3wczqzd81ignxlmb6rarnzg98j02-home-manager-generation.drv'...
building '/nix/store/9a95g5a0vq7zgpi7yrq0i50sgpawaksa-unit-home-manager-tux.service.drv'...
building '/nix/store/25src3midvb5xg8miblb3qqa7zxh3vsa-nixos-help.drv'...
building '/nix/store/iw6l9g8x996sb9k9arrsyzi7znylkcb1-nixos-help.drv'...
building '/nix/store/g9ld1g7lzn2hi388l8yx16lw48337kqq-firefox-148.0.2.drv'...
structuredAttrs is enabled
building '/nix/store/cf9zqna6s281p31dl29l3b37w23kl3nw-system-path.drv'...
created 17354 symlinks in user environment
gtk-update-icon-cache: Cache file created successfully.
gtk-update-icon-cache: Cache file created successfully.
building '/nix/store/hmkylq2wisrqzkay1g114d9bn3ldhh21-X-Restart-Triggers-polkit.drv'...
building '/nix/store/4mhz6rj8lc2wqkfrpldzcs525h9c3qnn-dbus-1.drv'...
building '/nix/store/bfn4wadrsmjid51nk8psyf6wgqm29w34-etc-pam-environment.drv'...
building '/nix/store/wm6cidi0m12gmllkgxxx2vsykglpkaf5-set-environment.drv'...
building '/nix/store/gmgsk2a12zhim9dszdhgqws3pflk3b45-unit-accounts-daemon.service.drv'...
building '/nix/store/39jj15r74mw0qm29a8n0sbpcrpyb494r-X-Restart-Triggers-dbus.drv'...
building '/nix/store/3xnl6w81ghq16b83k49kcpslwrwy6f53-etc-profile.drv'...
building '/nix/store/5b1dic45z0rvygb84vxcdfisihz61zbx-unit-polkit.service.drv'...
building '/nix/store/527mn05vqx547wh95q7lk52al8fd1ahd-unit-dbus.service.drv'...
building '/nix/store/fhv9dfwdsi1msc3y0vm0v77xfp8jypiq-unit-dbus.service.drv'...
building '/nix/store/cjakj7rs129a6zl0qk3v5vcx2829j3my-user-units.drv'...
building '/nix/store/qziy886mckvi4cickbh6f9g0ppzh8agv-system-units.drv'...
building '/nix/store/ghy5k3h7ppqd9bp8z650jsmhas1n623g-firmware.drv'...
created 996 symlinks in user environment
building '/nix/store/4r0hvcsjiaz7wxwf14zzqk9w2kjqmc00-etc-modprobe.d-firmware.conf.drv'...
building '/nix/store/vwcz8p5ccm4ay80b00fh7m57n4npw6pw-linux-6.18.16-modules-shrunk.drv'...
building '/nix/store/2p7mz2rmknks8fznzk9yhn6gn538jfa5-etc.drv'...
kernel version is 6.18.16
root module: ahci
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libata.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libahci.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/ahci.ko.xz
root module: ata_piix
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libata.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/ata_piix.ko.xz
root module: atkbd
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/vivaldi-fmap.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/serio/serio.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/serio/libps2.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/keyboard/atkbd.ko.xz
root module: ehci_hcd
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ehci-hcd.ko.xz
root module: ehci_pci
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ehci-hcd.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ehci-pci.ko.xz
root module: ext2
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/fs/mbcache.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/fs/ext2/ext2.ko.xz
root module: ext4
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/fs/jbd2/jbd2.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/fs/mbcache.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/lib/crc/crc16.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/fs/ext4/ext4.ko.xz
root module: hid_apple
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/leds/led-class.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-apple.ko.xz
root module: hid_cherry
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-cherry.ko.xz
root module: hid_corsair
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/leds/led-class.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/usbhid/usbhid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-corsair.ko.xz
root module: hid_generic
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-generic.ko.xz
root module: hid_lenovo
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/leds/led-class.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-lenovo.ko.xz
root module: hid_logitech_dj
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/usbhid/usbhid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-logitech-dj.ko.xz
root module: hid_logitech_hidpp
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/usbhid/usbhid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-logitech-hidpp.ko.xz
root module: hid_microsoft
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/ff-memless.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-microsoft.ko.xz
root module: hid_roccat
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid-roccat.ko.xz
root module: i8042
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/serio/serio.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/serio/i8042.ko.xz
root module: mmc_block
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/mmc/core/mmc_core.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/misc/rpmb-core.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/mmc/core/mmc_block.ko.xz
root module: nvme
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/crypto/hkdf.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/nvme/common/nvme-auth.ko.xz
building '/nix/store/igmprqwqchn1qryn1kscd8i351260j2n-activate.drv'...
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/nvme/common/nvme-keyring.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/nvme/host/nvme-core.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/nvme/host/nvme.ko.xz
root module: ohci_hcd
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ohci-hcd.ko.xz
root module: ohci_pci
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ohci-hcd.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ehci-hcd.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ehci-pci.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ohci-pci.ko.xz
root module: pata_marvell
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libata.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/pata_marvell.ko.xz
root module: pcips2
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/serio/serio.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/input/serio/pcips2.ko.xz
root module: sata_nv
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libata.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/sata_nv.ko.xz
root module: sata_sis
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libata.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/pata_sis.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/sata_sis.ko.xz
root module: sata_uli
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libata.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/sata_uli.ko.xz
root module: sata_via
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/libata.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/ata/sata_via.ko.xz
root module: sd_mod
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/sd_mod.ko.xz
root module: sr_mod
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/cdrom/cdrom.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_common.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/scsi_mod.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/scsi/sr_mod.ko.xz
root module: uhci_hcd
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ehci-hcd.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/ehci-pci.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/uhci-hcd.ko.xz
root module: usbhid
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/hid.ko.xz
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/hid/usbhid/usbhid.ko.xz
root module: xhci_hcd
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/xhci-hcd.ko.xz
root module: xhci_pci
  dependency already copied: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/xhci-hcd.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/usb/host/xhci-pci.ko.xz
root module: dm_mod
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/dax/dax.ko.xz
  copying dependency: /nix/store/d15nnvviidmmlm8lvsfx9bclvkqsn6cn-linux-6.18.16-modules/lib/modules/6.18.16/kernel/drivers/md/dm-mod.ko.xz
lib/firmware/edid not found, skipping.
building '/nix/store/rb50a5yfj8idsphh29nwqhv6bkh1mq1r-closure-info.drv'...
structuredAttrs is enabled
building '/nix/store/r7zjph3z4rxggkb56qxbbgjkc37b5nc3-initrd-linux-6.18.16.drv'...
structuredAttrs is enabled
building '/nix/store/8ggml26v3fmpk1i2lhrifkiwnpn8694a-boot.json.drv'...
building '/nix/store/m12jiqvy7kx550xaklvccgv9a4769j6g-nixos-system-igloo-26.05.19700101.dirty.drv'...
Done. The new configuration is /nix/store/mygpqyy2498b42f9z2gw89khmhh81jpk-nixos-system-igloo-26.05.19700101.dirty
```