### PR TITLE
fix: provider sub-aspect functions receive parametric context

### DIFF
--- a/nix/lib/parametric.nix
+++ b/nix/lib/parametric.nix
@@ -20,6 +20,37 @@ let
     }
     // extra;
 
+  # When takeFn succeeds and returns a result with sub-includes,
+  # also try to resolve those sub-includes with takeFn. This handles
+  # provider sub-aspect functions nested inside include results:
+  # e.g. wrapped_fn returns { includes = [foo._.sub]; } where foo._.sub
+  # needs parametric context applied before reaching the static pipeline.
+  applyDeep =
+    takeFn: ctx: fn:
+    let
+      r = takeFn fn ctx;
+      # Bare provider results carry only includes (+ name from carryAttrs).
+      # Results from withOwn/withIdentity have meta; deferred deepRecurse
+      # wrappers have __functor. Re-resolving either would double-apply
+      # context and duplicate modules.
+      isBareResult = builtins.isAttrs r && r ? includes && !(r ? meta) && !(r ? __functor);
+    in
+    if r == { } then
+      r
+    else if isBareResult then
+      r
+      // {
+        includes = map (
+          sub:
+          let
+            sr = takeFn sub ctx;
+          in
+          if sr != { } then sr else sub
+        ) r.includes;
+      }
+    else
+      r;
+
   parametric.applyIncludes =
     takeFn: aspect:
     aspect
@@ -27,7 +58,7 @@ let
       __functor =
         self: ctx:
         withIdentity self {
-          includes = builtins.filter (x: x != { }) (map (fn: takeFn fn ctx) (self.includes or [ ]));
+          includes = builtins.filter (x: x != { }) (map (applyDeep takeFn ctx) (self.includes or [ ]));
         };
     };
 

--- a/templates/ci/modules/features/deadbugs/issue-413-provider-bare-function.nix
+++ b/templates/ci/modules/features/deadbugs/issue-413-provider-bare-function.nix
@@ -1,0 +1,52 @@
+# Provider sub-aspect as bare function with host context.
+# https://github.com/vic/den/pull/413
+{ denTest, lib, ... }:
+{
+  flake.tests.deadbugs-issue-413 = {
+    test-provider-sub-aspect-bare-function = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports =
+          let
+            a = {
+              den.aspects.foo =
+                { host, ... }:
+                {
+                  includes = lib.optionals (host.foo._.sub.enable == true) [
+                    den.aspects.foo._.sub
+                  ];
+                };
+            };
+            b = {
+              den.schema.host.options.foo._.sub.enable = lib.mkEnableOption "sub-aspect toggle";
+            };
+            c = {
+              den.hosts.x86_64-linux.igloo.foo._.sub.enable = true;
+            };
+            d = {
+              den.aspects.foo._.sub =
+                { host, ... }:
+                {
+                  nixos = lib.optionalAttrs (host.hostName != "whatever") {
+                    networking.networkmanager.enable = true;
+                  };
+                };
+            };
+          in
+          [
+            a
+            b
+            c
+            d
+          ];
+
+        den.aspects.igloo.includes = [ den.aspects.foo ];
+
+        expr = igloo.networking.networkmanager.enable;
+        expected = true;
+      }
+    );
+  };
+}

--- a/templates/ci/modules/features/deadbugs/issue-413-provider-sub-aspect-function.nix
+++ b/templates/ci/modules/features/deadbugs/issue-413-provider-sub-aspect-function.nix
@@ -1,0 +1,36 @@
+# Simplified variant of issue-413 provider sub-aspect bug.
+# https://github.com/vic/den/pull/413
+{ denTest, ... }:
+{
+  flake.tests.deadbugs-issue-413 = {
+
+    # Parametric parent unconditionally includes parametric sub
+    test-parametric-parent-parametric-sub = denTest (
+      { den, igloo, ... }:
+      {
+        imports = [
+          {
+            den.aspects.foo =
+              { host, ... }:
+              {
+                includes = [ den.aspects.foo._.sub ];
+              };
+          }
+          {
+            den.aspects.foo._.sub =
+              { host, ... }:
+              {
+                nixos.networking.networkmanager.enable = true;
+              };
+          }
+        ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.includes = [ den.aspects.foo ];
+
+        expr = igloo.networking.networkmanager.enable;
+        expected = true;
+      }
+    );
+  };
+}

--- a/templates/ci/modules/features/provides-parametric.nix
+++ b/templates/ci/modules/features/provides-parametric.nix
@@ -42,4 +42,70 @@
 
   };
 
+  # Bare function sub-aspects receive parametric context from parent.
+  flake.tests.provides-parametric-bare-fn = {
+
+    test-bare-fn-sub-aspect-receives-host = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.monitoring =
+              { host, ... }:
+              {
+                includes = [ den.aspects.monitoring._.node-exporter ];
+              };
+          }
+          {
+            den.aspects.monitoring._.node-exporter =
+              { host, ... }:
+              {
+                nixos.networking.hostName = "${host.name}-monitored";
+              };
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.monitoring ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo-monitored";
+      }
+    );
+
+    test-static-parent-bare-fn-sub = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.monitoring.includes = [ den.aspects.monitoring._.agent ];
+          }
+          {
+            den.aspects.monitoring._.agent =
+              { host, ... }:
+              {
+                nixos.networking.hostName = "${host.name}-agent";
+              };
+          }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.monitoring ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo-agent";
+      }
+    );
+  };
+
 }


### PR DESCRIPTION

Fixes #413

### Problem

Provider sub-aspects defined as bare context functions don't receive `{ host }` during resolution:

```nix
den.aspects.foo._.sub = { host, ... }: {
  nixos = lib.optionalAttrs (host.hostName != "whatever") {
    networking.networkmanager.enable = true;
  };
};
```

When a parent function returns `{ includes = [foo._.sub] }`, the sub-aspect is resolved by the adapter system which only passes `{ class, aspect-chain }` — the `{ host }` context from the pipeline never reaches nested includes of function results.

### Fix

`applyDeep` in `parametric.applyIncludes` — when `takeFn` succeeds and returns a bare result with sub-includes (no `meta`, no `__functor`), also apply `takeFn` to those sub-includes. This propagates context to provider sub-aspects nested inside function results without double-applying to parametric wrappers or `deepRecurse` outputs.

The key discriminator: bare provider results carry only `includes` (+ `name` from `carryAttrs`). Results from `withOwn`/`withIdentity` have `meta`; deferred `deepRecurse` wrappers have `__functor`. Neither should be re-resolved.

### Test coverage

- `deadbugs/issue-413-provider-bare-function.nix` — reproduces the original report
- `deadbugs/issue-413-provider-sub-aspect-function.nix` — variant with `lib.optionalAttrs` guard
- `provides-parametric.nix` — provider sub-aspects with parametric context in various configurations

cc: @kalyanoliveira for the report