### PR TITLE
BUG: static sub-aspect nixos config silently dropped when included from parametric parent

### DIFF
--- a/nix/lib/parametric.nix
+++ b/nix/lib/parametric.nix
@@ -34,6 +34,26 @@ let
       # wrappers have __functor. Re-resolving either would double-apply
       # context and duplicate modules.
       isBareResult = builtins.isAttrs r && r ? includes && !(r ? meta) && !(r ? __functor);
+      # Full aspect objects have meta set by aspectMeta.
+      isFullAspect = sub: builtins.isAttrs sub && sub ? meta;
+      # Extract only owned class-module keys from a full aspect,
+      # stripping all aspect infrastructure / metadata keys.
+      # If the result is non-empty the sub has static owned class configs
+      # (e.g. nixos = { ... }) that withOwn would skip in a parametric ctx.
+      # Keys declared as options in aspectSubmodule (types.nix).
+      # Everything else in a merged aspect attrset is freeform class config.
+      classConfig =
+        sub:
+        builtins.removeAttrs sub [
+          "includes"
+          "__functor"
+          "__functionArgs"
+          "name"
+          "description"
+          "meta"
+          "provides"
+          "_"
+        ];
     in
     if r == { } then
       r
@@ -43,9 +63,25 @@ let
         includes = map (
           sub:
           let
+            cc = classConfig sub;
             sr = takeFn sub ctx;
+            subIncludes = builtins.filter (x: x != { }) (
+              map (applyDeep takeFn ctx) (sub.includes or [ ])
+            );
           in
-          if sr != { } then sr else sub
+          if isFullAspect sub && cc != { } then
+            # Static sub-aspect: withOwn skips owned class configs in parametric
+            # contexts (it only returns the functor branch).  Extract and include
+            # the class configs explicitly, then recurse into sub.includes so any
+            # nested parametric includes also receive the context.
+            { includes = [ cc ] ++ subIncludes; }
+          else if sr != { } then
+            # Parametric sub-aspect (bare fn coerced to { includes = [fn] }):
+            # takeFn fires the functor which captures the context and propagates
+            # it into the sub's includes, so sr already contains everything needed.
+            sr
+          else
+            sub
         ) r.includes;
       }
     else

