### PR TITLE
docs: remove absolute size from main den logo

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Aspect-oriented, context-driven Nix configurations
   image:
     html: |
-      <img width="400" height="400" src="https://github.com/user-attachments/assets/af9c9bca-ab8b-4682-8678-31a70d510bbb" />
+      <img width="100%" src="https://github.com/user-attachments/assets/af9c9bca-ab8b-4682-8678-31a70d510bbb" />
   actions:
     - text: Getting Started
       link: /guides/from-zero-to-den


### PR DESCRIPTION
Fixes broken default viewport on mobile browsers.