### PR TITLE
feat: structural provider provenance via meta.provider

### DIFF
--- a/modules/aspects/provides.nix
+++ b/modules/aspects/provides.nix
@@ -10,7 +10,14 @@
         default = { };
         description = "Batteries Included - re-usable high-level aspects";
         type = lib.types.submodule {
-          freeformType = lib.types.attrsOf config.den.lib.aspects.types.providerType;
+          freeformType = lib.types.attrsOf (
+            (config.den.lib.aspects.mkAspectsType {
+              providerPrefix = [
+                "den"
+                "provides"
+              ];
+            }).providerType
+          );
         };
       };
     };

--- a/nix/lib/aspects/default.nix
+++ b/nix/lib/aspects/default.nix
@@ -14,4 +14,5 @@ let
 in
 {
   inherit types adapters resolve;
+  mkAspectsType = cnf': lib.mapAttrs (_: v: v (typesConf // cnf')) rawTypes;
 }

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -107,6 +107,13 @@ let
                 type = lib.types.nullOr (lastFunctionTo lib.types.raw);
                 default = null;
               };
+              options.provider = lib.mkOption {
+                internal = true;
+                visible = false;
+                description = "Provider path tracking aspect provenance";
+                type = lib.types.listOf lib.types.str;
+                default = cnf.providerPrefix or [ ];
+              };
             };
             defaultText = lib.literalExpression "{ }";
             default = { };
@@ -124,7 +131,14 @@ let
             defaultText = lib.literalExpression "{ }";
             default = { };
             type = lib.types.submodule {
-              freeformType = lib.types.lazyAttrsOf (providerType cnf);
+              freeformType = lib.types.lazyAttrsOf (
+                providerType (
+                  cnf
+                  // {
+                    providerPrefix = (cnf.providerPrefix or [ ]) ++ [ config.name ];
+                  }
+                )
+              );
             };
           };
 

--- a/nix/lib/namespace-types.nix
+++ b/nix/lib/namespace-types.nix
@@ -1,10 +1,10 @@
 { den, lib, ... }:
 let
   inherit (den.lib) ctxApply;
-  inherit (den.lib.aspects.types) aspectsType;
+  inherit (den.lib.aspects) mkAspectsType;
 
   namespaceType = lib.types.submodule (
-    nsArgs:
+    nsArgs@{ name, ... }:
     let
       nsCtxApply = ctxApply nsArgs.config.ctx;
       inherit (den.lib.ctxTypes nsCtxApply) ctxTreeType;
@@ -24,7 +24,7 @@ let
           freeformType = lib.types.lazyAttrsOf lib.types.deferredModule;
         };
       };
-      freeformType = aspectsType;
+      freeformType = (mkAspectsType { providerPrefix = [ name ]; }).aspectsType;
     }
   );
 in

--- a/templates/ci/modules/features/aspect-meta.nix
+++ b/templates/ci/modules/features/aspect-meta.nix
@@ -80,7 +80,7 @@
             KEYS
             ;
         };
-        expected.KEYS = "adapter:file:loc:name:self";
+        expected.KEYS = "adapter:file:loc:name:provider:self";
       }
     );
 
@@ -110,7 +110,7 @@
             KEYS
             ;
         };
-        expected.KEYS = "adapter:file:foo:loc:name:self";
+        expected.KEYS = "adapter:file:foo:loc:name:provider:self";
       }
     );
 

--- a/templates/ci/modules/features/provider-provenance.nix
+++ b/templates/ci/modules/features/provider-provenance.nix
@@ -1,0 +1,74 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.provider-provenance =
+    let
+      getProvenance =
+        { aspect, recurse, ... }:
+        {
+          name = aspect.name;
+          provider = aspect.meta.provider or [ ];
+          children = map (i: recurse i) (aspect.includes or [ ]);
+        };
+    in
+    {
+
+      test-top-level-has-empty-provider = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo.nixos = { };
+
+          expr = (den.lib.aspects.resolve.withAdapter getProvenance "nixos" den.aspects.foo).provider;
+          expected = [ ];
+        }
+      );
+
+      test-provided-aspect-has-provider-path = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo.includes = [ den.aspects.foo._.bar ];
+          den.aspects.foo._.bar.nixos = { };
+
+          expr =
+            let
+              result = den.lib.aspects.resolve.withAdapter getProvenance "nixos" den.aspects.foo;
+            in
+            (lib.head result.children).provider;
+          expected = [ "foo" ];
+        }
+      );
+
+      test-deep-provider-chain = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo._.bar.includes = [ den.aspects.foo._.bar._.baz ];
+          den.aspects.foo._.bar._.baz.nixos = { };
+          den.aspects.foo.includes = [ den.aspects.foo._.bar ];
+
+          expr =
+            let
+              result = den.lib.aspects.resolve.withAdapter getProvenance "nixos" den.aspects.foo;
+              barResult = lib.head result.children;
+            in
+            (lib.head barResult.children).provider;
+          expected = [
+            "foo"
+            "bar"
+          ];
+        }
+      );
+
+      test-namespace-provider-root = denTest (
+        { den, ... }:
+        {
+          den.provides.myaspect.nixos = { };
+
+          expr = (den.lib.aspects.resolve.withAdapter getProvenance "nixos" den.provides.myaspect).provider;
+          expected = [
+            "den"
+            "provides"
+          ];
+        }
+      );
+
+    };
+}


### PR DESCRIPTION
**Summary**
- Adds meta.provider typed option tracking each aspect's structural origin as a path (e.g., ["foo" "bar"] for foo.provides.bar)
- providerPrefix threads through the provides submodule so child providers accumulate their parent's path
- mkAspectsType factory allows namespaces and den.provides to set their own provider root

### How it works

The provides submodule extends providerPrefix with the current aspect's name before passing it to child provider types. Namespaces set providerPrefix = [ name ] as their root. den.provides uses [ "den" "provides" ]. Top-level aspects default to [].

This lets adapters distinguish "bar provided by foo" from a top-level "bar" by inspecting aspect.meta.provider.