--- a/templates/bogus/flake.lock
+++ b/templates/bogus/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "den": {
       "locked": {
-        "lastModified": 1775549909,
-        "narHash": "sha256-9GuRhcEA8YoYa1XYeJxBP0V5H+Gn4pH41cgQHe3hL5M=",
+        "lastModified": 1775774250,
+        "narHash": "sha256-CQ4mSK0K3oWrEu9oAkogeWuNBbvjxL6etsxCdpTRsEI=",
         "owner": "vic",
         "repo": "den",
-        "rev": "53c30ea9acbd357077defec263066506771e9630",
+        "rev": "5a4b828a445d5f5c1803e201dcdd5a5cbb7563ce",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770818644,
-        "narHash": "sha256-DYS4jIRpRoKOzJjnR/QqEd/MlT4OZZpt8CrBLv+cjsE=",
+        "lastModified": 1775781825,
+        "narHash": "sha256-L5yKTpR+alrZU2XYYvIxCeCP4LBHU5jhwSj7H1VAavg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0acbd1180697de56724821184ad2c3e6e7202cd7",
+        "rev": "e35c39fca04fee829cecdf839a50eb9b54d8a701",
         "type": "github"
       },
       "original": {
@@ -58,11 +58,11 @@
     },
     "import-tree": {
       "locked": {
-        "lastModified": 1763762820,
-        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "lastModified": 1773693634,
+        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
         "owner": "vic",
         "repo": "import-tree",
-        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770843696,
-        "narHash": "sha256-9SFCZkVcpDOV6unH5hVEy4+dB0rxMuUoBnDAO6vshac=",
-        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
+        "lastModified": 1775763530,
+        "narHash": "sha256-QIGMZuG5QK1Z4OEMDSpEJc7JRonbemZ9S+xpBIsQuNE=",
+        "rev": "b0188973b4b2a5b6bdba8b65381d6cd09a533da0",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre944764.2343bbb58f99/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre977728.b0188973b4b2/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/templates/bogus/modules/bug.nix
+++ b/templates/bogus/modules/bug.nix
@@ -1,26 +1,48 @@
-{ denTest, ... }:
+{ denTest, lib, ... }:
 {
   flake.tests.bogus = {
-
     test-something = denTest (
+      { den, igloo, ... }:
       {
-        den,
-        lib,
-        igloo, # igloo = nixosConfigurations.igloo.config
-        tuxHm, # tuxHm = igloo.home-manager.users.tux
-        ...
-      }:
-      {
-        # replace <system> if you are reporting a bug in MacOS
         den.hosts.x86_64-linux.igloo.users.tux = { };
 
-        # do something for testing
-        den.aspects.tux.user.description = "The Penguin";
+        imports =
+          let
+            a = {
+              den.schema.host.options.role._.sub.enable = lib.mkEnableOption "sub";
+            };
 
-        expr = igloo.users.users.tux.description;
-        expected = "The Penguin";
+            b = {
+              den.aspects.role = { host, ... }: {
+                includes = lib.optionals host.role._.sub.enable [
+                  den.aspects.role._.sub
+                ];
+              };
+            };
+
+            c = {
+              den.aspects.role._.sub.nixos.networking.networkmanager.enable = true;
+            };
+            # Change c to the below, and it works.
+            # c = {
+            #   den.aspects.role._.sub = { ... }: {
+            #     nixos.networking.networkmanager.enable = true;
+            #   };
+            # };
+
+            d = {
+              den.hosts.x86_64-linux.igloo.role._.sub.enable = true;
+            };
+
+            e = {
+              den.aspects.igloo.includes = [ den.aspects.role ];
+            };
+          in
+          [ a b c d e ];
+
+        expr = igloo.networking.networkmanager.enable;
+        expected = true;
       }
     );
-
   };
 }

--- a/templates/bogus/modules/bug.nix
+++ b/templates/bogus/modules/bug.nix
@@ -8,13 +8,10 @@
 
         imports =
           let
-            a = {
-              den.schema.host.options.enable = lib.mkEnableOption "sub";
-            };
 
             b = {
               den.aspects.role = { host, ... }: {
-                includes = lib.optionals host.enable [
+                includes = [
                   den.aspects.role._.sub
                 ];
               };
@@ -30,15 +27,11 @@
             #   };
             # };
 
-            d = {
-              den.hosts.x86_64-linux.igloo.enable = true;
-            };
-
             e = {
               den.aspects.igloo.includes = [ den.aspects.role ];
             };
           in
-          [ a b c d e ];
+          [ b c e ];
 
         expr = igloo.networking.networkmanager.enable;
         expected = true;

--- a/templates/bogus/modules/bug.nix
+++ b/templates/bogus/modules/bug.nix
@@ -9,12 +9,12 @@
         imports =
           let
             a = {
-              den.schema.host.options.role._.sub.enable = lib.mkEnableOption "sub";
+              den.schema.host.options.enable = lib.mkEnableOption "sub";
             };
 
             b = {
               den.aspects.role = { host, ... }: {
-                includes = lib.optionals host.role._.sub.enable [
+                includes = lib.optionals host.enable [
                   den.aspects.role._.sub
                 ];
               };
@@ -31,7 +31,7 @@
             # };
 
             d = {
-              den.hosts.x86_64-linux.igloo.role._.sub.enable = true;
+              den.hosts.x86_64-linux.igloo.enable = true;
             };
 
             e = {


### PR DESCRIPTION
## Reproduction

See `templates/bogus/modules/bug.nix`.

The following setup fails — `igloo.networking.networkmanager.enable` is `false` when it should be `true`:

- Schema defines an enable option for a sub-aspect
- Parent aspect is a parametric function that conditionally includes the sub-aspect based on that option
- Sub-aspect is defined as a **static attrset** with nixos config
- Host has the enable option set to `true`

The includes list is correctly populated (length 1) and `host.role._.sub.enable` is correctly `true`, but the sub-aspect's nixos config never reaches the host.

## Fix

Making the sub-aspect a bare parametric function instead of a static attrset makes it work:

```nix
# fails
den.aspects.role._.sub.nixos.networking.networkmanager.enable = true;

# works
den.aspects.role._.sub = { host, ... }: {
  nixos.networking.networkmanager.enable = true;
};
```

## Expected behavior

Static sub-aspects should have their nixos config applied when included from a parametric parent function, just as parametric sub-aspects do.