### PR TITLE
feat: per-aspect adapter accumulation in resolve

### DIFF
--- a/nix/lib/aspects/adapters.nix
+++ b/nix/lib/aspects/adapters.nix
@@ -40,6 +40,50 @@ let
     f: adapter: args:
     adapter (args // { recurse = included: args.recurse (f included); });
 
+  # Handles per-aspect adapter accumulation via meta.adapter.
+  # Composes meta.adapter with the inner adapter, removes includes that
+  # would resolve to { }, and tags survivors for downstream propagation.
+  filterIncludes =
+    inner:
+    args@{ aspect, resolveChild, ... }:
+    let
+      metaAdapter = aspect.meta.adapter or null;
+    in
+    if metaAdapter != null && aspect ? includes then
+      let
+        composed = metaAdapter (filterIncludes inner);
+        keeps =
+          i:
+          composed (
+            args
+            // {
+              aspect = resolveChild i;
+              classModule = [ ];
+            }
+          ) != { };
+        tag =
+          i:
+          if builtins.isAttrs i && i.meta.adapter or null == null then
+            i
+            // {
+              meta = (i.meta or { }) // {
+                adapter = metaAdapter;
+              };
+            }
+          else
+            i;
+      in
+      inner (
+        args
+        // {
+          aspect = aspect // {
+            includes = builtins.map tag (lib.filter keeps aspect.includes);
+          };
+        }
+      )
+    else
+      inner args;
+
 in
 {
   inherit
@@ -48,5 +92,6 @@ in
     map
     mapAspect
     mapIncludes
+    filterIncludes
     ;
 }

--- a/nix/lib/aspects/resolve.nix
+++ b/nix/lib/aspects/resolve.nix
@@ -31,10 +31,17 @@ let
           aspect-chain = prevChain ++ [ provided ] ++ (lib.optional (provided != aspect) aspect);
 
           classModule = lib.optional (aspect ? ${class}) (
-            lib.setDefaultModuleLocation "${class}@${aspect.name}" aspect.${class}
+            lib.setDefaultModuleLocation "${class}@${aspect.name or "<anon>"}" aspect.${class}
           );
 
           recurse = go aspect-chain;
+
+          resolveChild =
+            i:
+            apply i {
+              inherit class;
+              aspect-chain = aspect-chain ++ [ i ];
+            };
         in
         adapter {
           inherit
@@ -43,12 +50,13 @@ let
             classModule
             recurse
             aspect-chain
+            resolveChild
             ;
         };
     in
     go [ ];
 
-  resolve = withAdapter adapters.module;
+  resolve = withAdapter (adapters.filterIncludes adapters.module);
 
 in
 {

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -101,7 +101,12 @@ let
             description = "Aspect attached meta data";
             type = lib.types.submodule {
               freeformType = lib.types.lazyAttrsOf lib.types.unspecified;
-              self = config;
+              config.self = config;
+              options.adapter = lib.mkOption {
+                description = "Adapter to compose into resolution for this aspect's subtree";
+                type = lib.types.nullOr (lastFunctionTo lib.types.raw);
+                default = null;
+              };
             };
             defaultText = lib.literalExpression "{ }";
             default = { };

--- a/templates/ci/modules/features/aspect-adapter.nix
+++ b/templates/ci/modules/features/aspect-adapter.nix
@@ -1,0 +1,87 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.aspect-adapter =
+    let
+      traceName =
+        { aspect, recurse, ... }:
+        {
+          trace = [ aspect.name ] ++ map (i: (recurse i).trace or [ ]) (aspect.includes or [ ]);
+        };
+    in
+    {
+
+      test-meta-adapter-filters-subtree = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo.includes = [
+            den.aspects.bar
+            den.aspects.baz
+          ];
+          den.aspects.foo.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: a.name != "baz") inherited;
+          den.aspects.bar.nixos = { };
+          den.aspects.baz.nixos = { };
+
+          expr =
+            den.lib.aspects.resolve.withAdapter (den.lib.aspects.adapters.filterIncludes traceName) "nixos"
+              den.aspects.foo;
+          expected.trace = [
+            "foo"
+            [ "bar" ]
+          ];
+        }
+      );
+
+      test-meta-adapter-only-affects-subtree = denTest (
+        { den, ... }:
+        {
+          den.aspects.root.includes = [
+            den.aspects.foo
+            den.aspects.baz
+          ];
+          den.aspects.foo.includes = [ den.aspects.bar ];
+          den.aspects.foo.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: a.name != "baz") inherited;
+          den.aspects.bar.nixos = { };
+          den.aspects.baz.nixos = { };
+
+          expr =
+            den.lib.aspects.resolve.withAdapter (den.lib.aspects.adapters.filterIncludes traceName) "nixos"
+              den.aspects.root;
+          expected.trace = [
+            "root"
+            [
+              "foo"
+              [ "bar" ]
+            ]
+            [ "baz" ]
+          ];
+        }
+      );
+
+      test-meta-adapter-composes-with-caller = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo.includes = [
+            den.aspects.bar
+            den.aspects.baz
+          ];
+          den.aspects.foo.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: a.name != "bar") inherited;
+          den.aspects.bar.nixos = { };
+          den.aspects.baz.nixos = { };
+
+          expr =
+            let
+              outerAdapter = den.lib.aspects.adapters.filter (a: a.name != "baz") traceName;
+            in
+            den.lib.aspects.resolve.withAdapter (den.lib.aspects.adapters.filterIncludes outerAdapter) "nixos"
+              den.aspects.foo;
+          expected.trace = [
+            "foo"
+          ];
+        }
+      );
+
+    };
+}

--- a/templates/ci/modules/features/aspect-meta.nix
+++ b/templates/ci/modules/features/aspect-meta.nix
@@ -80,7 +80,7 @@
             KEYS
             ;
         };
-        expected.KEYS = "file:loc:name:self";
+        expected.KEYS = "adapter:file:loc:name:self";
       }
     );
 
@@ -110,7 +110,7 @@
             KEYS
             ;
         };
-        expected.KEYS = "file:foo:loc:name:self";
+        expected.KEYS = "adapter:file:foo:loc:name:self";
       }
     );
 


### PR DESCRIPTION
Aspects can declare meta.adapter (typed nullOr functionTo raw) to compose into resolution for their subtree. resolve's go function accumulates aspect-level adapters as it descends, composing them with the inherited adapter.