### PR TITLE
feat: tombstones, identity paths, and substitution in filterIncludes

### DIFF
--- a/nix/lib/aspects/adapters.nix
+++ b/nix/lib/aspects/adapters.nix
@@ -1,16 +1,12 @@
-# Adapters for resolve.withAdapter. Default one is module.
+# Adapters for resolve.withAdapter. Default adapter is module.
 #
-# These adapters determine the return value of resolve. The adapters
-# are called by resolve for each resolved aspect, and the adapter can choose
-# to recurse or to replace which aspects will be used.
+# Adapters determine the return value of resolve. They are called for each
+# resolved aspect and can recurse into includes, filter, or transform them.
 #
-# Only basic adapters are provided here, see the arguments given by resolve.nix to them.
-# Some adapters compose by taking other adapters as parameters.
+# See resolve.nix for the arguments passed to adapters:
+#   { aspect, class, classModule, recurse, aspect-chain, resolveChild }
 { lib, ... }:
 let
-
-  # Default adapter used by `resolve`.
-  default = filterIncludes module;
 
   # Produces a single module importing all classModules from aspect and its includes.
   module =
@@ -21,31 +17,68 @@ let
       ...
     }:
     {
-      imports = classModule ++ (lib.concatMap (i: (recurse i).imports or [ ]) (aspect.includes or [ ]));
+      imports = classModule ++ lib.concatMap (i: (recurse i).imports or [ ]) (aspect.includes or [ ]);
     };
 
+  # Conditionally apply adapter. Returns { } when pred fails (signals exclusion).
   filter =
     pred: adapter: args:
     if pred args.aspect then adapter args else { };
 
-  # transforms the result of other adapters using f.
+  # Post-process adapter result.
   map =
     f: adapter: args:
     f (adapter args);
 
-  # transform each aspect into another by applying f to it.
+  # Transform the aspect before passing to inner adapter.
   mapAspect =
     f: adapter: args:
     adapter (args // { aspect = f args.aspect; });
 
-  # transforms aspect includes by applying f to it.
+  # Transform includes before recursion.
   mapIncludes =
     f: adapter: args:
-    adapter (args // { recurse = included: args.recurse (f included); });
+    adapter (args // { recurse = i: args.recurse (f i); });
 
-  # Handles per-aspect adapter accumulation via meta.adapter.
-  # Composes meta.adapter with the inner adapter, removes includes that
-  # would resolve to { }, and tags survivors for downstream propagation.
+  # Derive an aspect's identity path from name and provider.
+  # Use instead of reference equality — resolved aspects are fresh attrsets.
+  aspectPath = a: (a.meta.provider or [ ]) ++ [ (a.name or "<anon>") ];
+
+  # Exclude by aspect reference.
+  excludeAspect = ref: filter (a: aspectPath a != aspectPath ref);
+
+  # Substitute an aspect reference with a replacement.
+  substituteAspect =
+    ref: replacement: mapAspect (a: if aspectPath a == aspectPath ref then replacement else a);
+
+  # Empty aspect marking an excluded include. ~prefix prevents accidental
+  # name collisions with live aspects. Harmless to module, visible to trace.
+  # Consumers should check meta.excluded before accessing other aspect fields.
+  tombstone =
+    resolved: extra:
+    let
+      n = resolved.name or "<anon>";
+    in
+    {
+      name = "~${n}";
+      meta =
+        (resolved.meta or { })
+        // {
+          excluded = true;
+          originalName = n;
+        }
+        // extra;
+    };
+
+  # Extract what a metaAdapter transforms an aspect to (for substitution detection).
+  # Assumes metaAdapter eventually calls its inner adapter exactly once.
+  probeTransform =
+    metaAdapter: args: resolved:
+    (metaAdapter (_: { _probed = _.aspect; }) (args // { aspect = resolved; }))._probed or resolved;
+
+  # Handles per-aspect meta.adapter composition. Probes each include to
+  # determine: keep, exclude (tombstone), or substitute (tombstone + replacement).
+  # Tags survivors with the adapter for downstream propagation.
   filterIncludes =
     inner:
     args@{ aspect, resolveChild, ... }:
@@ -55,18 +88,33 @@ let
     if metaAdapter != null && aspect ? includes then
       let
         composed = metaAdapter (filterIncludes inner);
-        keeps =
+
+        processInclude =
           i:
-          composed (
-            args
-            // {
-              aspect = resolveChild i;
-              classModule = [ ];
-            }
-          ) != { };
+          let
+            resolved = resolveChild i;
+            result = composed (
+              args
+              // {
+                aspect = resolved;
+                classModule = [ ];
+              }
+            );
+            probed = probeTransform metaAdapter args resolved;
+          in
+          if result == { } then
+            [ (tombstone resolved { }) ]
+          else if aspectPath probed != aspectPath resolved then
+            [
+              (tombstone resolved { replacedBy = probed.name or "<anon>"; })
+              probed
+            ]
+          else
+            [ i ];
+
         tag =
           i:
-          if builtins.isAttrs i && i.meta.adapter or null == null then
+          if builtins.isAttrs i && i.meta.adapter or null == null && !(i.meta.excluded or false) then
             i
             // {
               meta = (i.meta or { }) // {
@@ -80,32 +128,38 @@ let
         args
         // {
           aspect = aspect // {
-            includes = builtins.map tag (lib.filter keeps aspect.includes);
+            includes = builtins.map tag (lib.concatMap processInclude aspect.includes);
           };
         }
       )
     else
       inner args;
 
