### PR TITLE
fix: don't coerce factory-function aspects

### DIFF
--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -156,13 +156,24 @@ let
 
   # Wrap non-module functions into { includes = [fn] } so they don't get
   # treated as module functions by aspectType's submodule merge.
+  #
+  # Only coerce functions that destructure a context attrset
+  # (`{ host, ... }: ...`, `{ user, ... }: ...`, etc.) — those have a
+  # non-empty `functionArgs`. Bare-arg "factory" functions like
+  # `facter = reportPath: { nixos = ...; }` have empty `functionArgs`
+  # and must NOT be coerced — coercing them turns `den.aspects.facter`
+  # into a full aspect whose default functor ignores the user's
+  # argument, so `(facter ./facter.json)` no longer materializes the
+  # config. Such functions stay typed as `providerFnType`, whose merge
+  # wraps the underlying function via `__functor = _: eth.merge loc
+  # defs` so `(aspect arg)` correctly invokes the user function.
   coercedProviderType =
     cnf:
     let
       pt = providerType cnf;
     in
     lib.types.coercedTo (lib.types.addCheck lib.types.raw (
-      v: builtins.isFunction v && !isSubmoduleFn v
+      v: builtins.isFunction v && !isSubmoduleFn v && lib.functionArgs v != { }
     )) (fn: { includes = [ fn ]; }) pt;
 
   aspectsType =

--- a/templates/ci/modules/features/deadbugs/issue-429-parametrized-aspect-call-at-include.nix
+++ b/templates/ci/modules/features/deadbugs/issue-429-parametrized-aspect-call-at-include.nix
@@ -1,0 +1,29 @@
+# Minimal reproduction of drupol's pattern from issue #429
+# A factory-function aspect called at include time, returning nixos config.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs-issue-429 = {
+
+    test-parametrized-aspect-call-at-include = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.facter = reportPath: {
+              nixos.environment.variables.FACTER_REPORT = reportPath;
+            };
+          }
+          {
+            den.aspects.igloo.includes = [ (den.aspects.facter "/path/to/report") ];
+          }
+        ];
+
+        expr = igloo.environment.variables.FACTER_REPORT or null;
+        expected = "/path/to/report";
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
PR #410 added coercedProviderType to make `{host, ...}: {nixos = ...}` aspects merge with sibling static `.nixos = ...` defs (fixes #408). The predicate was too broad: any non-module function got wrapped into `{ includes = [fn] }`, which silently broke "factory" aspects like:

    den.aspects.facter = reportPath: { nixos = ...; };
    den.aspects.igloo.includes = [ (den.aspects.facter "/path") ];

Coercing turns den.aspects.facter into a full aspect with the default functor. Calling `(facter "/path")` invokes the default functor in a non-static branch with the string as `ctx` — the user's `reportPath` is discarded and the config body never materializes.

Narrow the predicate with `lib.functionArgs v != {}`. Context fns have destructured named args (non-empty functionArgs) and still get coerced. Factory fns with a bare positional arg stay typed as providerFnType, whose merge wraps the underlying function via
`__functor = _: eth.merge loc defs` so `(aspect arg)` correctly dispatches to the user function.

Bisected to d266c3a (PR #410). Minimal repro verified broken at that commit and working at v0.15.0. Fix passes the new deadbugs test plus all 278 existing CI tests including deadbugs-issue-408 (`context-fn + static` merge still works).

Fixes #429.