### PR TITLE
fix: excludeAspect cascades to provider sub-aspects

### DIFF
--- a/nix/lib/aspects/adapters.nix
+++ b/nix/lib/aspects/adapters.nix
@@ -44,8 +44,20 @@ let
   # Use instead of reference equality — resolved aspects are fresh attrsets.
   aspectPath = a: (a.meta.provider or [ ]) ++ [ (a.name or "<anon>") ];
 
-  # Exclude by aspect reference.
-  excludeAspect = ref: filter (a: aspectPath a != aspectPath ref);
+  # Exclude by aspect reference. Also excludes aspects provided by the
+  # reference (e.g., excluding monitoring also excludes monitoring._.node-exporter).
+  excludeAspect =
+    ref:
+    let
+      refPath = aspectPath ref;
+    in
+    filter (
+      a:
+      let
+        ap = aspectPath a;
+      in
+      ap != refPath && lib.take (builtins.length refPath) ap != refPath
+    );
 
   # Substitute an aspect reference with a replacement.
   substituteAspect =

--- a/templates/ci/modules/features/aspect-path.nix
+++ b/templates/ci/modules/features/aspect-path.nix
@@ -124,6 +124,34 @@
       }
     );
 
+    # excludeAspect: excluding a parent also excludes its providers
+    test-excludeAspect-cascades-to-providers = denTest (
+      { den, ... }:
+      {
+        den.aspects.monitoring = {
+          nixos = { };
+          provides.node-exporter.nixos = { };
+          provides.alerting.nixos = { };
+        };
+        den.aspects.server.includes = with den.aspects; [
+          monitoring
+          monitoring._.node-exporter
+          monitoring._.alerting
+        ];
+        den.aspects.server.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.monitoring inherited;
+
+        expr = with den.lib.aspects; resolve.withAdapter adapters.trace "nixos" den.aspects.server;
+        # monitoring and all its providers excluded
+        expected.trace = [
+          "server"
+          [ "~monitoring" ]
+          [ "~node-exporter" ]
+          [ "~alerting" ]
+        ];
+      }
+    );
+
     # substituteAspect: replaced include becomes tombstone + replacement
     test-substituteAspect-replaces = denTest (
       { den, ... }:


### PR DESCRIPTION
`excludeAspect` now checks if the reference's `aspectPath` is a prefix of the aspect's path. Excluding `monitoring` also excludes `monitoring._.node-exporter`, `monitoring._.alerting`, etc.