### PR TITLE
BUG: aspect being called as if it was a module-function

### DIFF
--- a/templates/bogus/modules/bug.nix
+++ b/templates/bogus/modules/bug.nix
@@ -14,11 +14,30 @@
         # replace <system> if you are reporting a bug in MacOS
         den.hosts.x86_64-linux.igloo.users.tux = { };
 
-        # do something for testing
-        den.aspects.tux.user.description = "The Penguin";
+        den.aspects.igloo.includes = [ den.aspects.foo ];
 
-        expr = igloo.users.users.tux.description;
-        expected = "The Penguin";
+        imports = 
+        let
+          one = {
+            den.aspects.foo = { host, ... }: {
+              nixos.environment.sessionVariables.FOO = host.name;
+            };
+          };
+
+          two = {
+            den.aspects.foo.nixos = { pkgs, ... }: {
+              environment.systemPackages = [ pkgs.hello ];
+            };
+          };
+        in
+        [ one two ];
+
+        expr = {
+          hello = lib.elem "hello" (map lib.getName igloo.environment.systemPackages);
+          FOO = igloo.environment.sessionVariables.FOO;
+        };
+        expected.FOO = "igloo";
+        expected.hello = true;
       }
     );
 


### PR DESCRIPTION
EDIT: we need a new CI action that runs bogus when it detect we change a .nix file on templates/bogus. Instead of having to approve this for templates to run at CI. #246 

Fails with

```console
       error: attribute 'host' missing
       at /nix/store/2n2i983z59kjmw707xpddjdywyk8vn2g-source/lib/modules.nix:726:13:
          725|             "noting that argument `${name}` is not externally provided, so querying `_module.args` instead, requiring `config`"
          726|             config._module.args.${name}
             |             ^
          727|           )
```