### PR TITLE
future: v0.13.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,26 +1,25 @@
 on:
+  workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, future]
     paths: ["**/*.nix"]
   pull_request:
     types: [labeled, opened, synchronize, reopened, review_requested, ready_for_review]
-    paths: ["**/*.nix"]
+    paths: ["**/*.nix", "**/*.lock"]
   pull_request_review:
     types: [submitted]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  non-draft:
+  future:
     runs-on: ubuntu-latest
-    if: ${{github.ref == 'refs/heads/main' || github.event.pull_request.draft == false}}
+    name: "Check PR base is future branch"
     steps:
-      - uses: actions/checkout@v6
       - run: |
-          git fetch --depth 1 origin refs/heads/main
-          test "refs/heads/main" == "${{github.ref}}" || (git diff --name-only origin/main..${{ github.sha }} -- | grep '.nix')
+          [[ "refs/heads/main" == "${{github.ref}}" || "refs/heads/future" == "${{github.ref}}" || "future" == "${{github.base_ref}}" ]]
   tests:
-    needs: [non-draft]
+    needs: [future]
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -46,14 +45,14 @@ jobs:
       - run: nix flake metadata
       - run: nix flake check -L
   flake-check:
-    needs: [non-draft]
+    needs: [future]
     name: nix flake check
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@v31
       - run: nix flake check -L github:vic/checkmate --override-input target github:$GITHUB_REPOSITORY/$GITHUB_SHA
   approved:
-    needs: [non-draft]
+    needs: [future]
     name: approved
     runs-on: ubuntu-latest
     if: ${{github.ref == 'refs/heads/main' || contains( github.event.pull_request.labels.*.name, 'approved')}}

--- a/templates/bogus/flake.lock
+++ b/templates/bogus/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773434013,
-        "narHash": "sha256-PrpDQ9hQr4DxgpRmapH6k49+hkp/RKbn8Dlw1fbxw5Q=",
+        "lastModified": 1773446380,
+        "narHash": "sha256-Bm+V/HP3OGdmG+NnsgQTi5SEpmouJBVaZESUjBBFEc0=",
         "owner": "vic",
         "repo": "den",
-        "rev": "c5320826a9e4633cf90b7566c6446303e32180e8",
+        "rev": "ae6a59acba4e3729dc5055e12003b533aee12aae",
         "type": "github"
       },
       "original": {

--- a/templates/ci/flake.lock
+++ b/templates/ci/flake.lock
@@ -22,11 +22,11 @@
     },
     "den": {
       "locked": {
-        "lastModified": 1773434013,
-        "narHash": "sha256-PrpDQ9hQr4DxgpRmapH6k49+hkp/RKbn8Dlw1fbxw5Q=",
+        "lastModified": 1773446380,
+        "narHash": "sha256-Bm+V/HP3OGdmG+NnsgQTi5SEpmouJBVaZESUjBBFEc0=",
         "owner": "vic",
         "repo": "den",
-        "rev": "c5320826a9e4633cf90b7566c6446303e32180e8",
+        "rev": "ae6a59acba4e3729dc5055e12003b533aee12aae",
         "type": "github"
       },
       "original": {

--- a/templates/default/flake.lock
+++ b/templates/default/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773434013,
-        "narHash": "sha256-PrpDQ9hQr4DxgpRmapH6k49+hkp/RKbn8Dlw1fbxw5Q=",
+        "lastModified": 1773446380,
+        "narHash": "sha256-Bm+V/HP3OGdmG+NnsgQTi5SEpmouJBVaZESUjBBFEc0=",
         "owner": "vic",
         "repo": "den",
-        "rev": "c5320826a9e4633cf90b7566c6446303e32180e8",
+        "rev": "ae6a59acba4e3729dc5055e12003b533aee12aae",
         "type": "github"
       },
       "original": {

--- a/templates/example/flake.lock
+++ b/templates/example/flake.lock
@@ -22,11 +22,11 @@
     },
     "den": {
       "locked": {
-        "lastModified": 1773434013,
-        "narHash": "sha256-PrpDQ9hQr4DxgpRmapH6k49+hkp/RKbn8Dlw1fbxw5Q=",
+        "lastModified": 1773446380,
+        "narHash": "sha256-Bm+V/HP3OGdmG+NnsgQTi5SEpmouJBVaZESUjBBFEc0=",
         "owner": "vic",
         "repo": "den",
-        "rev": "c5320826a9e4633cf90b7566c6446303e32180e8",
+        "rev": "ae6a59acba4e3729dc5055e12003b533aee12aae",
         "type": "github"
       },
       "original": {

--- a/templates/microvm/flake.lock
+++ b/templates/microvm/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773434013,
-        "narHash": "sha256-PrpDQ9hQr4DxgpRmapH6k49+hkp/RKbn8Dlw1fbxw5Q=",
+        "lastModified": 1773446380,
+        "narHash": "sha256-Bm+V/HP3OGdmG+NnsgQTi5SEpmouJBVaZESUjBBFEc0=",
         "owner": "vic",
         "repo": "den",
-        "rev": "c5320826a9e4633cf90b7566c6446303e32180e8",
+        "rev": "ae6a59acba4e3729dc5055e12003b533aee12aae",
         "type": "github"
       },
       "original": {

--- a/templates/minimal/flake.lock
+++ b/templates/minimal/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1773434013,
-        "narHash": "sha256-PrpDQ9hQr4DxgpRmapH6k49+hkp/RKbn8Dlw1fbxw5Q=",
+        "lastModified": 1773446380,
+        "narHash": "sha256-Bm+V/HP3OGdmG+NnsgQTi5SEpmouJBVaZESUjBBFEc0=",
         "owner": "vic",
         "repo": "den",
-        "rev": "c5320826a9e4633cf90b7566c6446303e32180e8",
+        "rev": "ae6a59acba4e3729dc5055e12003b533aee12aae",
         "type": "github"
       },
       "original": {

--- a/templates/noflake/npins/sources.json
+++ b/templates/noflake/npins/sources.json
@@ -9,9 +9,9 @@
       },
       "branch": "main",
       "submodules": false,
-      "revision": "c5320826a9e4633cf90b7566c6446303e32180e8",
-      "url": "https://github.com/vic/den/archive/c5320826a9e4633cf90b7566c6446303e32180e8.tar.gz",
-      "hash": "sha256-PrpDQ9hQr4DxgpRmapH6k49+hkp/RKbn8Dlw1fbxw5Q="
+      "revision": "ae6a59acba4e3729dc5055e12003b533aee12aae",
+      "url": "https://github.com/vic/den/archive/ae6a59acba4e3729dc5055e12003b533aee12aae.tar.gz",
+      "hash": "sha256-Bm+V/HP3OGdmG+NnsgQTi5SEpmouJBVaZESUjBBFEc0="
     },
     "flake-aspects": {
       "type": "Git",


### PR DESCRIPTION
All PR are now always against `future` branch to keep `main` (default branch) stable for people to do `flake update` `npins update` safely.

This PR tracks all changes that will become v0.13.0