### PR TITLE
feat(ctx): Aspect contributions can access source and target contexts

### DIFF
--- a/modules/outputs/flakeSystemOutputs.nix
+++ b/modules/outputs/flakeSystemOutputs.nix
@@ -42,7 +42,7 @@ let
 
       ctxs = map (output: {
         flake-system.into."flake-${output}" = systemOutput output;
-        flake-system.provides."flake-${output}" = systemOutputFwd;
+        flake-system.provides."flake-${output}" = _: systemOutputFwd;
       }) outputs;
     in
     ctxs;

--- a/modules/outputs/hmConfigurations.nix
+++ b/modules/outputs/hmConfigurations.nix
@@ -4,7 +4,7 @@ let
   ctx.flake-system.into.flake-hm =
     { system }: map (home: { inherit home; }) (builtins.attrValues den.homes.${system} or { });
 
-  ctx.flake-system.provides.flake-hm = hmFwd;
+  ctx.flake-system.provides.flake-hm = _: hmFwd;
 
   hmFwd =
     { home }:

--- a/modules/outputs/osConfigurations.nix
+++ b/modules/outputs/osConfigurations.nix
@@ -3,7 +3,7 @@ let
   ctx.flake-system.into.flake-os =
     { system }: map (host: { inherit host; }) (builtins.attrValues den.hosts.${system} or { });
 
-  ctx.flake-system.provides.flake-os = osFwd;
+  ctx.flake-system.provides.flake-os = _: osFwd;
 
   osFwd =
     { host }:

--- a/nix/lib/ctx-apply.nix
+++ b/nix/lib/ctx-apply.nix
@@ -38,11 +38,11 @@ let
     );
 
   transformAll =
-    source: self: ctxValue: key:
+    source: ctxPrev: self: ctxValue: key:
     [
       {
+        inherit source ctxPrev key;
         ctx = ctxValue;
-        inherit source key;
         ctxDef = self;
       }
     ]
@@ -51,7 +51,7 @@ let
       let
         target = lib.attrByPath path null ctxNs;
         tkey = lib.concatStringsSep "." path;
-        recurse = t: k: lib.concatMap (v: transformAll self t v k) into;
+        recurse = t: k: lib.concatMap (v: transformAll self ctxValue t v k) into;
       in
       if target != null then
         recurse target tkey
@@ -69,7 +69,7 @@ let
 
   noop = _: { };
 
-  crossProvider = p: p.source.provides.${p.key} or noop;
+  crossProvider = p: p.source.provides.${p.key} or (_: noop);
 
   buildIncludes =
     items:
@@ -80,7 +80,7 @@ let
           clean = cleanCtx p.ctxDef;
           isFirst = !(acc.seen ? ${p.key});
           selfFun = p.ctxDef.provides.${p.ctxDef.name} or noop;
-          crossFun = crossProvider p;
+          crossFun = crossProvider p p.ctxPrev;
         in
         {
           seen = acc.seen // {
@@ -99,7 +99,7 @@ let
     } items).result;
 
   ctxApply = self: ctxValue: {
-    includes = buildIncludes (transformAll null self ctxValue self.name);
+    includes = buildIncludes (transformAll null null self ctxValue self.name);
   };
 
 in

--- a/templates/ci/modules/features/context/cross-provider.nix
+++ b/templates/ci/modules/features/context/cross-provider.nix
@@ -17,6 +17,7 @@
             funny.names = [ "parent-${x}" ];
           };
         den.ctx.parent._.child =
+          _:
           { x, y }:
           {
             funny.names = [ "parent-for-child-${x}-${y}" ];
@@ -60,6 +61,7 @@
             funny.names = [ x ];
           };
         den.ctx.src._.dst =
+          _:
           { x, i }:
           {
             funny.names = [ "src-for-${x}-${toString i}" ];

--- a/templates/ci/modules/features/context/named-provider.nix
+++ b/templates/ci/modules/features/context/named-provider.nix
@@ -52,6 +52,7 @@
 
         den.ctx.greet.into.other = lib.singleton;
         den.ctx.greet.provides.other =
+          _:
           { who }:
           {
             funny.names = [ "other-${who}" ];
@@ -130,6 +131,7 @@
           };
 
         den.ctx.greet.provides.num =
+          _:
           { number }:
           {
             funny.names = [ ("num:" + lib.toString number) ];

--- a/templates/ci/modules/features/context/nested-ctx-providers.nix
+++ b/templates/ci/modules/features/context/nested-ctx-providers.nix
@@ -20,6 +20,7 @@
           };
 
         den.ctx.root.provides.${"ns.inner"} =
+          _:
           { z }:
           {
             funny.names = [ "root-for-inner-${z}" ];
@@ -54,6 +55,7 @@
         };
 
         den.ctx.root.provides.${"a.leaf"} =
+          _:
           { v }:
           {
             funny.names = [ "cross-a-${v}" ];

--- a/templates/ci/modules/features/den-as-lib.nix
+++ b/templates/ci/modules/features/den-as-lib.nix
@@ -88,9 +88,10 @@ in
               };
             den.ctx.foo.into.bar = { name }: lib.singleton { shout = lib.toUpper name; };
             den.ctx.foo.provides.bar =
+              { name }:
               { shout }:
               {
-                my.names = [ "foo shouted ${shout}" ];
+                my.names = [ "foo ${name} shouted ${shout}" ];
               };
 
             den.ctx.bar.provides.bar =
@@ -115,7 +116,7 @@ in
 
         expr = ev2.config.names;
         expected = [
-          "foo shouted GOOD"
+          "foo good shouted GOOD"
           "bar GOOD"
           "foo good"
         ];

--- a/templates/ci/modules/features/perf/ctx-pipeline.nix
+++ b/templates/ci/modules/features/perf/ctx-pipeline.nix
@@ -55,7 +55,7 @@ let
               };
             into = lib.genAttrs (lib.genList (i: "t${toString i}") n) (_: { v }: [ { v = "${v}!"; } ]);
             provides = lib.genAttrs (lib.genList (i: "t${toString i}") n) (
-              name:
+              name: _:
               { v }:
               {
                 funny.names = [ "cross-${name}-${v}" ];

--- a/templates/flake-parts-modules/modules/perSystem-forward.nix
+++ b/templates/flake-parts-modules/modules/perSystem-forward.nix
@@ -18,7 +18,7 @@ let
     );
 
   ctx.flake-parts = { };
-  ctx.flake-parts-system.provides.flake-parts-system = perSystemFwd;
+  ctx.flake-parts-system.provides.flake-parts-system = _: perSystemFwd;
   perSystemModule = den.lib.aspects.resolve "flake-parts" (den.ctx.flake-parts { });
 in
 {

--- a/templates/microvm/modules/microvm-integration.nix
+++ b/templates/microvm/modules/microvm-integration.nix
@@ -58,6 +58,7 @@ let
   # aspect configuring a guest vm at the host level (Declarative in MicroVM parlance)
   # See: https://microvm-nix.github.io/microvm.nix/declarative.html
   ctx.microvm-host.provides.microvm-guest =
+    { host }:
     { host, vm }:
     {
       includes =


### PR DESCRIPTION
Usage Example:


```nix
# foo -> [bar] 
den.ctx.foo.into.bar = { foo }: [ { bar = 22; } ];

# aspect for configuring foo
den.ctx.foo.provides.foo = { foo }: <aspect>;

# aspect for configuring bar
den.ctx.bar.provides.bar = { bar }: <aspect>;

# NEW: foo contributes configuration to bar
# The aspect here can read from both source and target contexts
den.ctx.foo.provides.bar = { foo }: { bar }: <aspect>;
```
