### PR TITLE
fix: strip _ aliases from external denful to prevent include duplication

### DIFF
--- a/nix/lib/namespace.nix
+++ b/nix/lib/namespace.nix
@@ -8,7 +8,14 @@ let
     name
   ]) (builtins.filter builtins.isAttrs from);
 
-  sourceModules = map (denful: { config.den.ful.${name} = denful; }) denfuls;
+  # Strip _ aliases from external denful to prevent duplication on re-import.
+  # The _ → provides alias in aspectSubmodule means evaluated configs contain
+  # both _ and provides with identical content. Re-importing both causes
+  # listOf options (like includes) to merge duplicates.
+  stripAliases = lib.mapAttrs (
+    _: v: if builtins.isAttrs v then builtins.removeAttrs v [ "_" ] else v
+  );
+  sourceModules = map (denful: { config.den.ful.${name} = stripAliases denful; }) denfuls;
 
   aliasModule = lib.mkAliasOptionModule [ name ] [ "den" "ful" name ];
 

--- a/templates/ci/modules/features/deadbugs/issue-400-namespace-include-duplication.nix
+++ b/templates/ci/modules/features/deadbugs/issue-400-namespace-include-duplication.nix
@@ -1,0 +1,107 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.deadbugs-issue-400 =
+    let
+      module =
+        { inputs, ... }:
+        {
+          imports = [
+            inputs.den.flakeModule
+            (inputs.den.namespace "test" true)
+          ];
+
+          test.aspect =
+            { host }:
+            {
+              nixos.test = [ "aspect-${host.name}" ];
+            };
+
+          test.provided._.provider =
+            { host }:
+            {
+              nixos.test = [ "provider-${host.name}" ];
+            };
+
+          test.provided._.included = {
+            includes = [
+              (
+                { host }:
+                {
+                  nixos.test = [ "included-${host.name}" ];
+                }
+              )
+            ];
+          };
+        };
+
+      external-module =
+        inputs:
+        (inputs.nixpkgs.lib.evalModules {
+          specialArgs = { inherit inputs; };
+          modules = [ module ];
+        }).config.flake;
+
+      test-module.nixos.options.test = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+    in
+    {
+      test-internal-namespace = denTest (
+        {
+          test,
+          igloo,
+          ...
+        }:
+        {
+          imports = [ module ];
+
+          den.hosts.x86_64-linux.igloo.users.tux = { };
+          den.aspects.igloo.includes = [ test-module ];
+
+          den.ctx.host.includes = [
+            test.aspect
+            test.provided._.provider
+            test.provided._.included
+          ];
+
+          expr = igloo.test;
+          expected = [
+            "included-igloo"
+            "provider-igloo"
+            "aspect-igloo"
+          ];
+        }
+      );
+
+      test-external-namespace = denTest (
+        {
+          inputs,
+          test,
+          igloo,
+          ...
+        }:
+        {
+          imports = [
+            (inputs.den.namespace "test" [ (external-module inputs) ])
+          ];
+
+          den.hosts.x86_64-linux.igloo.users.tux = { };
+          den.aspects.igloo.includes = [ test-module ];
+
+          den.ctx.host.includes = [
+            test.aspect
+            test.provided._.provider
+            test.provided._.included
+          ];
+
+          expr = igloo.test;
+          expected = [
+            "included-igloo"
+            "provider-igloo"
+            "aspect-igloo"
+          ];
+        }
+      );
+    };
+}


### PR DESCRIPTION
When an external namespace's evaluated config is re-imported via den.namespace, both _ and provides contain identical content due to the _ → provides alias in aspectSubmodule. The module system merges both paths, causing listOf options like includes to duplicate entries.

Strip _ from external denful configs before assignment to den.ful.

Fixes #400