### PR TITLE
fix(ctx): should not use hm from host when no-bidir enabled.

### DIFF
--- a/modules/context/user.nix
+++ b/modules/context/user.nix
@@ -76,6 +76,7 @@ let
 
   from-user = { host, user }: fixedTo { inherit host user; } den.aspects.${user.aspect};
   from-host = { host, user }: atLeast den.aspects.${host.aspect} { inherit host user; };
+
 in
 {
   den.ctx = ctx;

--- a/nix/lib/home-env.nix
+++ b/nix/lib/home-env.nix
@@ -72,7 +72,6 @@ let
       includes = [
         (den.ctx."${ctxName}-user" { inherit host user; })
         (den.ctx.user { inherit host user; })
-        (den.lib.parametric.fixedTo { inherit host user; } den.aspects.${host.aspect})
       ];
     };
 

--- a/templates/ci/modules/features/conditional-config.nix
+++ b/templates/ci/modules/features/conditional-config.nix
@@ -69,6 +69,7 @@
           pingu = { };
         };
         den.default.homeManager.home.stateVersion = "25.11";
+        den.ctx.user.includes = [ den._.bidirectional ];
         den.aspects.igloo.includes = [ git-for-linux-only ];
 
         expr = [

--- a/templates/ci/modules/features/deadbugs/issue-292-hm-used-when-no-bidir-enabled.nix
+++ b/templates/ci/modules/features/deadbugs/issue-292-hm-used-when-no-bidir-enabled.nix
@@ -1,0 +1,27 @@
+{ denTest, ... }:
+{
+  flake.tests.deadbugs-issue-292 = {
+
+    test-should-not-read-from-host-without-bidirectionality = denTest (
+      {
+        den,
+        lib,
+        igloo, # igloo = nixosConfigurations.igloo.config
+        tuxHm, # tuxHm = igloo.home-manager.users.tux
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.bash ];
+        den.aspects.tux.includes = [ den.aspects.bash ];
+
+        den.aspects.bash.homeManager.programs.bash.historyIgnore = [ "foo" ];
+
+        expr = tuxHm.programs.bash.historyIgnore;
+        expected = [ "foo" ];
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/perUser-perHost.nix
+++ b/templates/ci/modules/features/perUser-perHost.nix
@@ -85,6 +85,7 @@
         };
 
         den.aspects.igloo.includes = [
+
           (den.lib.perHost { nixos.funny = [ "atHost perHost static" ]; })
           (den.lib.perHost (
             { host }:

--- a/templates/ci/modules/features/user-host-bidirectional-config.nix
+++ b/templates/ci/modules/features/user-host-bidirectional-config.nix
@@ -2,7 +2,7 @@
 {
   flake.tests.user-host-bidirectional-config = {
 
-    test-host-owned-configures-all-users = denTest (
+    test-host-owned-unidirectional = denTest (
       {
         den,
         tuxHm,
@@ -10,13 +10,12 @@
         ...
       }:
       {
-        den.default.homeManager.home.stateVersion = "25.11";
-
         den.hosts.x86_64-linux.igloo.users = {
           tux = { };
           pingu = { };
         };
 
+        # no bidirectionality enabled, this is ignored
         den.aspects.igloo.homeManager.programs.direnv.enable = true;
 
         expr = [
@@ -24,13 +23,13 @@
           pinguHm.programs.direnv.enable
         ];
         expected = [
-          true
-          true
+          false
+          false
         ];
       }
     );
 
-    test-host-static-configures-all-users = denTest (
+    test-host-owned-bidirectional = denTest (
       {
         den,
         tuxHm,
@@ -38,17 +37,48 @@
         ...
       }:
       {
-        den.default.homeManager.home.stateVersion = "25.11";
-
         den.hosts.x86_64-linux.igloo.users = {
           tux = { };
           pingu = { };
         };
 
+        den.ctx.user.includes = [ den._.bidirectional ];
+        den.aspects.igloo.homeManager.programs.direnv.enable = true;
+
+        expr = [
+          tuxHm.programs.direnv.enable
+          pinguHm.programs.direnv.enable
+        ];
+        expected = [
+          false
+          false
+        ];
+      }
+    );
+
+    test-host-bidirectional-static-includes-configures-all-users = denTest (
+      {
+        den,
+        tuxHm,
+        pinguHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users = {
+          tux = { };
+          pingu = { };
+        };
+
+        den.ctx.user.includes = [ den._.bidirectional ];
+
         den.aspects.igloo.includes = [
           {
-            homeManager.programs.direnv.enable = true;
+            homeManager.programs.direnv.enable = throw "unreachable, static includes wont be used by bidirectionality";
           }
+          # This is the way, walk in it:
+          (den.lib.perUser {
+            homeManager.programs.direnv.enable = true;
+          })
         ];
 
         expr = [
@@ -62,7 +92,7 @@
       }
     );
 
-    test-host-parametric-configures-all-users = denTest (
+    test-host-parametric-unidirectional = denTest (
       {
         den,
         tuxHm,
@@ -70,12 +100,47 @@
         ...
       }:
       {
-        den.default.homeManager.home.stateVersion = "25.11";
 
         den.hosts.x86_64-linux.igloo.users = {
           tux = { };
           pingu = { };
         };
+
+        den.aspects.igloo.includes = [
+          (
+            { host, user }:
+            {
+              homeManager.programs.direnv.enable = true;
+            }
+          )
+        ];
+
+        expr = [
+          tuxHm.programs.direnv.enable
+          pinguHm.programs.direnv.enable
+        ];
+        expected = [
+          false
+          false
+        ];
+      }
+    );
+
+    test-host-parametric-bidirectional = denTest (
+      {
+        den,
+        tuxHm,
+        pinguHm,
+        ...
+      }:
+      {
+
+        den.hosts.x86_64-linux.igloo.users = {
+          tux = { };
+          pingu = { };
+        };
+
+        den.ctx.user.includes = [ den._.bidirectional ];
 
         den.aspects.igloo.includes = [
           (
@@ -105,7 +170,6 @@
         ...
       }:
       {
-        den.default.homeManager.home.stateVersion = "25.11";
 
         den.hosts.x86_64-linux.igloo.users.tux = { };
         den.hosts.x86_64-linux.iceberg.users.tux = { };
@@ -123,7 +187,7 @@
       }
     );
 
-    test-user-static-configures-all-hosts = denTest (
+    test-user-static-unidirectional-configures-all-hosts = denTest (
       {
         den,
         igloo,
@@ -131,7 +195,6 @@
         ...
       }:
       {
-        den.default.homeManager.home.stateVersion = "25.11";
 
         den.hosts.x86_64-linux.igloo.users.tux = { };
         den.hosts.x86_64-linux.iceberg.users.tux = { };
@@ -161,7 +224,6 @@
         ...
       }:
       {
-        den.default.homeManager.home.stateVersion = "25.11";
 
         den.hosts.x86_64-linux.igloo.users.tux = { };
         den.hosts.x86_64-linux.iceberg.users.tux = { };


### PR DESCRIPTION
cc @Sharparam, offending line was: https://github.com/vic/den/pull/293/changes#diff-a008f96c95a197db435b512a966b1b8a2038e6da23230fddd6184e120aa22b15L75

Fixes #292.