### PR TITLE
fix: prevent options.json store path context warning (Determinate Nix)

### DIFF
--- a/modules/aspects/provides/home-manager/hm-os.nix
+++ b/modules/aspects/provides/home-manager/hm-os.nix
@@ -25,7 +25,18 @@ let
   ctx.hm-host.provides.hm-host =
     { host }:
     {
-      ${host.class}.imports = [ host.home-manager.module ];
+      ${host.class} = {
+        imports = [ host.home-manager.module ];
+        # Prevent the home-manager manual.nix module from eagerly evaluating
+        # nixosOptionsDoc (which creates an options.json derivation referencing
+        # the nixpkgs source store path without proper string context).
+        # Users can re-enable with mkForce if they need HM manpages.
+        home-manager.sharedModules = [
+          {
+            manual.manpages.enable = lib.mkDefault false;
+          }
+        ];
+      };
     };
 
   hostConf = hostOptions {

--- a/nix/nixModule/lib.nix
+++ b/nix/nixModule/lib.nix
@@ -10,5 +10,6 @@
     internal = true;
     visible = false;
     type = lib.types.attrsOf lib.types.raw;
+    defaultText = lib.literalExpression "den-lib";
   };
 }

--- a/nix/types.nix
+++ b/nix/types.nix
@@ -56,6 +56,13 @@ let
             '';
             example = lib.literalExpression "inputs.nixpkgs.lib.nixosSystem";
             type = lib.types.raw;
+            defaultText = lib.literalExpression ''
+              {
+                nixos = inputs.nixpkgs.lib.nixosSystem;
+                darwin = inputs.darwin.lib.darwinSystem;
+                systemManager = inputs.system-manager.lib.makeSystemConfig;
+              }.''${config.class}
+            '';
             default =
               {
                 nixos = inputs.nixpkgs.lib.nixosSystem;
@@ -164,6 +171,7 @@ let
             '';
             example = lib.literalExpression ''inputs.nixpkgs.legacyPackages.''${home.system}'';
             type = lib.types.raw;
+            defaultText = lib.literalExpression ''inputs.nixpkgs.legacyPackages.''${config.system}'';
             default = inputs.nixpkgs.legacyPackages.${config.system};
           };
           instantiate = lib.mkOption {
@@ -180,6 +188,11 @@ let
             '';
             example = lib.literalExpression "inputs.home-manager.lib.homeManagerConfiguration";
             type = lib.types.raw;
+            defaultText = lib.literalExpression ''
+              {
+                homeManager = inputs.home-manager.lib.homeManagerConfiguration;
+              }.''${config.class}
+            '';
             default =
               {
                 homeManager = inputs.home-manager.lib.homeManagerConfiguration;


### PR DESCRIPTION
claude-code running in dangerously skip permissions mode, oops. 

(Implemented a fix addressing symptoms, not a real solution)