### PR TITLE
feat(lib): den.lib.perHost and den.lib.perUser

### DIFF
--- a/docs/src/content/docs/explanation/parametric.mdx
+++ b/docs/src/content/docs/explanation/parametric.mdx
@@ -20,7 +20,7 @@ A function's **required parameters** determine which contexts it matches:
 ({ host, ... }: { nixos.x = host.hostName; })
 
 # Matches: {host, user} only
-(den.lib.take.exactly ({ host, user }: { nixos.x = user.userName; }))
+(den.lib.perUser ({ host, user }: { nixos.x = user.userName; }))
 
 # Matches: {home} **or** {home, foo}
 ({ home }: { homeManager.x = home.userName; })

--- a/docs/src/content/docs/guides/bidirectional.mdx
+++ b/docs/src/content/docs/guides/bidirectional.mdx
@@ -131,11 +131,11 @@ Because the list of functions at `igloo.includes` get invoked more than once, wi
 they must take care of the following:
 
 ```nix
-# use den.lib.take.exactly to avoid being called with `{host, user}`
-take.exactly ({ host }: ...)
+# avoid being called with `{host, user}`
+den.lib.perHost ({ host }: ...)
 
-# use den.lib.take.atLeast to avoid being called with `{host}`
-take.atLeast ({ host, user }: ...)
+# avoid being called with `{host}`
+den.lib.perUser ({ host, user }: ...)
 ```
 
 Read the documentation at [`context/user.nix`](https://github.com/vic/den/blob/main/modules/context/user.nix) for all the details.

--- a/docs/src/content/docs/guides/debug.md
+++ b/docs/src/content/docs/guides/debug.md
@@ -85,10 +85,10 @@ nix-repl> cfg.networking.hostName
 
 **Duplicate values in lists**: Den deduplicates owned and static configs
 from `den.default`, but parametric functions in `den.default.includes`
-run at every context stage. Use `den.lib.take.exactly` to restrict:
+run at every context stage. Use `den.lib.perHost` to restrict:
 
 ```nix
-den.lib.take.exactly ({ host }: { nixos.x = 1; })
+den.lib.perHost ({ host }: { nixos.x = 1; })
 ```
 
 **Missing attribute**: The context does not have the expected parameter.

--- a/modules/context/perHost-perUser.nix
+++ b/modules/context/perHost-perUser.nix
@@ -1,0 +1,15 @@
+{
+  lib,
+  inputs,
+  config,
+  ...
+}:
+let
+  inherit (config.den.lib) take parametric;
+  fixed = ctx: aspect: parametric.fixedTo ctx { includes = [ aspect ]; };
+  perHost = aspect: take.exactly ({ host }@ctx: fixed ctx aspect);
+  perUser = aspect: take.exactly ({ host, user }@ctx: fixed ctx aspect);
+in
+{
+  den.lib = { inherit perUser perHost; };
+}

--- a/modules/context/user.nix
+++ b/modules/context/user.nix
@@ -53,11 +53,11 @@ let
 
        Do this to prevent the function being invoked with `{host,user}`
 
-          take.exactly ({host}: ...)
+          den.lib.perHost ({host}: ...)
 
        Or this to avoid it being invoked with `{host}`
 
-          take.atLeast ({host,user}: ...)
+          den.lib.perUser ({host,user}: ...)
 
     Static aspects, -functions  like `{class,aspect-chain}: ...`- at host-aspect.includes
     have **no way** to distinguish when the calling context is `{host}` or `{host,user}` if
@@ -66,7 +66,7 @@ let
     Because of this, if you have such functions, they might produce duplicate values on list or
     conflicting values on package types. A work around is to wrap them in a context-aware function:
 
-       take.exactly ({host}: { includes = [ ({class, aspect-chain}: ...) ]; })
+          den.lib.perHost ({host}: {class, aspect-chain}: ...)
 
   '';
 

--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -5,7 +5,5 @@
   ...
 }:
 {
-  imports = [
-    (inputs.den.lib { inherit inputs lib config; }).nixModule
-  ];
+  imports = [ (inputs.den.lib { inherit inputs lib config; }).nixModule ];
 }

--- a/nix/nixModule/lib.nix
+++ b/nix/nixModule/lib.nix
@@ -9,6 +9,6 @@
   options.den.lib = lib.mkOption {
     internal = true;
     visible = false;
-    type = lib.types.attrsOf lib.types.raw;
+    type = lib.types.submodule { freeformType = lib.types.lazyAttrsOf lib.types.unspecified; };
   };
 }

