### PR TITLE
fix(core): make entity.aspect be real aspect reference not an string

### DIFF
--- a/modules/aspects/definition.nix
+++ b/modules/aspects/definition.nix
@@ -11,7 +11,7 @@ let
   allUsers = lib.concatMap (h: builtins.attrValues h.users) allHosts;
 
   deps = map (from: {
-    ${from.aspect} = parametric (lib.genAttrs (from.classes or [ from.class ]) (_: { }));
+    ${from.name} = parametric (lib.genAttrs (from.classes or [ from.class ]) (_: { }));
   }) (allHosts ++ allHomes ++ allUsers);
 in
 {

--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -22,8 +22,7 @@ let
   };
 
   homeCtx = {
-    home.provides.home =
-      { home }: den.lib.parametric.fixedTo { inherit home; } den.aspects.${home.aspect};
+    home.provides.home = { home }: den.lib.parametric.fixedTo { inherit home; } home.aspect;
     home.into.default = lib.singleton;
   };
 

--- a/modules/aspects/provides/mutual-provider.nix
+++ b/modules/aspects/provides/mutual-provider.nix
@@ -34,10 +34,9 @@ let
       };
   '';
 
-  find-mutual = from: to: den.aspects.${from.aspect}._.${to.aspect} or { };
-  user-to-hosts = user: den.aspects.${user.aspect}._.to-hosts or { };
-  host-to-users = host: den.aspects.${host.aspect}._.to-users or { };
-  user-to-users = user: den.aspects.${user.aspect}._.to-users or { };
+  find-mutual = from: to: from.aspect._.${to.aspect.name} or { };
+  to-hosts = from: from.aspect._.to-hosts or { };
+  to-users = from: from.aspect._.to-users or { };
 
   mutual-user-user = host: user: {
     includes = map (
@@ -45,7 +44,7 @@ let
       parametric.fixedTo { inherit host user; } {
         includes = [
           (find-mutual from user)
-          (user-to-users from)
+          (to-users from)
         ];
       }
     ) (builtins.filter (u: u != user) (builtins.attrValues host.users));
@@ -58,8 +57,8 @@ let
       includes = [
         (find-mutual host user)
         (find-mutual user host)
-        (host-to-users host)
-        (user-to-hosts user)
+        (to-users host)
+        (to-hosts user)
         (mutual-user-user host user)
       ];
     };
@@ -67,7 +66,7 @@ let
   mutual-standalone-home =
     { home }:
     parametric.fixedTo { inherit home; } (
-      if home.hostName == null then { } else den.aspects.${home.aspect}._.${home.hostName} or { }
+      if home.hostName == null then { } else home.aspect._.${home.hostName} or { }
     );
 
 in

--- a/modules/aspects/provides/os-user.nix
+++ b/modules/aspects/provides/os-user.nix
@@ -40,7 +40,7 @@ let
         "users"
         user.userName
       ];
-      fromAspect = _: den.lib.parametric.fixedTo { inherit host user; } den.aspects.${user.aspect};
+      fromAspect = _: den.lib.parametric.fixedTo { inherit host user; } user.aspect;
       adaptArgs = args: args // { osConfig = args.config; };
     };
 

--- a/modules/context/host.nix
+++ b/modules/context/host.nix
@@ -20,7 +20,7 @@ let
 
   ctx.host.into.user = { host }: map (user: { inherit host user; }) (lib.attrValues host.users);
   ctx.host.into.default = lib.singleton;