-  # Utility for debugging. Traces aspect.name as nested lists per includes.
-  traceName =
+  default = filterIncludes module;
+
+  # Traces aspect.name as nested lists per includes. Composed with filterIncludes
+  # so tombstones and substitutions are visible.
+  trace = filterIncludes (
     { aspect, recurse, ... }:
     {
       trace = [ aspect.name ] ++ builtins.map (i: (recurse i).trace or [ ]) (aspect.includes or [ ]);
-    };
+    }
+  );
 
-  trace = filterIncludes traceName;
 in
 {
   inherit
+    aspectPath
     default
+    excludeAspect
     filter
     filterIncludes
     map
     mapAspect
     mapIncludes
     module
+    substituteAspect
+    tombstone
     trace
-    traceName
     ;
 }

--- a/templates/ci/modules/features/adapter-propagation.nix
+++ b/templates/ci/modules/features/adapter-propagation.nix
@@ -27,9 +27,13 @@
         den.aspects.baz.nixos = { };
 
         expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.parent;
+        # baz tombstone visible in trace
         expected.trace = [
           "parent"
-          [ "child" ]
+          [
+            "child"
+            [ "~baz" ]
+          ]
         ];
       }
     );
@@ -53,6 +57,7 @@
           [
             "child"
             [ "kept" ]
+            [ "~excluded" ]
           ]
         ];
       }
@@ -76,6 +81,7 @@
           "a"
           [
             "b"
+            [ "~c" ]
             [ "d" ]
           ]
         ];
@@ -98,8 +104,14 @@
         expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.a;
         expected.trace = [
           "a"
-          [ "b" ]
-          [ "c" ]
+          [
+            "b"
+            [ "~d" ]
+          ]
+          [
+            "c"
+            [ "~d" ]
+          ]
         ];
       }
     );

--- a/templates/ci/modules/features/aspect-adapter.nix
+++ b/templates/ci/modules/features/aspect-adapter.nix
@@ -15,9 +15,11 @@
         den.aspects.baz.nixos = { };
 
         expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.foo;
+        # baz tombstone visible in trace
         expected.trace = [
           "foo"
           [ "bar" ]
+          [ "~baz" ]
         ];
       }
     );
@@ -36,6 +38,7 @@
         den.aspects.baz.nixos = { };
 
         expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.root;