--- a/templates/ci/modules/features/perUser-perHost.nix
+++ b/templates/ci/modules/features/perUser-perHost.nix
@@ -1,0 +1,136 @@
+{ denTest, ... }:
+{
+  flake.tests.perUser-perHost = {
+
+    test-included-in-default-pipeline = denTest (
+      {
+        den,
+        igloo,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users = {
+          tux = { };
+          pingu = { };
+        };
+
+        den.aspects.igloo.nixos.options.funny = lib.mkOption {
+          default = [ ];
+          type = lib.types.listOf lib.types.str;
+        };
+
+        den.aspects.igloo.includes = [
+          (den.lib.perHost { nixos.funny = [ "atHost perHost static" ]; })
+          (den.lib.perHost (
+            { host }:
+            {
+              nixos.funny = [ "atHost perHost ${host.name} fun" ];
+            }
+          ))
+          (den.lib.perUser { nixos.funny = [ "atHost IGNORED perUser static" ]; })
+          (den.lib.perUser (
+            { user, host }:
+            {
+              nixos.funny = [ "atHost IGNORED perUser ${user.name}@${host.name} fun" ];
+            }
+          ))
+        ];
+
+        den.aspects.tux.includes = [
+          (den.lib.perHost { nixos.funny = [ "atUser IGNORED perHost static" ]; })
+          (den.lib.perHost (
+            { host }:
+            {
+              nixos.funny = [ "atUser IGNORED perHost ${host.name} fun" ];
+            }
+          ))
+          (den.lib.perUser { nixos.funny = [ "atUser perUser static" ]; })
+          (den.lib.perUser (
+            { user, host }:
+            {
+              nixos.funny = [ "atUser perUser ${user.name}@${host.name} fun" ];
+            }
+          ))
+        ];
+
+        expr = igloo.funny;
+        expected = [
+          "atUser perUser tux@igloo fun"
+          "atUser perUser static"
+          "atHost perHost igloo fun"
+          "atHost perHost static"
+        ];
+      }
+    );
+
+    test-included-in-bidirectional-pipeline = denTest (
+      {
+        den,
+        igloo,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users = {
+          tux = { };
+          pingu = { };
+        };
+
+        den.ctx.user.includes = [ den._.bidirectional ];
+
+        den.aspects.igloo.nixos.options.funny = lib.mkOption {
+          default = [ ];
+          type = lib.types.listOf lib.types.str;
+        };
+
+        den.aspects.igloo.includes = [
+          (den.lib.perHost { nixos.funny = [ "atHost perHost static" ]; })
+          (den.lib.perHost (
+            { host }:
+            {
+              nixos.funny = [ "atHost perHost ${host.name} fun" ];
+            }
+          ))
+          (den.lib.perUser { nixos.funny = [ "atHost perUser static" ]; })
+          (den.lib.perUser (
+            { user, host }:
+            {
+              nixos.funny = [ "atHost perUser ${user.name}@${host.name} fun" ];
+            }
+          ))
+        ];
+
+        den.aspects.tux.includes = [
+          (den.lib.perHost { nixos.funny = [ "atUser ignored perHost static" ]; })
+          (den.lib.perHost (
+            { host }:
+            {
+              nixos.funny = [ "atUser ignored perHost ${host.name} fun" ];
+            }
+          ))
+          (den.lib.perUser { nixos.funny = [ "atUser perUser static" ]; })
+          (den.lib.perUser (
+            { user, host }:
+            {
+              nixos.funny = [ "atUser perUser ${user.name}@${host.name} fun" ];
+            }
+          ))
+        ];
+
+        expr = igloo.funny;
+        expected = [
+          "atHost perUser pingu@igloo fun"
+          "atHost perUser static" # pingu
+          "atHost perUser tux@igloo fun"
+          "atHost perUser static" # tux
+          "atUser perUser tux@igloo fun"
+          "atUser perUser static"
+          "atHost perHost igloo fun"
+          "atHost perHost static"
+        ];
+      }
+    );
+
+  };
+}

--- a/templates/example/modules/aspects/defaults.nix
+++ b/templates/example/modules/aspects/defaults.nix
@@ -33,9 +33,11 @@
     # you could be duplicating config values. For example:
     #
     #  # This will append 42 into foo option for the {host} and for EVERY {host,user}
-    #  ({ host, ... }: { nixos.foo = [ 42 ]; }) # DO-NOT-DO-THIS.
+    #     ({ host, ... }: { nixos.foo = [ 42 ]; }) # DO-NOT-DO-THIS.
     #
     #  # Instead try to be explicit if a function is intended for ONLY { host }
-    #  den.lib.take.exactly ({ host }: { nixos.foo = [ 42 ]; })
+    #     den.lib.perHost ({ host }: { nixos.foo = [ 42 ]; })
+    #  # Or for { host, user } ONLY:
+    #     den.lib.perUser ({ host, user }: { nixos.foo = [ 42 ]; })
   ];
 }


### PR DESCRIPTION
These are shortcuts for `exactly {host}` and `exactly {host,user}` respectively.