### PR TITLE
feat: forward and output resolution respects meta.adapter

### DIFF
--- a/docs/src/content/docs/reference/aspects.mdx
+++ b/docs/src/content/docs/reference/aspects.mdx
@@ -71,12 +71,90 @@ evaluated once during aspect resolution. Functions receiving context
 arguments (`{ host }`, `{ user }`, etc.) are **parametric** -- evaluated
 per context during `ctxApply`.
 
+### `meta.adapter`
+
+An aspect can declare a subtree adapter that controls how its includes
+are resolved. The adapter composes with the inherited adapter from
+parent aspects or context nodes.
+
+```nix
+den.aspects.monitoring = {
+  meta.adapter = inherited:
+    den.lib.aspects.adapters.filter (a: a.name != "noisy-exporter") inherited;
+
+  includes = [
+    den.aspects.prometheus
+    den.aspects.noisy-exporter  # filtered out
+    den.aspects.grafana
+  ];
+};
+```
+
+The adapter receives the inherited adapter and returns a new one. This
+enables composition — a parent's filter cannot be overridden by children.
+
+Adapters set on context nodes (`den.ctx.host.meta.adapter`) apply
+transitively to all aspects resolved within that context:
+
+```nix
+# Exclude "debug-tools" from all host resolution
+den.ctx.host.meta.adapter = inherited:
+  den.lib.aspects.adapters.filter (a: a.name != "debug-tools") inherited;
+```
+
+### `meta.provider`
+
+Tracks the structural origin of an aspect as a path. Top-level aspects
+have `meta.provider = []`. An aspect provided by `foo` (via
+`foo.provides.bar` or `foo._.bar`) has `meta.provider = ["foo"]`.
+Deeply nested providers accumulate: `foo._.bar._.baz` has
+`meta.provider = ["foo" "bar"]`.
+
+Adapters can use this to distinguish aspects by origin:
+
+```nix
+# Only include aspects provided by "monitoring"
+meta.adapter = inherited:
+  den.lib.aspects.adapters.filter
+    (a: lib.take 1 (a.meta.provider or []) == ["monitoring"])
+    inherited;
+```
+
 ## `den.provides` (aliased as `den._`)
 
 This is the place for Den built-in batteries, reusable aspects that serve
 as basic utilities and examples.
 
 See [Batteries Reference](/reference/batteries/).
+
+## Cross-context forwarding
+
+Entities (hosts, users, homes) expose `.resolved` — the aspect produced
+by their context pipeline. Forwards can use this to pull configuration
+from one entity into another without manually wiring context calls.
+
+When `den._.forward` is called without `fromAspect`, it defaults to
+`item.resolved`, resolving the source entity through its own context
+pipeline:
+
+```nix
+# Collect SSH host keys from all other hosts
+den.aspects.iceberg.includes = [
+  ({ host }:
+    den._.forward {
+      each = lib.filter (h: h != host) (lib.attrValues den.hosts.${host.system});
+      fromClass = _: "ssh-host-key";
+      intoClass = _: host.class; # "nixos" or "darwin"
+      intoPath = _: [ ];
+    }
+  )
+];
+```
+
+Each host in `each` is resolved via its `.resolved` attribute, and the
+`ssh-host-key` class content is forwarded into the target's OS config.
+`host.class` is the OS class name (`"nixos"`, `"darwin"`), not the
+context type.
 
 ## Class resolution
 

