### PR TITLE
feat: preserve aspect identity and adapter through functor evaluation

### DIFF
--- a/checkmate/modules/aspect-functor.nix
+++ b/checkmate/modules/aspect-functor.nix
@@ -69,9 +69,17 @@ let
     ];
   };
 
+  identity = {
+    meta = {
+      adapter = null;
+      provider = [ ];
+    };
+    name = "<anon>";
+  };
+
   flake.tests."test functor applied with empty attrs" = {
     expr = (aspect-example { });
-    expected = {
+    expected = identity // {
       includes = [
         { nixos.any = 10; }
       ];
@@ -84,7 +92,7 @@ let
         host = 2;
       }
     );
-    expected = {
+    expected = identity // {
       includes = [
         { nixos.host = 2; } # host
         { nixos.any = 10; }
@@ -98,7 +106,7 @@ let
         home = 2;
       }
     );
-    expected = {
+    expected = identity // {
       includes = [
         { nixos.home = 2; } # home
         { nixos.any = 10; }
@@ -113,7 +121,7 @@ let
         unknown = 1;
       }
     );
-    expected = {
+    expected = identity // {
       includes = [
         { nixos.home = 2; }
         { nixos.any = 10; }
@@ -127,7 +135,7 @@ let
         user = 2;
       }
     );
-    expected = {
+    expected = identity // {
       includes = [
         { nixos.user = 2; } # user
         { nixos.user-only = 2; } # user-only
@@ -143,7 +151,7 @@ let
         host = 1;
       }
     );