+        # foo's adapter only affects its subtree; root's baz is unaffected
         expected.trace = [
           "root"
           [
@@ -62,11 +65,15 @@
         expr =
           let
             inherit (den.lib.aspects) resolve adapters;
-            outerAdapter = adapters.filter (a: a.name != "baz") adapters.traceName;
+            outerTrace = adapters.filter (a: a.name != "baz") adapters.trace;
           in
-          resolve.withAdapter (adapters.filterIncludes outerAdapter) "nixos" den.aspects.foo;
+          resolve.withAdapter outerTrace "nixos" den.aspects.foo;
+        # bar tombstoned by meta.adapter, baz killed by outer filter (no tombstone
+        # since the outer filter is not wrapped in filterIncludes)
         expected.trace = [
           "foo"
+          [ "~bar" ]
+          [ ]
         ];
       }
     );

--- a/templates/ci/modules/features/aspect-path.nix
+++ b/templates/ci/modules/features/aspect-path.nix
@@ -1,0 +1,199 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.aspect-path = {
+
+    test-aspectPath-named = denTest (
+      { den, ... }:
+      {
+        den.aspects.foo.nixos = { };
+        expr = den.lib.aspects.adapters.aspectPath den.aspects.foo;
+        expected = [ "foo" ];
+      }
+    );
+
+    test-aspectPath-with-provider = denTest (
+      { den, ... }:
+      {
+        den.aspects.monitoring = {
+          nixos = { };
+          provides.node-exporter.nixos = { };
+        };
+        expr = den.lib.aspects.adapters.aspectPath den.aspects.monitoring._.node-exporter;
+        expected = [
+          "monitoring"
+          "node-exporter"
+        ];
+      }
+    );
+
+    # excludeAspect: excluded include becomes a tombstone (visible in trace)
+    test-excludeAspect-tombstone-in-trace = denTest (
+      { den, ... }:
+      {
+        den.aspects.foo.includes = [
+          den.aspects.bar
+          den.aspects.baz
+        ];
+        den.aspects.foo.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.baz inherited;
+        den.aspects.bar.nixos = { };
+        den.aspects.baz.nixos = { };
+
+        expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.foo;
+        # baz appears as tombstone (~baz, no children)
+        expected.trace = [
+          "foo"
+          [ "bar" ]
+          [ "~baz" ]
+        ];
+      }
+    );
+
+    # excludeAspect: tombstone contributes no modules to the build
+    test-excludeAspect-no-modules = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+        den.aspects.igloo.includes = [
+          den.aspects.bar
+          den.aspects.baz
+        ];
+        den.aspects.igloo.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.baz inherited;
+        den.aspects.bar.nixos.environment.sessionVariables.msg = "bar";
+        den.aspects.baz.nixos.environment.sessionVariables.msg = "baz";
+
+        # only bar's module is included, baz is excluded
+        expr = igloo.environment.sessionVariables.msg;
+        expected = "bar";
+      }
+    );
+
+    # excludeAspect: propagates through subtree
+    test-excludeAspect-propagates-to-subtree = denTest (
+      { den, ... }:
+      {
+        den.aspects.root.includes = [ den.aspects.role ];
+        den.aspects.root.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.baz inherited;
+        den.aspects.role.includes = [
+          den.aspects.bar
+          den.aspects.baz
+        ];
+        den.aspects.bar.nixos = { };
+        den.aspects.baz.nixos = { };
+
+        expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.root;
+        # baz tombstone appears in role's subtree
+        expected.trace = [
+          "root"
+          [
+            "role"
+            [ "bar" ]
+            [ "~baz" ]
+          ]
+        ];
+      }
+    );
+
+    # excludeAspect: by provider path
+    test-excludeAspect-by-provider = denTest (
+      { den, ... }:
+      {
+        den.aspects.monitoring = {
+          nixos = { };
+          provides.node-exporter.nixos = { };
+          provides.alerting.nixos = { };
+        };
+        den.aspects.server.includes = with den.aspects; [
+          monitoring
+          monitoring._.node-exporter
+          monitoring._.alerting
+        ];
+        den.aspects.server.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.monitoring._.node-exporter inherited;
+
+        expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.server;
+        # node-exporter tombstone visible, alerting kept
+        expected.trace = [
+          "server"
+          [ "monitoring" ]
+          [ "~node-exporter" ]
+          [ "alerting" ]
+        ];
+      }
+    );
+
+    # substituteAspect: replaced include becomes tombstone + replacement
+    test-substituteAspect-replaces = denTest (
+      { den, ... }:
+      {
+        den.aspects.foo.includes = [
+          den.aspects.bar
+          den.aspects.baz
+        ];
+        den.aspects.foo.meta.adapter =
+          inherited: den.lib.aspects.adapters.substituteAspect den.aspects.bar den.aspects.qux inherited;
+        den.aspects.bar.nixos = { };
+        den.aspects.baz.nixos = { };
+        den.aspects.qux.nixos = { };
+
+        expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.foo;
+        # bar tombstone + qux replacement, baz unchanged
+        expected.trace = [
+          "foo"
+          [ "~bar" ]
+          [ "qux" ]
+          [ "baz" ]
+        ];
+      }
+    );
+
+    # substituteAspect: replacement modules are used in build
+    test-substituteAspect-build-uses-replacement = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+        den.aspects.igloo.includes = [ den.aspects.bar ];
+        den.aspects.igloo.meta.adapter =
+          inherited: den.lib.aspects.adapters.substituteAspect den.aspects.bar den.aspects.qux inherited;
+        den.aspects.bar.nixos.environment.sessionVariables.msg = "bar";
+        den.aspects.qux.nixos.environment.sessionVariables.msg = "qux";
+
+        # qux's module is used, not bar's
+        expr = igloo.environment.sessionVariables.msg;
+        expected = "qux";
+      }
+    );
+
+    # substituteAspect: propagates through subtree
+    test-substituteAspect-propagates = denTest (
+      { den, ... }:
+      {
+        den.aspects.root.includes = [ den.aspects.role ];
+        den.aspects.root.meta.adapter =
+          inherited: den.lib.aspects.adapters.substituteAspect den.aspects.baz den.aspects.qux inherited;
+        den.aspects.role.includes = [
+          den.aspects.bar
+          den.aspects.baz
+        ];
+        den.aspects.bar.nixos = { };
+        den.aspects.baz.nixos = { };
+        den.aspects.qux.nixos = { };
+
+        expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.root;
+        # baz tombstone + qux in role's subtree
+        expected.trace = [
+          "root"
+          [
+            "role"
+            [ "bar" ]
+            [ "~baz" ]
+            [ "qux" ]
+          ]
+        ];
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/resolve-adapters.nix
+++ b/templates/ci/modules/features/resolve-adapters.nix
@@ -10,7 +10,7 @@
         den.aspects.bar.includes = [ den.aspects.baz ];
         den.aspects.baz.nixos = { };
 
-        expr = with den.lib.aspects; resolve.withAdapter adapters.traceName "nixos" den.aspects.foo;
+        expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.foo;
         expected.trace = [
           "foo"
           [
@@ -32,8 +32,7 @@
         expr =
           let
             inherit (den.lib.aspects) resolve adapters;
-            notBar = adapters.filter (aspect: aspect.name != "bar");
-            composed = notBar adapters.traceName;
+            composed = adapters.filter (aspect: aspect.name != "bar") adapters.trace;
           in
           resolve.withAdapter composed "nixos" den.aspects.foo;
         expected.trace = [


### PR DESCRIPTION
filterIncludes now produces tombstones (~name, meta.excluded) for excluded includes instead of silently dropping them. Tombstones are empty aspects harmless to module but visible to trace/debug adapters.

Substituted includes produce a tombstone for the original plus the replacement, enabling both to appear in traces.

New adapters:
- aspectPath: derive identity from name + provider (replaces == on aspects)
- excludeAspect: exclude by aspect reference via path comparison
- substituteAspect: substitute by aspect reference via mapAspect + path
- tombstone: create a tombstone from a resolved aspect (exported utility)