-  ctx.host.provides.host = { host }: fixedTo { inherit host; } den.aspects.${host.aspect};
+  ctx.host.provides.host = { host }: fixedTo { inherit host; } host.aspect;
 
 in
 {

--- a/modules/context/user.nix
+++ b/modules/context/user.nix
@@ -28,7 +28,7 @@ let
   ctx.user.into.default = lib.singleton;
   ctx.user.provides.user = take.exactly from-user;
 
-  from-user = { host, user }: fixedTo { inherit host user; } den.aspects.${user.aspect};
+  from-user = { host, user }: fixedTo { inherit host user; } user.aspect;
 
 in
 {

--- a/nix/lib/types.nix
+++ b/nix/lib/types.nix
@@ -35,7 +35,12 @@ let
           class = strOpt "os-configuration nix class for host" (
             if lib.hasSuffix "darwin" config.system then "darwin" else "nixos"
           );
-          aspect = strOpt "main aspect name of <class>" config.name;
+          aspect = lib.mkOption {
+            description = "Aspect that configures this host.";
+            type = lib.types.raw; # no merging
+            defaultText = "den.aspects.<name>";
+            default = den.aspects.${config.name};
+          };
           description = strOpt "host description" "${config.class}.${config.hostName}@${config.system}";
           users = lib.mkOption {
             description = "user accounts";
@@ -128,7 +133,12 @@ let
             defaultText = lib.literalExpression ''[ "user" ]'';
             default = [ "user" ];
           };
-          aspect = strOpt "main aspect name" config.name;
+          aspect = lib.mkOption {
+            description = "Aspect that configures this user.";
+            type = lib.types.raw; # no merging
+            defaultText = "den.aspects.<name>";
+            default = den.aspects.${config.name};
+          };
           host = lib.mkOption {
             default = host;
             defaultText = lib.literalExpression "host";
@@ -188,7 +198,7 @@ let
         config._module.args.host = hostByName;
         config._module.args.user = userByName;
         options = {
-          name = strOpt "home configuration name" name;
+          name = strOpt "home configuration name" userName;
           userName = strOpt "user account name" userName;
           hostName = strOpt "host name" hostName;
           user = lib.mkOption {
@@ -201,7 +211,12 @@ let
           };
           system = strOpt "platform system" system;
           class = strOpt "home management nix class" "homeManager";
-          aspect = strOpt "main aspect name" userName;
+          aspect = lib.mkOption {
+            description = "Aspect that configures this home.";
+            type = lib.types.raw; # no merging
+            defaultText = "den.aspects.<name>";
+            default = den.aspects.${config.name};
+          };
           description = strOpt "home description" "home.${config.name}@${config.system}";
           pkgs = lib.mkOption {
             description = ''
@@ -248,7 +263,7 @@ let
               {
                 homeManager = [
                   "homeConfigurations"
-                  config.name
+                  name
                 ];
               }
               .${config.class};

--- a/templates/ci/modules/features/cross-context-forward.nix
+++ b/templates/ci/modules/features/cross-context-forward.nix
@@ -187,7 +187,7 @@
             lib.optionalAttrs (primaryUser != null) (
               den._.forward {
                 each = lib.singleton host;
-                fromAspect = h: den.lib.parametric.fixedTo { host = h; } den.aspects.${h.aspect};
+                fromAspect = h: den.lib.parametric.fixedTo { host = h; } h.aspect;
                 fromClass = _: "homeManager";
                 intoClass = _: host.class;
                 intoPath = _: [

--- a/templates/ci/modules/features/deadbugs/cybolic-routes.nix
+++ b/templates/ci/modules/features/deadbugs/cybolic-routes.nix
@@ -19,7 +19,7 @@
           let
             inherit (den.lib) parametric;
             # eg, `<user>._.<host>` and `<host>._.<user>`
-            mutual = from: to: den.aspects.${from.aspect}._.${to.aspect} or { };
+            mutual = from: to: from.aspect._.${to.aspect.name} or { };
 
             routes =
               { host, user, ... }@ctx:

--- a/templates/ci/modules/features/homes.nix
+++ b/templates/ci/modules/features/homes.nix
@@ -87,7 +87,7 @@
             inherit (den.homes.x86_64-linux."tux@igloo")
               userName
               hostName
-              aspect
+              name
               host
               user
               ;
@@ -96,7 +96,7 @@
           keyboard = config.flake.homeConfigurations."tux@igloo".config.home.keyboard;
         };
         expected = {
-          homeSchema.aspect = "tux";
+          homeSchema.name = "tux";
           homeSchema.userName = "tux";
           homeSchema.hostName = "igloo";
           homeSchema.host = null;
@@ -132,14 +132,14 @@
             inherit (den.homes.x86_64-linux."tux@igloo")
               userName
               hostName
-              aspect
+              name
               ;
           };
           configuredUserName = config.flake.homeConfigurations."tux@igloo".config.home.username;
           hasOsConfig = config.flake.homeConfigurations."tux@igloo".config.home.keyboard.model;
         };
         expected = {
-          homeSchema.aspect = "tux"; # re-uses same aspect as hosted HM.
+          homeSchema.name = "tux"; # re-uses same aspect as hosted HM.
           homeSchema.userName = "tux";
           homeSchema.hostName = "igloo";
           configuredUserName = "tux";

--- a/templates/microvm/modules/microvm-integration.nix
+++ b/templates/microvm/modules/microvm-integration.nix
@@ -100,7 +100,7 @@ let
               "vms"
               vm.name
             ];
-            fromAspect = _: den.aspects.${vm.aspect};
+            fromAspect = _: vm.aspect;
           };
 
         in


### PR DESCRIPTION

this allows people to customize the aspect being used to configure their host/user/home, even if it is in another namespace than den.aspects.

Fixes #416 