-    expected = {
+    expected = identity // {
       includes = [
         { nixos.host = 1; }
         {
@@ -167,7 +175,7 @@ let
         host = 1;
       }
     );
-    expected = {
+    expected = identity // {
       includes = [
         { nixos.host = 1; }
         {

--- a/nix/lib/ctx-apply.nix
+++ b/nix/lib/ctx-apply.nix
@@ -105,14 +105,16 @@ let
       result = [ ];
     } items).result;
 
-  ctxApply = self: ctx: {
-    includes = assembleIncludes (traverse {
-      prev = null;
-      prevCtx = null;
-      key = self.name;
-      inherit self ctx;
-    });
-  };
+  ctxApply =
+    self: ctx:
+    parametric.withIdentity self {
+      includes = assembleIncludes (traverse {
+        prev = null;
+        prevCtx = null;
+        key = self.name;
+        inherit self ctx;
+      });
+    };
 
 in
 ctxApply

--- a/nix/lib/parametric.nix
+++ b/nix/lib/parametric.nix
@@ -3,13 +3,32 @@ let
   inherit (den.lib) take;
   inherit (den.lib.statics) owned statics isCtxStatic;
 
+  # Preserve aspect identity through functor evaluation.
+  # Carries name and typed meta options so adapters and provenance
+  # survive, without leaking freeform user meta to child results.
+  withIdentity =
+    self: extra:
+    let
+      meta = self.meta or { };
+    in
+    {
+      name = self.name or "<anon>";
+      meta = {
+        adapter = meta.adapter or null;
+        provider = meta.provider or [ ];
+      };
+    }
+    // extra;
+
   parametric.applyIncludes =
     takeFn: aspect:
     aspect
     // {
-      __functor = self: ctx: {
-        includes = (builtins.filter (x: x != { })) (map (fn: takeFn fn ctx) (self.includes or [ ]));
-      };
+      __functor =
+        self: ctx:
+        withIdentity self {
+          includes = builtins.filter (x: x != { }) (map (fn: takeFn fn ctx) (self.includes or [ ]));
+        };
     };
 
   mapIncludes =
@@ -35,7 +54,7 @@ let
       __functor =
         self:
         { class, aspect-chain }:
-        {
+        withIdentity self {
           includes = [
             (include self { inherit class aspect-chain; })
             (mapIncludes (deepRecurse include branch leaf) leaf (branch aspect))
@@ -64,17 +83,21 @@ let
     functor: aspect:
     aspect
     // {
-      __functor = self: ctx: {
-        includes =
-          if isCtxStatic ctx then
-            [
-              (owned self)
-              (statics self ctx)
-            ]
-          else
-            [ (functor self ctx) ];
-      };
+      __functor =
+        self: ctx:
+        withIdentity self {
+          includes =
+            if isCtxStatic ctx then
+              [
+                (owned self)
+                (statics self ctx)
+              ]
+            else
+              [ (functor self ctx) ];
+        };
     };
+
+  parametric.withIdentity = withIdentity;
 
   parametric.__functor = _: parametric.withOwn parametric.atLeast;
 in

--- a/templates/ci/modules/features/identity-preservation.nix
+++ b/templates/ci/modules/features/identity-preservation.nix
@@ -1,0 +1,101 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.identity-preservation =
+    let
+      getName =
+        { aspect, recurse, ... }:
+        {
+          name = aspect.name;
+          adapter = aspect.meta.adapter or null;
+          children = map (i: (recurse i)) (aspect.includes or [ ]);
+        };
+    in
+    {
+
+      test-parametric-aspect-preserves-name = denTest (
+        { den, ... }:
+        {
+          den.aspects.igloo.includes = [ den.aspects.foo ];
+
+          den.aspects.foo =
+            { host }:
+            {
+              nixos.environment.sessionVariables.WHO = "foo";
+            };
+
+          expr = (den.lib.aspects.resolve.withAdapter getName "nixos" den.aspects.igloo).name;
+          expected = "igloo";
+        }
+      );
+
+      test-parametric-child-preserves-name = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo.includes = [ den.aspects.bar ];
+          den.aspects.bar =
+            { host }:
+            {
+              nixos = { };
+            };
+
+          expr =
+            let
+              result = den.lib.aspects.resolve.withAdapter getName "nixos" den.aspects.foo;
+            in
+            (lib.head result.children).name;
+          expected = "bar";
+        }
+      );
+
+      test-meta-preserved-through-functor = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo.nixos = { };
+
+          expr = (den.lib.aspects.resolve.withAdapter getName "nixos" den.aspects.foo).adapter;
+          expected = null;
+        }
+      );
+
+      # meta.loc, meta.name, meta.file are set by aspectMeta at merge
+      # time and aren't available during functor evaluation. They don't
+      # need explicit preservation — aspectType.merge provides defaults
+      # for curried results, and non-curried results pass through as-is.
+      test-den-meta-not-available-at-functor-eval = denTest (
+        { den, ... }:
+        let
+          getMeta =
+            { aspect, recurse, ... }:
+            {
+              metaName = aspect.meta.name or null;
+              children = map (i: recurse i) (aspect.includes or [ ]);
+            };
+        in
+        {
+          den.aspects.foo.includes = [ den.aspects.bar ];
+          den.aspects.bar =
+            { host }:
+            {
+              nixos = { };
+            };
+
+          expr =
+            let
+              result = den.lib.aspects.resolve.withAdapter getMeta "nixos" den.aspects.foo;
+              child = lib.head result.children;
+            in
+            {
+              # Both get "" because aspectMeta's mkForce hasn't
+              # resolved when the functor/merge runs.
+              parentMetaName = result.metaName;
+              childMetaName = child.metaName;
+            };
+          expected = {
+            parentMetaName = "";
+            childMetaName = "";
+          };
+        }
+      );
+
+    };
+}


### PR DESCRIPTION
Functor-producing functions in parametric.nix (applyIncludes, deepRecurse, withOwn) carry name, __provider, and eta.adapter from self into their return values. ctxApply also carries name and __provider on its result.

Currently, when parametric functors evaluate, they return plain { includes = [...]; } attrsets — losing the aspect's identity. This means any code inspecting the resolved aspect (such as a custom adapter via resolve.withAdapter) sees incorrect defaults instead of the original aspect's name.

This lays groundwork for context-level adapter resolution, where adapters declared on aspects or contexts need to propagate through the parametric pipeline to reach forward.nix and outputs.nix. Child includes are tagged with the parent's meta.adapter so adapters compose downward through the include tree.

Upcoming related PRs:
- #397
- Structural provider provenance via __provider paths
- Context-level adapter on ctxApply result
- Forward/output consumption of meta.adapter