### PR TITLE
fix: `nh` invocation for standalone homes

### DIFF
--- a/nix/lib/nh.nix
+++ b/nix/lib/nh.nix
@@ -16,16 +16,23 @@ let
       text =
         let
           command = getCommand item;
-          attr = lib.concatStringsSep "." (outPrefix ++ item.intoAttr);
+          attr = if command == "home" then "" else lib.concatStringsSep "." (outPrefix ++ item.intoAttr);
           from =
-            if fromFlake then
-              [ "${fromPath}#${attr}" ]
-            else
-              [
-                "--file"
-                fromPath
-                attr
-              ];
+            (
+              if fromFlake then
+                [ "${fromPath}#${attr}" ]
+              else
+                [
+                  "--file"
+                  fromPath
+                  attr
+                ]
+            )
+            ++ (lib.optionals (command == "home") [
+              "-c"
+              item.name
+            ]);
+
           args = lib.concatStringsSep " " from;
         in
         ''


### PR DESCRIPTION
Checks if the command is `home`, and if so, properly formats the arguments so that `nh` will be able to switch to the specified home.

Fixes #253 