### PR TITLE
fix: ensure example builds on non-linux machines

### DIFF
--- a/templates/flake-parts-modules/modules/custom-classes.nix
+++ b/templates/flake-parts-modules/modules/custom-classes.nix
@@ -6,7 +6,7 @@
   ...
 }:
 {
-  systems = builtins.attrNames den.hosts;
+  systems = lib.systems.flakeExposed;
 
   # Some third-party flake-parts modules for demo purposes.
   # Read their documentation at https://flake.parts for usage.


### PR DESCRIPTION
Since the only host in the example didn't match my architecture, `nix fmt` wouldn't run properly. This fixed it.