--- a/docs/src/content/docs/reference/ctx.mdx
+++ b/docs/src/content/docs/reference/ctx.mdx
@@ -51,6 +51,22 @@ den.ctx.host.into.user = { host }:
   map (user: { inherit host user; }) (lib.attrValues host.users);
 ```
 
+### `meta.adapter`
+
+Type: `nullOr (functionTo raw)`
+
+An adapter that controls how aspects are resolved within this context.
+Set on a context node to filter or transform aspects transitively
+during resolution.
+
+```nix
+den.ctx.host.meta.adapter = inherited:
+  den.lib.aspects.adapters.filter (a: a.name != "unwanted") inherited;
+```
+
+The adapter composes with aspect-level `meta.adapter` values — context
+adapters are outermost, aspect adapters are innermost.
+
 ### `includes`
 
 Aspect includes attached to this context type. Used by batteries to inject

--- a/docs/src/content/docs/reference/lib.mdx
+++ b/docs/src/content/docs/reference/lib.mdx
@@ -146,4 +146,31 @@ _module.args.__findFile = den.lib.__findFile;
 
 ## `den.lib.aspects`
 
-Den aspects API. Provides aspect type definitions, `resolve`, `resolve.withAdapter` and basic `adapters`
+Den aspects API. Provides aspect type definitions, `resolve`,
+`resolve.withAdapter`, and composable `adapters`.
+
+### `den.lib.aspects.resolve class aspect`
+
+Resolves an aspect for a given class (e.g., `"nixos"`), returning a
+module with `imports`. Uses `adapters.default` which honors
+`meta.adapter` on aspects.
+
+### `den.lib.aspects.resolve.withAdapter adapter class aspect`
+
+Resolves with a custom adapter instead of the default.
+
+### `den.lib.aspects.adapters`
+
+Composable adapters for `resolve.withAdapter`. Each adapter receives
+`{ aspect, class, classModule, recurse, aspect-chain, resolveChild }`
+and returns the resolved result.
+
+| Adapter | Description |
+|---------|-------------|
+| `module` | Collects class modules and recurses on includes |
+| `default` | `filterIncludes module` — the default pipeline |
+| `filter pred adapter` | Returns `{}` if `pred aspect` is false |
+| `map f adapter` | Transforms the adapter's result with `f` |
+| `mapAspect f adapter` | Transforms the aspect before passing to adapter |
+| `mapIncludes f adapter` | Transforms each include before recursion |
+| `filterIncludes adapter` | Honors `meta.adapter`, filters empty includes, tags survivors for propagation |

--- a/docs/src/content/docs/reference/schema.mdx
+++ b/docs/src/content/docs/reference/schema.mdx
@@ -96,6 +96,7 @@ den.hosts.x86_64-linux.myhost = {
 | `class` | `str` | auto | `"nixos"` or `"darwin"` based on system |
 | `aspect` | `str` | `name` | Main aspect name for this host |
 | `description` | `str` | auto | `class.hostName@system` |
+| `resolved` | `raw` | auto | Resolved aspect from context pipeline (see below) |
 | `users` | `attrsOf userType` | `{}` | User accounts on this host |
 | `instantiate` | `raw` | auto | OS builder function |
 | `intoAttr` | `listOf str` | auto | Flake output path |
@@ -130,6 +131,7 @@ Type: `attrsOf userType`
 | `userName` | `str` | `name` | System account name |
 | `classes` | `listOf str` | `[ "homeManager" ]` | Home management classes |
 | `aspect` | `str` | `name` | Main aspect name |
+| `resolved` | `raw` | auto | Resolved aspect from context pipeline (see below) |
 | `*` | `den.schema.user` options | | Options from base module |
 | `*` |  | | free-form attributes |
 
@@ -157,7 +159,26 @@ den.homes.x86_64-linux.vic = {};
 | `description` | `str` | auto | `home.userName@system` |
 | `pkgs` | `raw` | `inputs.nixpkgs.legacyPackages.$sys` | Nixpkgs instance |
 | `instantiate` | `raw` | `inputs.home-manager.lib.homeManagerConfiguration` | Builder |
+| `resolved` | `raw` | auto | Resolved aspect from context pipeline (see below) |
 | `intoAttr` | `listOf str` | `[ "homeConfigurations" name ]` | Output path |
 | `*` | `den.schema.home` options | | Options from base module |
 | `*` |  | | free-form attributes |
+
+## Entity `resolved`
+
+Every entity (host, user, home) has a `resolved` attribute — the aspect
+produced by running the entity through its context pipeline
+(`den.ctx.${kind}`). This is auto-derived and used internally by
+`mainModule` to produce the entity's final configuration.
+
+To control which aspects are included during resolution, set
+`meta.adapter` on a context node:
+
+```nix
+den.ctx.host.meta.adapter = inherited:
+  den.lib.aspects.adapters.filter (a: a.name != "unwanted") inherited;
+```
+
+This filters transitively — nested aspects reached through includes
+are also subject to the adapter.
 

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -14,12 +14,51 @@ let
       config
       ;
   };
+
+  # Schema entries auto-inject config.resolved when den.ctx.${kind} exists.
+  # Context args are derived from the entity's _module.args, filtered to
+  # known context kinds so framework args don't leak through.
+  schemaEntryType =
+    let
+      base = lib.types.deferredModule;
+    in
+    base
+    // {
+      merge =
+        loc: defs:
+        let
+          kind = lib.last loc;
+          merged = base.merge loc defs;
+          resolvedCtx =
+            { config, ... }:
+            {
+              options.resolved = lib.mkOption {
+                description = "The resolved aspect for this ${kind}, produced by den.ctx.${kind}.";
+                readOnly = true;
+                type = lib.types.raw;
+                default = den.ctx.${kind} (
+                  lib.filterAttrs (n: _: den.ctx ? ${n}) config._module.args // { ${kind} = config; }
+                );
+              };
+            };
+        in
+        if den.ctx ? ${kind} then
+          {
+            imports = [
+              merged
+              resolvedCtx
+            ];
+          }
+        else
+          merged;
+    };
+
   schemaOption = lib.mkOption {
     description = "freeform deferred modules per entity kind";
     defaultText = lib.literalExpression "{ }";
     default = { };
     type = lib.types.submodule {
-      freeformType = lib.types.lazyAttrsOf lib.types.deferredModule;
+      freeformType = lib.types.lazyAttrsOf schemaEntryType;
     };
   };
 in

--- a/nix/lib/forward.nix
+++ b/nix/lib/forward.nix
@@ -18,7 +18,8 @@ let
       intoPathFn = if lib.isFunction intoPath then intoPath else _: intoPath;
       staticIntoPath = if lib.isFunction intoPath then [ ] else intoPath;
 
-      asp = fwd.fromAspect item;
+      # Entities have .resolved (their context pipeline result); raw aspects don't.
+      asp = if fwd ? fromAspect then fwd.fromAspect item else item.resolved or item;
       sourceModule = mapModule (den.lib.aspects.resolve fromClass asp);
 
       forward =

--- a/nix/lib/types.nix
+++ b/nix/lib/types.nix
@@ -103,8 +103,8 @@ let
             visible = false;
             readOnly = true;
             type = lib.types.deferredModule;
-            defaultText = ''den.lib.aspects.resolve "nixos" (den.ctx.host { inherit host; })'';
-            default = mainModule config den.ctx.host "host";
+            defaultText = "den.lib.aspects.resolve config.class config.resolved";
+            default = den.lib.aspects.resolve config.class config.resolved;
           };
         };
       }
@@ -258,19 +258,12 @@ let
             visible = false;
             readOnly = true;
             type = lib.types.deferredModule;
-            defaultText = lib.literalExpression "mainModule";
-            default = mainModule config den.ctx.home "home";
+            defaultText = "den.lib.aspects.resolve config.class config.resolved";
+            default = den.lib.aspects.resolve config.class config.resolved;
           };
         };
       }
     );
-
-  mainModule =
-    from: intent: name:
-    let
-      asp = intent { ${name} = from; };
-    in
-    den.lib.aspects.resolve (from.class) asp;
 in
 {
   inherit hostsOption homesOption;

--- a/templates/ci/modules/features/adapter-propagation.nix
+++ b/templates/ci/modules/features/adapter-propagation.nix
@@ -1,0 +1,180 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.adapter-propagation =
+    let
+      traceName =
+        { aspect, recurse, ... }:
+        {
+          trace = [ (aspect.name or null) ] ++ map (i: (recurse i).trace or [ ]) (aspect.includes or [ ]);
+        };
+    in
+    {
+
+      # --- Aspect-level meta.adapter ---
+
+      test-resolve-honors-meta-adapter = denTest (
+        { den, ... }:
+        {
+          den.aspects.foo.includes = [ den.aspects.bar ];
+          den.aspects.foo.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: (a.name or null) != "bar") inherited;
+          den.aspects.bar.nixos = { };
+
+          expr = (den.lib.aspects.resolve "nixos" den.aspects.foo) ? imports;
+          expected = true;
+        }
+      );
+
+      test-tags-includes-with-adapter = denTest (
+        { den, ... }:
+        {
+          den.aspects.parent.includes = [ den.aspects.child ];
+          den.aspects.parent.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: (a.name or null) != "baz") inherited;
+          den.aspects.child.includes = [ den.aspects.baz ];
+          den.aspects.baz.nixos = { };
+
+          expr =
+            den.lib.aspects.resolve.withAdapter (den.lib.aspects.adapters.filterIncludes traceName) "nixos"
+              den.aspects.parent;
+          expected.trace = [
+            "parent"
+            [ "child" ]
+          ];
+        }
+      );
+
+      test-child-inherits-parent-adapter = denTest (
+        { den, ... }:
+        {
+          den.aspects.parent.includes = [ den.aspects.child ];
+          den.aspects.parent.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: (a.name or null) != "excluded") inherited;
+          den.aspects.child.includes = [
+            den.aspects.kept
+            den.aspects.excluded
+          ];
+          den.aspects.kept.nixos = { };
+          den.aspects.excluded.nixos = { };
+
+          expr =
+            den.lib.aspects.resolve.withAdapter (den.lib.aspects.adapters.filterIncludes traceName) "nixos"
+              den.aspects.parent;
+          expected.trace = [
+            "parent"
+            [
+              "child"
+              [ "kept" ]
+            ]
+          ];
+        }
+      );
+
+      test-deep-chain-a-excludes-c-through-b = denTest (
+        { den, ... }:
+        {
+          den.aspects.a.includes = [ den.aspects.b ];
+          den.aspects.a.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: (a.name or null) != "c") inherited;
+          den.aspects.b.includes = [
+            den.aspects.c
+            den.aspects.d
+          ];
+          den.aspects.c.nixos = { };
+          den.aspects.d.nixos = { };
+
+          expr =
+            den.lib.aspects.resolve.withAdapter (den.lib.aspects.adapters.filterIncludes traceName) "nixos"
+              den.aspects.a;
+          expected.trace = [
+            "a"
+            [
+              "b"
+              [ "d" ]
+            ]
+          ];
+        }
+      );
+
+      test-diamond-a-excludes-d-through-both-paths = denTest (
+        { den, ... }:
+        {
+          den.aspects.a.includes = [
+            den.aspects.b
+            den.aspects.c
+          ];
+          den.aspects.a.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: (a.name or null) != "d") inherited;
+          den.aspects.b.includes = [ den.aspects.d ];
+          den.aspects.c.includes = [ den.aspects.d ];
+          den.aspects.d.nixos = { };
+
+          expr =
+            den.lib.aspects.resolve.withAdapter (den.lib.aspects.adapters.filterIncludes traceName) "nixos"
+              den.aspects.a;
+          expected.trace = [
+            "a"
+            [ "b" ]
+            [ "c" ]
+          ];
+        }
+      );
+
+      # --- Context-level meta.adapter ---
+
+      test-ctx-carries-meta-adapter = denTest (
+        { den, ... }:
+        {
+          den.hosts.x86_64-linux.igloo = { };
+
+          den.ctx.host.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: a.name != "foo") inherited;
+
+          expr = (den.ctx.host { host = den.hosts.x86_64-linux.igloo; }).meta.adapter != null;
+          expected = true;
+        }
+      );
+
+      test-ctx-meta-adapter-null-when-unset = denTest (
+        { den, ... }:
+        {
+          den.hosts.x86_64-linux.igloo = { };
+
+          expr = (den.ctx.host { host = den.hosts.x86_64-linux.igloo; }).meta.adapter;
+          expected = null;
+        }
+      );
+
+      # --- Cross-stage: host adapter filters at user level ---
+
+      # Host context adapter transitively filters nested aspects.
+      # blocked-deep is two levels below igloo but still excluded.
+      test-ctx-host-adapter-filters-transitively = denTest (
+        { den, igloo, ... }:
+        {
+          den.hosts.x86_64-linux.igloo.users.tux = { };
+
+          den.ctx.host.meta.adapter =
+            inherited: den.lib.aspects.adapters.filter (a: (a.name or null) != "blocked") inherited;
+
+          den.aspects.igloo.includes = [ den.aspects.parent ];
+          den.aspects.parent.includes = [
+            den.aspects.allowed
+            den.aspects.blocked
+          ];
+          den.aspects.allowed.nixos.environment.sessionVariables.ALLOWED = "yes";
+          den.aspects.blocked.nixos.environment.sessionVariables.BLOCKED = "yes";
+
+          expr = {
+            hasAllowed = igloo.environment.sessionVariables ? ALLOWED;
+            hasBlocked = igloo.environment.sessionVariables ? BLOCKED;
+          };
+          expected = {
+            hasAllowed = true;
+            hasBlocked = false;
+          };
+        }
+      );
+
+    };
+}

--- a/templates/ci/modules/features/cross-context-forward.nix
+++ b/templates/ci/modules/features/cross-context-forward.nix
@@ -1,0 +1,280 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.cross-context-forward = {
+
+    test-resolve-other-host-context = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+        den.hosts.x86_64-linux.iceberg = { };
+
+        den.aspects.igloo.nixos.environment.sessionVariables.FROM_IGLOO = "yes";
+
+        expr =
+          let
+            iglooCtx = den.ctx.host { host = den.hosts.x86_64-linux.igloo; };
+            resolved = den.lib.aspects.resolve "nixos" iglooCtx;
+          in
+          resolved ? imports;
+        expected = true;
+      }
+    );
+
+    test-entities-have-resolved = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.homes.x86_64-linux.cabin = { };
+
+        expr = {
+          host = den.hosts.x86_64-linux.igloo ? resolved;
+          user = den.hosts.x86_64-linux.igloo.users.tux ? resolved;
+          home = den.homes.x86_64-linux.cabin ? resolved;
+        };
+        expected = {
+          host = true;
+          user = true;
+          home = true;
+        };
+      }
+    );
+
+    test-user-resolved-produces-aspect = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.tux =
+          { host, user }:
+          {
+            nixos.environment.sessionVariables.USER_HOST = "${user.userName}@${host.hostName}";
+          };
+
+        expr =
+          let
+            user = den.hosts.x86_64-linux.igloo.users.tux;
+            resolved = den.lib.aspects.resolve "nixos" user.resolved;
+          in
+          resolved ? imports;
+        expected = true;
+      }
+    );
+
+    test-cross-context-forward-with-ctx = denTest (
+      { den, iceberg, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+        den.hosts.x86_64-linux.iceberg = { };
+
+        den.aspects.igloo.ssh-host-key.environment.sessionVariables.FROM_IGLOO = "yes";
+
+        den.aspects.iceberg.includes = [
+          (
+            { host }:
+            den._.forward {
+              each = lib.filter (h: h != host) (lib.attrValues den.hosts.${host.system});
+              fromClass = _: "ssh-host-key";
+              intoClass = _: host.class;
+              intoPath = _: [ ];
+            }
+          )
+        ];
+
+        expr = iceberg.environment.sessionVariables ? FROM_IGLOO;
+        expected = true;
+      }
+    );
+
+    test-forward-each-filter-excludes-self = denTest (
+      { den, iceberg, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+        den.hosts.x86_64-linux.iceberg = { };
+
+        den.aspects.igloo.test-class.environment.sessionVariables.FROM_IGLOO = "yes";
+        den.aspects.iceberg.test-class.environment.sessionVariables.FROM_ICEBERG = "yes";
+
+        den.aspects.iceberg.includes = [
+          (
+            { host }:
+            den._.forward {
+              each = lib.filter (h: h != host) (lib.attrValues den.hosts.${host.system});
+              fromClass = _: "test-class";
+              intoClass = _: host.class;
+              intoPath = _: [ ];
+            }
+          )
+        ];
+
+        expr = {
+          hasIgloo = iceberg.environment.sessionVariables ? FROM_IGLOO;
+          hasIceberg = iceberg.environment.sessionVariables ? FROM_ICEBERG;
+        };
+        expected = {
+          hasIgloo = true;
+          hasIceberg = false;
+        };
+      }
+    );
+
+    test-cross-context-adapter-data-collection = denTest (
+      { den, iceberg, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+        den.hosts.x86_64-linux.iceberg = { };
+
+        den.aspects.igloo.meta.sshKey = "ssh-ed25519 AAAA igloo";
+
+        den.aspects.iceberg.includes = [
+          (
+            { host }:
+            let
+              otherHosts = lib.filter (h: h != host) (lib.attrValues den.hosts.${host.system});
+              collectKeys = lib.concatMap (
+                srcHost:
+                let
+                  traceMeta =
+                    { aspect, recurse, ... }:
+                    {
+                      keys =
+                        lib.optional (aspect.meta.sshKey or null != null) {
+                          host = aspect.name or "unknown";
+                          key = aspect.meta.sshKey;
+                        }
+                        ++ lib.concatMap (i: (recurse i).keys or [ ]) (aspect.includes or [ ]);
+                    };
+                  result = den.lib.aspects.resolve.withAdapter traceMeta srcHost.class srcHost.resolved;
+                in
+                result.keys or [ ]
+              ) otherHosts;
+            in
+            {
+              nixos.environment.sessionVariables.COLLECTED_KEYS = lib.concatStringsSep "," (
+                map (k: k.key) collectKeys
+              );
+            }
+          )
+        ];
+
+        expr = iceberg.environment.sessionVariables.COLLECTED_KEYS;
+        expected = "ssh-ed25519 AAAA igloo";
+      }
+    );
+
+    test-host-hm-aspects-forward-to-primary-user = denTest (
+      { den, igloo, ... }:
+      {
+        den.schema.user.classes = [ "homeManager" ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # Host-level aspect defines homeManager config
+        # tux does NOT explicitly include this
+        den.aspects.shared-hm = {
+          homeManager.programs.git.enable = true;
+        };
+
+        # Forward: collect all homeManager content from host resolution,
+        # inject into primary user's home-manager path
+        den.aspects.igloo.includes = [
+          den.aspects.shared-hm
+          (
+            { host }:
+            let
+              primaryUser =
+                lib.findFirst (u: true) # first user as "primary"
+                  null
+                  (lib.attrValues host.users);
+            in
+            lib.optionalAttrs (primaryUser != null) (
+              den._.forward {
+                each = lib.singleton host;
+                fromAspect = h: den.lib.parametric.fixedTo { host = h; } den.aspects.${h.aspect};
+                fromClass = _: "homeManager";
+                intoClass = _: host.class;
+                intoPath = _: [
+                  "home-manager"
+                  "users"
+                  primaryUser.userName
+                ];
+              }
+            )
+          )
+        ];
+
+        expr = igloo.home-manager.users.tux.programs.git.enable;
+        expected = true;
+      }
+    );
+
+    test-forward-hm-from-other-host-to-local-user = denTest (
+      { den, iceberg, ... }:
+      {
+        den.schema.user.classes = [ "homeManager" ];
+        den.hosts.x86_64-linux.igloo = { };
+        den.hosts.x86_64-linux.iceberg.users.pingu = { };
+
+        # igloo has homeManager aspects — pingu on iceberg doesn't include them
+        den.aspects.igloo.includes = [ den.aspects.igloo-hm-stuff ];
+        den.aspects.igloo-hm-stuff.homeManager.programs.firefox.enable = true;
+
+        # iceberg forwards igloo's homeManager content into pingu
+        den.aspects.iceberg.includes = [
+          (
+            { host }:
+            let
+              igloo = den.hosts.x86_64-linux.igloo;
+              user = lib.head (lib.attrValues host.users);
+            in
+            den._.forward {
+              each = lib.singleton igloo;
+              fromClass = _: "homeManager";
+              intoClass = _: host.class;
+              intoPath = _: [
+                "home-manager"
+                "users"
+                user.userName
+              ];
+            }
+          )
+        ];
+
+        expr = iceberg.home-manager.users.pingu.programs.firefox.enable;
+        expected = true;
+      }
+    );
+
+    test-forward-carries-source-context-data = denTest (
+      { den, iceberg, ... }:
+      {
+        den.schema.user.classes = [ "homeManager" ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.iceberg = { };
+
+        # igloo has an aspect with a custom class carrying host-specific data
+        den.aspects.igloo.includes = [ den.aspects.igloo-identity ];
+        den.aspects.igloo-identity =
+          { host }:
+          {
+            host-identity.environment.sessionVariables.SOURCE_HOST = host.hostName;
+          };
+
+        # iceberg pulls igloo's host-identity class content into its own nixos
+        den.aspects.iceberg.includes = [
+          (
+            { host }:
+            den._.forward {
+              each = lib.singleton den.hosts.x86_64-linux.igloo;
+              fromClass = _: "host-identity";
+              intoClass = _: host.class;
+              intoPath = _: [ ];
+            }
+          )
+        ];
+
+        # Verify the forwarded value actually comes from igloo's context
+        expr = iceberg.environment.sessionVariables.SOURCE_HOST;
+        expected = "igloo";
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Summary
- Entities automatically expose `.resolved` — the result of their context pipeline — derived from the schema type system
- `forward.nix` defaults to `item.resolved` when `fromAspect` is absent, enabling cross-context forwarding without manual wiring
- `mainModule` helper eliminated — entity types resolve directly via `config.resolved`

## What changed
**options.nix** — `schemaEntryType` wraps `deferredModule` to auto-inject `config.resolved` for any schema entry where `den.ctx.${kind}` exists. Context args are derived from the entity's `_module.args`, filtered to known context kinds. No per-entity boilerplate — host, user, and home all get `.resolved` automatically.

**types.nix** — `mainModule` helper removed. Both host and home `mainModule` options simplified to `den.lib.aspects.resolve config.class config.resolved`.

**forward.nix** — `asp` falls back to `item.resolved or item` when `fromAspect` is absent.

## How context adapters flow through forwards
`den.ctx.host.meta.adapter` is carried through `ctxApply` (via `withIdentity` from #398) onto `.resolved`. When `resolve` processes it, `adapters.filterIncludes` (from #397) picks up the adapter and applies it transitively to the entire subtree — including nested aspects reached through forwards.
