### PR TITLE
feat: `entity.hasAspect <ref>` query method on context entities

### DIFF
--- a/modules/context/has-aspect.nix
+++ b/modules/context/has-aspect.nix
@@ -1,0 +1,72 @@
+# Defines `hasAspect` on every entity that imports den.schema.conf
+# (host, user, home, and user-defined kinds). Flake-level module:
+# the outer closure captures config.den so the inner entity submodule
+# can reach den.lib.aspects.mkEntityHasAspect at entity-eval time.
+{ lib, config, ... }:
+let
+  inherit (config) den;
+
+  entityModule =
+    { config, ... }:
+    {
+      options.hasAspect = lib.mkOption {
+        description = ''
+          Query whether an aspect is structurally present in this entity's
+          resolved aspect tree.
+
+          Usage:
+            host.hasAspect <facter>                         # primary class
+            host.hasAspect.forClass "nixos" <facter>        # explicit class
+            host.hasAspect.forAnyClass <facter>             # union across classes
+
+          Safe to call from inside class-config module bodies
+          (`nixos = ...`, `homeManager = ...`) and from lazy positions
+          inside aspect functor bodies. NOT safe to use for deciding an
+          aspect's `includes` list — that's cyclic; use meta.adapter +
+          excludeAspect / oneOfAspects for structural decisions instead.
+        '';
+        internal = true;
+        visible = false;
+        readOnly = true;
+        type = lib.types.raw;
+        defaultText = lib.literalMD "Computed from `config.resolved` and the entity's class/classes.";
+        default =
+          let
+            # Prefer `classes` (list), fall back to `[class]`, else error.
+            classes =
+              config.classes or (
+                if config ? class then
+                  [ config.class ]
+                else
+                  throw "den.schema.conf.hasAspect: entity has no `class` or `classes`"
+              );
+            primaryClass =
+              if classes == [ ] then
+                throw "den.schema.conf.hasAspect: entity has empty `classes` list"
+              else
+                lib.head classes;
+            # Lazy thunk throwing at call time (not attribute access), so
+            # entity.hasAspect / .forClass / .forAnyClass can be referenced
+            # safely by tooling and only fire when actually invoked.
+            err = throw (
+              "hasAspect: ${config.name or "<unnamed entity>"} has no config.resolved "
+              + "(no matching den.ctx.<kind> defined)."
+            );
+          in
+          if config ? resolved then
+            den.lib.aspects.mkEntityHasAspect {
+              tree = config.resolved;
+              inherit primaryClass classes;
+            }
+          else
+            {
+              __functor = _: _: err;
+              forClass = _: _: err;
+              forAnyClass = _: err;
+            };
+      };
+    };
+in
+{
+  config.den.schema.conf.imports = [ entityModule ];
+}

--- a/nix/lib/aspects/adapters.nix
+++ b/nix/lib/aspects/adapters.nix
@@ -5,7 +5,7 @@
 #
 # See resolve.nix for the arguments passed to adapters:
 #   { aspect, class, classModule, recurse, aspect-chain, resolveChild }
-{ lib, ... }:
+{ den, lib, ... }:
 let
 
   # Produces a single module importing all classModules from aspect and its includes.
@@ -189,6 +189,29 @@ let
   # { paths = [ [providerSeg..., name], ... ]; }. Depth-first, not deduped.
   collectPaths = filterIncludes collectPathsInner;
 
+  # meta.adapter that keeps the first candidate structurally present
+  # in the parent subtree and tombstones the rest via excludeAspect.
+  #
+  #   meta.adapter = oneOfAspects [ <agenix-rekey> <sops-nix> ];
+  #
+  # No-op when no candidates are present. Presence is determined
+  # from the raw tree (bypassing filterIncludes) so we don't re-enter
+  # our own meta.adapter.
+  oneOfAspects =
+    candidates: inherited:
+    args@{ class, aspect-chain, ... }:
+    let
+      # filterIncludes rebinds args.aspect to each child but keeps
+      # aspect-chain, whose tail is still the parent that owns us.
+      parent = lib.last aspect-chain;
+      subtree = den.lib.aspects.resolve.withAdapter collectPathsInner class parent;
+      present-keys = toPathSet (subtree.paths or [ ]);
+      keyOf = c: pathKey (aspectPath c);
+      present = builtins.filter (c: present-keys ? ${keyOf c}) candidates;
+      losers = if present == [ ] then [ ] else builtins.tail present;
+    in
+    (lib.foldl' (inner: loser: excludeAspect loser inner) inherited losers) args;
+
   # Traces aspect.name as nested lists per includes. Composed with filterIncludes
   # so tombstones and substitutions are visible.
   #
@@ -218,6 +241,7 @@ in
     mapAspect
     mapIncludes
     module
+    oneOfAspects
     pathKey
     substituteAspect
     toPathSet

--- a/nix/lib/aspects/adapters.nix
+++ b/nix/lib/aspects/adapters.nix
@@ -158,6 +158,37 @@ let
 
   default = filterIncludes module;
 
+  # Slash-joined key for an aspectPath. Canonical format for path
+  # lookup sets.
+  pathKey = path: lib.concatStringsSep "/" path;
+
+  # Convert a list of aspectPaths into an attrset-as-set keyed by pathKey.
+  toPathSet =
+    paths:
+    builtins.listToAttrs (
+      builtins.map (p: {
+        name = pathKey p;
+        value = true;
+      }) paths
+    );
+
+  # Shared walker used by collectPaths (through filterIncludes, so it
+  # sees tombstones) and by oneOfAspects (raw, to avoid re-entering
+  # its own meta.adapter). The excluded-guard is a no-op in the raw
+  # use since tombstones only appear after filterIncludes runs.
+  collectPathsInner =
+    { aspect, recurse, ... }:
+    {
+      paths =
+        (lib.optional (!(aspect.meta.excluded or false)) (aspectPath aspect))
+        ++ lib.concatMap (i: (recurse i).paths or [ ]) (aspect.includes or [ ]);
+    };
+
+  # Terminal adapter that walks via filterIncludes and collects the
+  # aspectPath of every non-tombstone aspect. Result shape:
+  # { paths = [ [providerSeg..., name], ... ]; }. Depth-first, not deduped.
+  collectPaths = filterIncludes collectPathsInner;
+
   # Traces aspect.name as nested lists per includes. Composed with filterIncludes
   # so tombstones and substitutions are visible.
   #
@@ -178,6 +209,7 @@ in
 {
   inherit
     aspectPath
+    collectPaths
     default
     excludeAspect
     filter
@@ -186,7 +218,9 @@ in
     mapAspect
     mapIncludes
     module
+    pathKey
     substituteAspect
+    toPathSet
     tombstone
     trace
     ;

--- a/nix/lib/aspects/default.nix
+++ b/nix/lib/aspects/default.nix
@@ -7,6 +7,7 @@ let
   rawTypes = import ./types.nix { inherit den lib; };
   adapters = import ./adapters.nix { inherit den lib; };
   resolve = import ./resolve.nix { inherit den lib; };
+  hasAspect = import ./has-aspect.nix { inherit den lib; };
 
   defaultFunctor = (den.lib.parametric { }).__functor;
   typesConf = { inherit defaultFunctor; };
@@ -14,5 +15,6 @@ let
 in
 {
   inherit types adapters resolve;
+  inherit (hasAspect) hasAspectIn collectPathSet mkEntityHasAspect;
   mkAspectsType = cnf': lib.mapAttrs (_: v: v (typesConf // cnf')) rawTypes;
 }

--- a/nix/lib/aspects/has-aspect.nix
+++ b/nix/lib/aspects/has-aspect.nix
@@ -1,0 +1,65 @@
+# Query whether an aspect is structurally present in a resolved tree.
+# Entity-facing wiring lives in modules/context/has-aspect.nix.
+{ lib, den, ... }:
+let
+  inherit (den.lib.aspects) adapters resolve;
+  inherit (adapters) pathKey toPathSet;
+
+  # Validate a ref has both `name` and `meta` (aspectPath requires
+  # both) and return its slash-joined path key.
+  refKey =
+    ref:
+    if (ref ? name) && (ref ? meta) then
+      pathKey (adapters.aspectPath ref)
+    else
+      throw "hasAspect: ref must have both `name` and `meta` (got ${builtins.typeOf ref}).";
+
+  # Run collectPaths under `class` on `tree`, returned as an
+  # attrset-as-set keyed by slash-joined path.
+  collectPathSet =
+    { tree, class }: toPathSet ((resolve.withAdapter adapters.collectPaths class tree).paths or [ ]);
+
+  hasAspectIn =
+    {
+      tree,
+      class,
+      ref,
+    }:
+    (collectPathSet { inherit tree class; }) ? ${refKey ref};
+
+  # Build the functor+attrs value attached to entities as `.hasAspect`.
+  # Per-class path sets are thunk-cached inside `setFor` so repeated
+  # calls share one traversal per class.
+  mkEntityHasAspect =
+    {
+      tree,
+      primaryClass,
+      classes,
+    }:
+    let
+      setFor = builtins.listToAttrs (
+        map (c: {
+          name = c;
+          value = collectPathSet {
+            inherit tree;
+            class = c;
+          };
+        }) (lib.unique ([ primaryClass ] ++ classes))
+      );
+      check = class: ref: (setFor.${class} or { }) ? ${refKey ref};
+      bareFn = check primaryClass;
+    in
+    {
+      __functor = _: bareFn;
+      forClass = check;
+      forAnyClass = ref: lib.any (c: check c ref) classes;
+    };
+
+in
+{
+  inherit
+    hasAspectIn
+    collectPathSet
+    mkEntityHasAspect
+    ;
+}

--- a/templates/ci/modules/features/collect-paths.nix
+++ b/templates/ci/modules/features/collect-paths.nix
@@ -1,0 +1,161 @@
+# Tests for den.lib.aspects.adapters.collectPaths — the path-collecting
+# terminal adapter used by hasAspect and other structural-query tooling.
+{ denTest, lib, ... }:
+{
+  flake.tests.collect-paths = {
+
+    test-basic-static-tree = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) resolve adapters;
+        paths = (resolve.withAdapter adapters.collectPaths "nixos" den.aspects.foo).paths or [ ];
+        toKey = p: lib.concatStringsSep "/" p;
+        keys = map toKey paths;
+      in
+      {
+        den.aspects.foo.includes = [
+          den.aspects.bar
+          den.aspects.baz
+        ];
+        den.aspects.bar.nixos = { };
+        den.aspects.baz.nixos = { };
+
+        expr = {
+          hasFoo = lib.elem "foo" keys;
+          hasBar = lib.elem "bar" keys;
+          hasBaz = lib.elem "baz" keys;
+          # Depth-first: foo visited first (it's the root of the walk).
+          firstIsFoo = builtins.head keys == "foo";
+        };
+        expected = {
+          hasFoo = true;
+          hasBar = true;
+          hasBaz = true;
+          firstIsFoo = true;
+        };
+      }
+    );
+
+    test-empty-tree = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) resolve adapters;
+        result = resolve.withAdapter adapters.collectPaths "nixos" den.aspects.alone;
+      in
+      {
+        den.aspects.alone = { };
+
+        expr = {
+          pathCount = builtins.length (result.paths or [ ]);
+          hasSelf = builtins.elem [ "alone" ] (result.paths or [ ]);
+        };
+        expected = {
+          pathCount = 1;
+          hasSelf = true;
+        };
+      }
+    );
+
+    test-forces-parametric-functors = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) resolve adapters;
+        paths = (resolve.withAdapter adapters.collectPaths "nixos" den.aspects.role).paths or [ ];
+        keys = map (lib.concatStringsSep "/") paths;
+      in
+      {
+        # role (static) includes a perHost parametric aspect; collectPaths
+        # should force the functor and include its entry in the path list.
+        den.aspects.role.includes = [
+          den.aspects.leaf
+          den.aspects.param
+        ];
+        den.aspects.leaf.nixos = { };
+        den.aspects.param = den.lib.perHost (
+          { host }:
+          {
+            nixos = { };
+          }
+        );
+
+        expr = {
+          hasRole = lib.elem "role" keys;
+          hasLeaf = lib.elem "leaf" keys;
+          hasParam = lib.elem "param" keys;
+        };
+        expected = {
+          hasRole = true;
+          hasLeaf = true;
+          hasParam = true;
+        };
+      }
+    );
+
+    test-skips-tombstones = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) resolve adapters;
+        paths = (resolve.withAdapter adapters.collectPaths "nixos" den.aspects.root).paths or [ ];
+        keys = map (lib.concatStringsSep "/") paths;
+      in
+      {
+        den.aspects.root.includes = [
+          den.aspects.keep
+          den.aspects.dropme
+        ];
+        den.aspects.root.meta.adapter = inherited: adapters.excludeAspect den.aspects.dropme inherited;
+        den.aspects.keep.nixos = { };
+        den.aspects.dropme.nixos = { };
+
+        expr = {
+          hasKeep = lib.elem "keep" keys;
+          hasDropme = lib.elem "dropme" keys;
+        };
+        expected = {
+          hasKeep = true;
+          hasDropme = false;
+        };
+      }
+    );
+
+    test-shared-subtree-not-deduped = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) resolve adapters;
+        paths = (resolve.withAdapter adapters.collectPaths "nixos" den.aspects.root).paths or [ ];
+        keys = map (lib.concatStringsSep "/") paths;
+        sharedCount = builtins.length (builtins.filter (k: k == "shared") keys);
+      in
+      {
+        # `shared` reached via both `a` and `b`.
+        den.aspects.root.includes = [
+          den.aspects.a
+          den.aspects.b
+        ];
+        den.aspects.a.includes = [ den.aspects.shared ];
+        den.aspects.b.includes = [ den.aspects.shared ];
+        den.aspects.shared.nixos = { };
+
+        # collectPaths does NOT dedupe — each visit produces a path.
+        expr = sharedCount;
+        expected = 2;
+      }
+    );
+
+    test-provider-path-included = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) resolve adapters;
+        paths = (resolve.withAdapter adapters.collectPaths "nixos" den.aspects.root).paths or [ ];
+      in
+      {
+        den.aspects.root.includes = [ den.aspects.foo._.sub ];
+        den.aspects.foo._.sub.nixos = { };
+
+        expr = lib.elem [ "foo" "sub" ] paths;
+        expected = true;
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/has-aspect-lib.nix
+++ b/templates/ci/modules/features/has-aspect-lib.nix
@@ -1,0 +1,245 @@
+# Tests for the lib primitives: hasAspectIn, collectPathSet,
+# mkEntityHasAspect. These exercise the query mechanics without any
+# entity wiring — see has-aspect.nix for the entity-method tests.
+{ denTest, lib, ... }:
+{
+  flake.tests.has-aspect-lib = {
+
+    test-hasAspectIn-positive = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) hasAspectIn;
+      in
+      {
+        den.aspects.root.includes = [ den.aspects.child ];
+        den.aspects.child.nixos = { };
+
+        expr = hasAspectIn {
+          tree = den.aspects.root;
+          class = "nixos";
+          ref = den.aspects.child;
+        };
+        expected = true;
+      }
+    );
+
+    test-hasAspectIn-negative = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) hasAspectIn;
+      in
+      {
+        den.aspects.root.includes = [ den.aspects.child ];
+        den.aspects.child.nixos = { };
+        den.aspects.other.nixos = { };
+
+        expr = hasAspectIn {
+          tree = den.aspects.root;
+          class = "nixos";
+          ref = den.aspects.other;
+        };
+        expected = false;
+      }
+    );
+
+    test-hasAspectIn-respects-tombstones = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) hasAspectIn adapters;
+      in
+      {
+        den.aspects.root.includes = [
+          den.aspects.keep
+          den.aspects.drop
+        ];
+        den.aspects.root.meta.adapter = inherited: adapters.excludeAspect den.aspects.drop inherited;
+        den.aspects.keep.nixos = { };
+        den.aspects.drop.nixos = { };
+
+        expr = {
+          keep = hasAspectIn {
+            tree = den.aspects.root;
+            class = "nixos";
+            ref = den.aspects.keep;
+          };
+          drop = hasAspectIn {
+            tree = den.aspects.root;
+            class = "nixos";
+            ref = den.aspects.drop;
+          };
+        };
+        expected = {
+          keep = true;
+          drop = false;
+        };
+      }
+    );
+
+    test-collectPathSet-returns-keys = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) collectPathSet;
+        s = collectPathSet {
+          tree = den.aspects.root;
+          class = "nixos";
+        };
+      in
+      {
+        den.aspects.root.includes = [ den.aspects.foo._.bar ];
+        den.aspects.foo._.bar.nixos = { };
+
+        expr = {
+          hasRoot = s ? "root";
+          hasSub = s ? "foo/bar";
+          hasNothing = s ? "nonexistent";
+        };
+        expected = {
+          hasRoot = true;
+          hasSub = true;
+          hasNothing = false;
+        };
+      }
+    );
+
+    test-mkEntityHasAspect-shape = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) mkEntityHasAspect;
+        has = mkEntityHasAspect {
+          tree = den.aspects.root;
+          primaryClass = "nixos";
+          classes = [ "nixos" ];
+        };
+      in
+      {
+        den.aspects.root.includes = [ den.aspects.child ];
+        den.aspects.child.nixos = { };
+
+        expr = {
+          isAttrs = builtins.isAttrs has;
+          hasForClass = has ? forClass;
+          hasForAnyClass = has ? forAnyClass;
+          callableBare = has den.aspects.child;
+          callableForClass = has.forClass "nixos" den.aspects.child;
+          callableForAnyClass = has.forAnyClass den.aspects.child;
+        };
+        expected = {
+          isAttrs = true;
+          hasForClass = true;
+          hasForAnyClass = true;
+          callableBare = true;
+          callableForClass = true;
+          callableForAnyClass = true;
+        };
+      }
+    );
+
+    test-mkEntityHasAspect-absent = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) mkEntityHasAspect;
+        has = mkEntityHasAspect {
+          tree = den.aspects.root;
+          primaryClass = "nixos";
+          classes = [ "nixos" ];
+        };
+      in
+      {
+        den.aspects.root.nixos = { };
+        den.aspects.unrelated.nixos = { };
+
+        expr = has den.aspects.unrelated;
+        expected = false;
+      }
+    );
+
+    test-mkEntityHasAspect-forClass-unknown-class = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) mkEntityHasAspect;
+        has = mkEntityHasAspect {
+          tree = den.aspects.root;
+          primaryClass = "nixos";
+          classes = [ "nixos" ];
+        };
+      in
+      {
+        den.aspects.root.includes = [ den.aspects.child ];
+        den.aspects.child.nixos = { };
+
+        # Unknown class returns false silently, not an error.
+        expr = has.forClass "bogus-class" den.aspects.child;
+        expected = false;
+      }
+    );
+
+    test-refKey-validator-throws-on-string = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) hasAspectIn;
+        result = builtins.tryEval (hasAspectIn {
+          tree = den.aspects.root;
+          class = "nixos";
+          ref = "not-an-aspect";
+        });
+      in
+      {
+        den.aspects.root.nixos = { };
+
+        # tryEval returns { success = false; value = false; } on throw
+        expr = result.success;
+        expected = false;
+      }
+    );
+
+    test-refKey-validator-throws-on-bare-meta = denTest (
+      { den, ... }:
+      let
+        inherit (den.lib.aspects) hasAspectIn;
+        result = builtins.tryEval (hasAspectIn {
+          tree = den.aspects.root;
+          class = "nixos";
+          # missing `name` — must throw
+          ref = {
+            meta.provider = [ "x" ];
+          };
+        });
+      in
+      {
+        den.aspects.root.nixos = { };
+
+        expr = result.success;
+        expected = false;
+      }
+    );
+
+    # Factory-function aspects (`den.aspects.myFactory = arg: {...}`)
+    # are merged through providerFnType and aspectSubmodule into an
+    # attrset-with-__functor. The factory itself has a stable
+    # aspectPath derived from its declaration name, so querying
+    # `host.hasAspect den.aspects.myFactory` is well-defined.
+    test-factory-fn-aspect-identity = denTest (
+      { den, lib, ... }:
+      let
+        inherit (den.lib.aspects) adapters;
+      in
+      {
+        den.aspects.myFactory = arg: {
+          nixos.environment.variables.FACTORY_ARG = arg;
+        };
+        # Reference the factory so submodule merging runs.
+        den.aspects.consumer.includes = [ (den.aspects.myFactory "/x") ];
+
+        expr = {
+          factoryPath = adapters.aspectPath den.aspects.myFactory;
+          factoryIsFunction = builtins.isFunction den.aspects.myFactory;
+        };
+        expected = {
+          factoryPath = [ "myFactory" ];
+          factoryIsFunction = false;
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/has-aspect.nix
+++ b/templates/ci/modules/features/has-aspect.nix
@@ -1,0 +1,131 @@
+# Smoke tests for entity.hasAspect — the core functionality:
+# host/user/home all have the method, and the bare form works for
+# structurally-present aspects. The full regression-class test matrix
+# (Groups A–I per design spec §7.3) lands in a follow-up commit.
+#
+# Note: `igloo` from denTest specialArgs is the resolved NixOS config
+# (config.flake.nixosConfigurations.igloo.config), not the den host
+# entity. The host entity — which is where `hasAspect` lives — is
+# reached via `den.hosts.x86_64-linux.igloo`. Same for users:
+# `den.hosts.x86_64-linux.igloo.users.tux`.
+{ denTest, lib, ... }:
+{
+  flake.tests.has-aspect = {
+
+    test-host-hasAspect-present-static = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.feature ];
+        den.aspects.feature.nixos = { };
+
+        # host.hasAspect is available because host imports
+        # den.schema.conf which imports modules/context/has-aspect.nix.
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.feature;
+        expected = true;
+      }
+    );
+
+    test-host-hasAspect-absent = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.nixos = { };
+        den.aspects.unrelated.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.unrelated;
+        expected = false;
+      }
+    );
+
+    test-user-hasAspect-present = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # denTest's default is classes = ["homeManager"] for users.
+        den.aspects.tux.includes = [ den.aspects.user-feature ];
+        den.aspects.user-feature.homeManager = { };
+
+        expr = den.hosts.x86_64-linux.igloo.users.tux.hasAspect den.aspects.user-feature;
+        expected = true;
+      }
+    );
+
+    test-hasAspect-forClass-explicit = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.feature ];
+        den.aspects.feature.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect.forClass "nixos" den.aspects.feature;
+        expected = true;
+      }
+    );
+
+    test-hasAspect-forAnyClass = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.feature ];
+        den.aspects.feature.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect.forAnyClass den.aspects.feature;
+        expected = true;
+      }
+    );
+
+    test-hasAspect-respects-tombstone = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [
+          den.aspects.keep
+          den.aspects.drop
+        ];
+        den.aspects.igloo.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.drop inherited;
+        den.aspects.keep.nixos = { };
+        den.aspects.drop.nixos = { };
+
+        expr = {
+          keep = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.keep;
+          drop = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.drop;
+        };
+        expected = {
+          keep = true;
+          drop = false;
+        };
+      }
+    );
+
+    test-hasAspect-angle-bracket-equivalent = denTest (
+      { den, __findFile, ... }:
+      {
+        _module.args.__findFile = den.lib.__findFile;
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.feature.nixos = { };
+        den.aspects.igloo.includes = [ den.aspects.feature ];
+
+        # <feature> sugar resolves to den.aspects.feature via __findFile.
+        expr = {
+          viaAttr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.feature;
+          viaAngle = den.hosts.x86_64-linux.igloo.hasAspect <feature>;
+        };
+        expected = {
+          viaAttr = true;
+          viaAngle = true;
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/has-aspect.nix
+++ b/templates/ci/modules/features/has-aspect.nix
@@ -1,7 +1,8 @@
-# Smoke tests for entity.hasAspect — the core functionality:
-# host/user/home all have the method, and the bare form works for
-# structurally-present aspects. The full regression-class test matrix
-# (Groups A–I per design spec §7.3) lands in a follow-up commit.
+# End-to-end tests for entity.hasAspect organized by aspect shape.
+# Every aspect-construction shape that has produced a regression
+# (#408, #413, #423, #429) has a lock-in test here, so a future
+# regression in parametric.nix or aspects/types.nix that affects any
+# of those shapes fails a hasAspect test before it reaches user code.
 #
 # Note: `igloo` from denTest specialArgs is the resolved NixOS config
 # (config.flake.nixosConfigurations.igloo.config), not the den host
@@ -124,6 +125,543 @@
           viaAttr = true;
           viaAngle = true;
         };
+      }
+    );
+
+    # ─── Group A: sanity completions ──────────────────────────────────
+
+    test-A-hosts-hasAspect-self = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.nixos = { };
+
+        # Host reports its own root aspect as present.
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.igloo;
+        expected = true;
+      }
+    );
+
+    test-A-hosts-hasAspect-chained-transitively = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.level1 ];
+        den.aspects.level1.includes = [ den.aspects.level2 ];
+        den.aspects.level2.includes = [ den.aspects.level3 ];
+        den.aspects.level3.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.level3;
+        expected = true;
+      }
+    );
+
+    # ─── Group B: parametric contexts (regression locks) ──────────────
+
+    # Baseline parametric parent with static child.
+    test-B-present-via-parametric-parent = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.parent ];
+        den.aspects.parent =
+          { host, ... }:
+          {
+            includes = [ den.aspects.child ];
+          };
+        den.aspects.child.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.child;
+        expected = true;
+      }
+    );
+
+    # #423 regression shape — parametric parent with static sub-aspect.
+    # If applyDeep regresses, role._.sub vanishes from the tree.
+    test-B-present-via-static-sub-aspect-in-parametric-parent = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.role =
+              { host, ... }:
+              {
+                includes = [ den.aspects.role._.sub ];
+              };
+          }
+          {
+            den.aspects.role._.sub.nixos.networking.networkmanager.enable = true;
+          }
+          {
+            den.aspects.igloo.includes = [ den.aspects.role ];
+          }
+        ];
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.role._.sub;
+        expected = true;
+      }
+    );
+
+    # #413 shape — parametric parent unconditionally includes a
+    # bare-function provider sub-aspect. Exercises the applyDeep
+    # inner-recursion + meta-carryover path.
+    test-B-present-via-bare-function-sub-aspect = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.foo =
+              { host, ... }:
+              {
+                includes = [ den.aspects.foo._.sub ];
+              };
+          }
+          {
+            den.aspects.foo._.sub =
+              { host, ... }:
+              {
+                nixos.networking.networkmanager.enable = true;
+              };
+          }
+          {
+            den.aspects.igloo.includes = [ den.aspects.foo ];
+          }
+        ];
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.foo._.sub;
+        expected = true;
+      }
+    );
+
+    test-B-absent-when-parametric-parent-omits = denTest (
+      { den, lib, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.gated ];
+        den.aspects.gated =
+          { host, ... }:
+          {
+            includes = lib.optional (host.name == "other-host") den.aspects.conditional;
+          };
+        den.aspects.conditional.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.conditional;
+        expected = false;
+      }
+    );
+
+    # ─── Group C: factory functions ───────────────────────────────────
+
+    # Factory-fn aspects have a stable aspectPath derived from their
+    # declaration name and can be queried directly when referenced in
+    # includes. Note: invoking the factory inline (`facter arg`)
+    # produces an anonymous sibling aspect with a loc-derived name —
+    # factory identity is NOT inherited by instances.
+    test-C-factory-fn-aspect-present = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.facter = reportPath: {
+          nixos.environment.variables.FACTER_REPORT = reportPath;
+        };
+        den.aspects.igloo.includes = [ den.aspects.facter ];
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.facter;
+        expected = true;
+      }
+    );
+
+    # #408 / #429 shape — parametric function + static sibling merging.
+    test-C-factory-fn-merged-with-static-sibling = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          {
+            den.aspects.mixed =
+              { host, ... }:
+              {
+                nixos.environment.variables.MIXED_HOST = host.name;
+              };
+          }
+          {
+            den.aspects.mixed.nixos.environment.variables.MIXED_STATIC = "yes";
+          }
+          {
+            den.aspects.igloo.includes = [ den.aspects.mixed ];
+          }
+        ];
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.mixed;
+        expected = true;
+      }
+    );
+
+    # ─── Group D: provider sub-aspects ────────────────────────────────
+
+    test-D-static-provider-sub-present = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.foo._.sub ];
+        den.aspects.foo._.sub.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.foo._.sub;
+        expected = true;
+      }
+    );
+
+    # Function-bodied provider sub-aspect reached via direct inclusion
+    # — exercises the applyDeep outer-result meta-carryover path.
+    test-D-parametric-provider-sub-present = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.foo._.sub ];
+        den.aspects.foo._.sub =
+          { host, ... }:
+          {
+            nixos.environment.variables.FOO_SUB = host.name;
+          };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.foo._.sub;
+        expected = true;
+      }
+    );
+
+    test-D-provider-sub-identity-distinct-from-homonym = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.bar._.foo ];
+        den.aspects.bar._.foo.nixos = { };
+        # `foo` also exists at top level — different aspectPath.
+        den.aspects.foo.nixos = { };
+
+        expr = {
+          sub = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.bar._.foo;
+          top = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.foo;
+        };
+        expected = {
+          sub = true;
+          top = false;
+        };
+      }
+    );
+
+    # ─── Group E: mutual-provider / provides chains ───────────────────
+
+    test-E-present-via-provides-to-users = denTest (
+      { den, ... }:
+      {
+        den.ctx.user.includes = [ den._.mutual-provider ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.provides.to-users = {
+          includes = [ den.aspects.user-target ];
+        };
+        den.aspects.user-target.homeManager = { };
+
+        expr = den.hosts.x86_64-linux.igloo.users.tux.hasAspect den.aspects.user-target;
+        expected = true;
+      }
+    );
+
+    test-E-present-via-provides-specific-user = denTest (
+      { den, ... }:
+      {
+        den.ctx.user.includes = [ den._.mutual-provider ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.igloo.users.alice = { };
+
+        den.aspects.igloo.provides.alice = {
+          includes = [ den.aspects.alice-only ];
+        };
+        den.aspects.alice-only.homeManager = { };
+
+        expr = {
+          alice = den.hosts.x86_64-linux.igloo.users.alice.hasAspect den.aspects.alice-only;
+          tux = den.hosts.x86_64-linux.igloo.users.tux.hasAspect den.aspects.alice-only;
+        };
+        expected = {
+          alice = true;
+          tux = false;
+        };
+      }
+    );
+
+    test-E-present-via-user-to-hosts = denTest (
+      { den, ... }:
+      {
+        den.ctx.user.includes = [ den._.mutual-provider ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tux.provides.to-hosts = {
+          includes = [ den.aspects.host-target ];
+        };
+        den.aspects.host-target.nixos = { };
+
+        expr = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.host-target;
+        expected = true;
+      }
+    );
+
+    # ─── Group F: meta.adapter interactions ───────────────────────────
+
+    test-F-respects-substituteAspect = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.original ];
+        den.aspects.igloo.meta.adapter =
+          inherited:
+          den.lib.aspects.adapters.substituteAspect den.aspects.original den.aspects.replacement inherited;
+        den.aspects.original.nixos = { };
+        den.aspects.replacement.nixos = { };
+
+        expr = {
+          original = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.original;
+          replacement = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.replacement;
+        };
+        expected = {
+          original = false;
+          replacement = true;
+        };
+      }
+    );
+
+    # Two adapters at DIFFERENT levels, each tombstoning a direct child
+    # of its own aspect. Nested-reaching does NOT work because
+    # filterIncludes.tag only stamps a parent's adapter onto children
+    # without their own adapter — children with adapters keep theirs.
+    # This test exercises composition that works: each adapter affects
+    # its own subtree.
+    test-F-composes-at-different-levels = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # igloo's adapter tombstones root-sibling at its own level.
+        den.aspects.igloo.includes = [
+          den.aspects.parent
+          den.aspects.root-sibling
+        ];
+        den.aspects.igloo.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.root-sibling inherited;
+
+        # parent's adapter tombstones parent-sibling at its own level.
+        den.aspects.parent.includes = [
+          den.aspects.child-a
+          den.aspects.parent-sibling
+        ];
+        den.aspects.parent.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.parent-sibling inherited;
+
+        den.aspects.root-sibling.nixos = { };
+        den.aspects.parent-sibling.nixos = { };
+        den.aspects.child-a.nixos = { };
+
+        # Each adapter tombstones its own direct-child target;
+        # child-a survives under parent.
+        expr = {
+          rootSibling = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.root-sibling;
+          parentSibling = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.parent-sibling;
+          childA = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.child-a;
+        };
+        expected = {
+          rootSibling = false;
+          parentSibling = false;
+          childA = true;
+        };
+      }
+    );
+
+    test-F-respects-oneOfAspects = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [ den.aspects.bundle ];
+        den.aspects.bundle.includes = [
+          den.aspects.primary
+          den.aspects.fallback
+        ];
+        den.aspects.bundle.meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+          den.aspects.primary
+          den.aspects.fallback
+        ];
+        den.aspects.primary.nixos = { };
+        den.aspects.fallback.nixos = { };
+
+        expr = {
+          primary = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.primary;
+          fallback = den.hosts.x86_64-linux.igloo.hasAspect den.aspects.fallback;
+        };
+        expected = {
+          primary = true;
+          fallback = false;
+        };
+      }
+    );
+
+    # ─── Group G: multi-class users ───────────────────────────────────
+
+    test-G-user-hasAspect-primary-class = denTest (
+      { den, lib, ... }:
+      {
+        den.schema.user.classes = lib.mkForce [
+          "user"
+          "homeManager"
+        ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tux.includes = [ den.aspects.target ];
+        den.aspects.target.user = { };
+        den.aspects.target.homeManager = { };
+
+        # Primary class = lib.head classes = "user"
+        expr = den.hosts.x86_64-linux.igloo.users.tux.hasAspect den.aspects.target;
+        expected = true;
+      }
+    );
+
+    test-G-user-hasAspect-forClass-explicit = denTest (
+      { den, lib, ... }:
+      {
+        den.schema.user.classes = lib.mkForce [
+          "user"
+          "homeManager"
+        ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tux.includes = [ den.aspects.target ];
+        den.aspects.target.homeManager = { };
+
+        expr = {
+          user = den.hosts.x86_64-linux.igloo.users.tux.hasAspect.forClass "user" den.aspects.target;
+          hm = den.hosts.x86_64-linux.igloo.users.tux.hasAspect.forClass "homeManager" den.aspects.target;
+        };
+        # Structural tree is class-invariant — both return true.
+        expected = {
+          user = true;
+          hm = true;
+        };
+      }
+    );
+
+    test-G-user-hasAspect-forAnyClass-matches-any = denTest (
+      { den, lib, ... }:
+      {
+        den.schema.user.classes = lib.mkForce [
+          "user"
+          "homeManager"
+        ];
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tux.includes = [ den.aspects.target ];
+        den.aspects.target.homeManager = { };
+
+        expr = den.hosts.x86_64-linux.igloo.users.tux.hasAspect.forAnyClass den.aspects.target;
+        expected = true;
+      }
+    );
+
+    test-G-user-hasAspect-forClass-unknown-class = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tux.includes = [ den.aspects.target ];
+        den.aspects.target.homeManager = { };
+
+        # Unknown class: returns false silently, no error.
+        expr = den.hosts.x86_64-linux.igloo.users.tux.hasAspect.forClass "bogus" den.aspects.target;
+        expected = false;
+      }
+    );
+
+    # ─── Group H: extensibility ───────────────────────────────────────
+
+    # Verify den.schema.conf owns the hasAspect option — not
+    # host/user/home individually. Any entity kind importing conf
+    # inherits hasAspect.
+    test-H-conf-option-exists = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # If conf owns the option, host imports conf, and therefore
+        # host.hasAspect is defined. The smoke test would fail first
+        # if not — this test documents the contract explicitly.
+        expr = den.schema ? conf;
+        expected = true;
+      }
+    );
+
+    # ─── Group I: error cases ─────────────────────────────────────────
+
+    test-I-bad-ref-throws = denTest (
+      { den, ... }:
+      let
+        result = builtins.tryEval (den.hosts.x86_64-linux.igloo.hasAspect "not-a-ref");
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.nixos = { };
+
+        expr = result.success;
+        expected = false;
+      }
+    );
+
+    # ─── Group J: real-world class-body call (cycle-safety check) ─────
+
+    # The primary intended use case: calling hasAspect from inside a
+    # deferred nixos module body. The body runs at evalModules time,
+    # long after the aspect tree is frozen — a cyclic implementation
+    # would hit infinite recursion here.
+    #
+    # Note: the `host` specialArg set by nix/lib/types.nix lives on
+    # the den host submodule and does NOT propagate into OS-level
+    # deferred nixos modules. We close over the entity at the outer
+    # level via a let binding — the nixos body is still deferred, so
+    # the cycle-safety property is still validated.
+    test-J-hasAspect-in-class-module-body = denTest (
+      { den, igloo, ... }:
+      let
+        hostEntity = den.hosts.x86_64-linux.igloo;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [
+          den.aspects.feature-flag
+          den.aspects.gated-consumer
+        ];
+        den.aspects.feature-flag.nixos = { };
+
+        den.aspects.gated-consumer.nixos =
+          { config, ... }:
+          {
+            environment.variables.HAS_FLAG =
+              if hostEntity.hasAspect den.aspects.feature-flag then "yes" else "no";
+          };
+
+        expr = igloo.environment.variables.HAS_FLAG or null;
+        expected = "yes";
       }
     );
 

--- a/templates/ci/modules/features/one-of-aspects.nix
+++ b/templates/ci/modules/features/one-of-aspects.nix
@@ -1,0 +1,162 @@
+# Tests for den.lib.aspects.adapters.oneOfAspects — the structural-
+# decision adapter for "prefer A over B when both are present".
+{ denTest, lib, ... }:
+{
+  flake.tests.one-of-aspects = {
+
+    test-prefers-first-present = denTest (
+      { den, trace, ... }:
+      {
+        den.aspects.bundle.includes = [
+          den.aspects.pref-a
+          den.aspects.pref-b
+        ];
+        den.aspects.bundle.meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+          den.aspects.pref-a
+          den.aspects.pref-b
+        ];
+        den.aspects.pref-a.nixos = { };
+        den.aspects.pref-b.nixos = { };
+
+        # Tombstone visible in trace as ~pref-b.
+        expr = trace "nixos" den.aspects.bundle;
+        expected.trace = [
+          "bundle"
+          [ "pref-a" ]
+          [ "~pref-b" ]
+        ];
+      }
+    );
+
+    test-falls-through-to-second = denTest (
+      { den, trace, ... }:
+      {
+        den.aspects.bundle.includes = [ den.aspects.only-b ];
+        den.aspects.bundle.meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+          den.aspects.pref-a
+          den.aspects.only-b
+        ];
+        # pref-a is defined but not included in the bundle subtree.
+        den.aspects.pref-a.nixos = { };
+        den.aspects.only-b.nixos = { };
+
+        expr = trace "nixos" den.aspects.bundle;
+        expected.trace = [
+          "bundle"
+          [ "only-b" ]
+        ];
+      }
+    );
+
+    test-both-absent-no-effect = denTest (
+      { den, trace, ... }:
+      {
+        den.aspects.bundle.includes = [ den.aspects.neither ];
+        den.aspects.bundle.meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+          den.aspects.pref-a
+          den.aspects.pref-b
+        ];
+        den.aspects.neither.nixos = { };
+        # pref-a and pref-b are defined but not included:
+        den.aspects.pref-a.nixos = { };
+        den.aspects.pref-b.nixos = { };
+
+        # No tombstones — neither candidate is in the subtree.
+        expr = trace "nixos" den.aspects.bundle;
+        expected.trace = [
+          "bundle"
+          [ "neither" ]
+        ];
+      }
+    );
+
+    test-composes-with-outer-adapter = denTest (
+      { den, trace, ... }:
+      {
+        # root sibling-filters bundle and sibling; bundle internally
+        # uses oneOfAspects. Verifies the two adapters both take effect
+        # at their own level without interfering: root's filter kills
+        # the sibling, bundle's oneOfAspects kills pref-b.
+        den.aspects.root.includes = [
+          den.aspects.bundle
+          den.aspects.sibling
+        ];
+        den.aspects.root.meta.adapter =
+          inherited: den.lib.aspects.adapters.excludeAspect den.aspects.sibling inherited;
+        den.aspects.bundle.includes = [
+          den.aspects.pref-a
+          den.aspects.pref-b
+        ];
+        den.aspects.bundle.meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+          den.aspects.pref-a
+          den.aspects.pref-b
+        ];
+        den.aspects.pref-a.nixos = { };
+        den.aspects.pref-b.nixos = { };
+        den.aspects.sibling.nixos = { };
+
+        expr = trace "nixos" den.aspects.root;
+        expected.trace = [
+          "root"
+          [
+            "bundle"
+            [ "pref-a" ]
+            [ "~pref-b" ]
+          ]
+          [ "~sibling" ]
+        ];
+      }
+    );
+
+    test-works-on-sub-aspects = denTest (
+      { den, trace, ... }:
+      {
+        den.aspects.bundle.includes = [
+          den.aspects.foo._.impl-a
+          den.aspects.foo._.impl-b
+        ];
+        den.aspects.bundle.meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+          den.aspects.foo._.impl-a
+          den.aspects.foo._.impl-b
+        ];
+        den.aspects.foo._.impl-a.nixos = { };
+        den.aspects.foo._.impl-b.nixos = { };
+
+        expr = trace "nixos" den.aspects.bundle;
+        expected.trace = [
+          "bundle"
+          [ "impl-a" ]
+          [ "~impl-b" ]
+        ];
+      }
+    );
+
+    test-preserves-non-candidate-includes = denTest (
+      { den, trace, ... }:
+      {
+        den.aspects.bundle.includes = [
+          den.aspects.pref-a
+          den.aspects.pref-b
+          den.aspects.unrelated
+        ];
+        den.aspects.bundle.meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+          den.aspects.pref-a
+          den.aspects.pref-b
+        ];
+        den.aspects.pref-a.nixos = { };
+        den.aspects.pref-b.nixos = { };
+        den.aspects.unrelated.nixos = { };
+
+        # unrelated is not a candidate and should be untouched.
+        expr = trace "nixos" den.aspects.bundle;
+        expected.trace = [
+          "bundle"
+          [ "pref-a" ]
+          [ "~pref-b" ]
+          [ "unrelated" ]
+        ];
+      }
+    );
+
+  };
+}

--- a/templates/example/modules/aspects/hasAspect-examples.nix
+++ b/templates/example/modules/aspects/hasAspect-examples.nix
@@ -1,0 +1,149 @@
+# Worked examples for `host.hasAspect` and `oneOfAspects`.
+#
+# Two complementary tools for two different jobs:
+#
+#   - `entity.hasAspect` READS structure at query time from inside
+#     class-config module bodies (`nixos = ...`, `homeManager = ...`).
+#     Cycle-safe because the body runs at evalModules time, long after
+#     the aspect tree has been resolved and frozen.
+#
+#   - `oneOfAspects` (and friends in `nix/lib/aspects/adapters.nix`)
+#     WRITE structure at adapter time with full structural visibility.
+#     The right tool for "prefer A over B when both are present" and
+#     other tree-shape decisions.
+#
+# These illustrative aspects are all `example-` prefixed to make it
+# clear they are pedagogical stubs and to avoid colliding with any
+# real aspect names in the template.
+{ den, lib, ... }:
+{
+
+  # ──────────────────────────────────────────────────────────────────
+  # Pattern 1 — Reading structure via `host.hasAspect` from a class body
+  # ──────────────────────────────────────────────────────────────────
+  #
+  # The 95% case. A parametric aspect captures `host` from its functor
+  # arguments and uses `host.hasAspect` inside its `nixos = ...` body
+  # to branch on whether a companion aspect is structurally present on
+  # the same host.
+  #
+  # This is cycle-safe: the `nixos` body is a deferred module that
+  # runs during evalModules, by which point `host.resolved` (the
+  # aspect tree this query reads) has already been computed and is
+  # frozen. There is no back-edge from the body into the tree.
+
+  # Two "backend" aspects an impermanence setup can be flavored against.
+  den.aspects.example-zfs-root.nixos = {
+    # Stub representing the zfs-root configuration that would set up
+    # zpools, datasets, the boot loader, etc. Kept empty here so the
+    # example template still evaluates without zfs-specific options.
+    environment.etc."example-root-backend".text = "zfs";
+  };
+
+  den.aspects.example-btrfs-root.nixos = {
+    environment.etc."example-root-backend".text = "btrfs";
+  };
+
+  # An impermanence aspect that adapts its config based on which root
+  # backend is also present on the host. The outer `{ host, ... }:`
+  # makes the aspect parametric, which is what gives the inner `nixos`
+  # body access to `host.hasAspect`.
+  den.aspects.example-impermanence =
+    { host, ... }:
+    {
+      nixos =
+        { lib, ... }:
+        lib.mkMerge [
+          (lib.mkIf (host.hasAspect den.aspects.example-zfs-root) {
+            # zfs-flavored impermanence wiring would go here
+            # (e.g. rollback service on a zfs snapshot of the root dataset).
+            environment.etc."example-impermanence-flavor".text = "zfs";
+          })
+          (lib.mkIf (host.hasAspect den.aspects.example-btrfs-root) {
+            # btrfs-flavored impermanence wiring would go here
+            # (e.g. snapshot rollback via btrfs subvolumes).
+            environment.etc."example-impermanence-flavor".text = "btrfs";
+          })
+        ];
+    };
+
+  # ──────────────────────────────────────────────────────────────────
+  # Pattern 2 — Deciding structure via a `meta.adapter` (`oneOfAspects`)
+  # ──────────────────────────────────────────────────────────────────
+  #
+  # When the decision is STRUCTURAL ("which of these aspects should
+  # actually be part of the tree?") rather than CONFIGURATIONAL ("given
+  # this aspect is in the tree, how should it configure NixOS?"), the
+  # right tool is a `meta.adapter` composed via `oneOfAspects`.
+  #
+  # The adapter runs during the resolve tree walk and has full
+  # structural visibility — and crucially, it operates ON the tree
+  # rather than reading FROM INSIDE it, so it can't cycle.
+  #
+  # Here: a secrets-bundle aspect lists both an agenix-rekey-style
+  # provider and a sops-nix-style provider in its includes, and a
+  # `oneOfAspects` adapter prefers agenix-rekey when both are present
+  # and falls back to sops-nix otherwise. Both candidates remain in
+  # the includes list — `oneOfAspects` tombstones the loser during
+  # resolution rather than at module-definition time.
+
+  den.aspects.example-agenix-rekey.nixos = {
+    environment.etc."example-secrets-provider".text = "agenix-rekey";
+  };
+
+  den.aspects.example-sops-nix.nixos = {
+    environment.etc."example-secrets-provider".text = "sops-nix";
+  };
+
+  den.aspects.example-secrets-bundle = {
+    includes = [
+      den.aspects.example-agenix-rekey
+      den.aspects.example-sops-nix
+    ];
+    meta.adapter = den.lib.aspects.adapters.oneOfAspects [
+      den.aspects.example-agenix-rekey # preferred when present
+      den.aspects.example-sops-nix # fallback
+    ];
+  };
+
+  # ──────────────────────────────────────────────────────────────────
+  # Anti-pattern — DO NOT use `hasAspect` to decide an `includes` list
+  # ──────────────────────────────────────────────────────────────────
+  #
+  # The following shape looks plausible but produces an infinite
+  # recursion at evaluation time:
+  #
+  #     den.aspects.broken =
+  #       { host, ... }:
+  #       {
+  #         includes =
+  #           if host.hasAspect den.aspects.example-zfs-root
+  #           then [ den.aspects.example-zfs-impermanence ]
+  #           else [ den.aspects.example-btrfs-impermanence ];
+  #       };
+  #
+  # Why it cycles:
+  #
+  #   - `host.hasAspect` queries the resolved aspect tree.
+  #   - The resolved aspect tree depends on every aspect's `includes`.
+  #   - `broken`'s `includes` depends on `host.hasAspect`.
+  #
+  # That is a back-edge into the tree from a position the tree itself
+  # has to read first to know its own shape — a classic fixed-point
+  # with no fixed point. Nix evaluation reports infinite recursion.
+  #
+  # The correct tool for "decide what to include based on what else
+  # is structurally present" is a `meta.adapter`. See
+  # `nix/lib/aspects/adapters.nix` for the full set:
+  #
+  #   - `oneOfAspects [ a b c ]`     keep the first present, tombstone the rest
+  #   - `excludeAspect <ref>`        tombstone a specific aspect by reference
+  #   - `substituteAspect <a> <b>`   swap one aspect for another
+  #   - `filter` / `filterIncludes`  custom filtering primitives
+  #
+  # These run during the tree walk with full structural visibility and
+  # operate ON the tree rather than FROM INSIDE it, so they can't
+  # cycle. Reach for them whenever the decision you want to make is
+  # "which aspects should be in the tree?" rather than "given this
+  # aspect is in the tree, what should it configure?"
+}


### PR DESCRIPTION
# feat: `entity.hasAspect <ref>` query method

## What this does

Adds a `.hasAspect` method on context entities (`host`, `user`, `home`, and any custom entity kind that imports `den.schema.conf`). It answers "is this aspect structurally present in my resolved tree?" from inside class-config module bodies:

```nix
den.aspects.impermanence.nixos = { config, host, ... }: lib.mkMerge [
  (lib.mkIf (host.hasAspect <zfs-root>)   { /* zfs impermanence */ })
  (lib.mkIf (host.hasAspect <btrfs-root>) { /* btrfs impermanence */ })
];
```

There are two variants for when the bare form isn't enough:

```nix
host.hasAspect.forClass "nixos" <facter>
user.hasAspect.forAnyClass <agenix-rekey>
```

Identity is compared by `aspectPath` (`meta.provider ++ [name]`), so provider sub-aspects like `foo._.sub` keep their full path. Refs can be plain aspect values (`den.aspects.facter`) or `<angle-bracket>` sugar, they're the same thing after `__findFile` resolves.

Alongside `hasAspect`, this ships a companion `oneOfAspects` adapter. That's the structural-decision primitive for "prefer A over B when both are present", which is the thing you actually want when you're tempted to use `hasAspect` to decide includes (see the guardrails section below).

## Why

Real patterns that users hit:

- `<impermanence>` config depends on whether `<zfs-root>` or
  `<btrfs-root>` is also configured on the host
- A secrets forward wants to pick `<agenix-rekey>` when present and
  fall back to `<sops-nix>` otherwise
- Library aspects want to gate opt-in behavior on companion aspects

Today these get worked around with `config.*` lookups, hand-maintained `lib.elem` checks, or structural hacks. `hasAspect` is the first-class primitive for the read side. `oneOfAspects` is the first-class primitive for the write side.

## Commits

Each commit is independently reviewable and builds green on its own.

### `fix(parametric): preserve meta on materialized parametric results`

Opened as it's own PR #440 

### `feat(adapters): add collectPaths terminal adapter`

New public terminal adapter. Walks a resolved tree via `filterIncludes` and returns `{ paths = [ [providerSeg..., name], ... ]; }`, depth-first, not deduplicated. Tombstones are skipped via the `meta.excluded` check.

Ships with two small helpers exported from the same file: `pathKey` (slash-joined path key) and `toPathSet` (list of paths to attrset-as-set for O(1) lookups). Both are used by `hasAspect` and `oneOfAspects`, so exporting them keeps the two consumers from duplicating the same one-liners.

### `feat(adapters): add oneOfAspects structural-decision adapter`

`meta.adapter` that keeps the first structurally-present candidate and tombstones the rest via `excludeAspect`:

```nix
den.aspects.secrets-bundle = {
  includes = [ <agenix-rekey> <sops-nix> ];
  meta.adapter = den.lib.aspects.adapters.oneOfAspects [
    <agenix-rekey>  # preferred
    <sops-nix>      # fallback
  ];
};
```

Complements `excludeAspect` and `substituteAspect`. The three together cover include-this / exclude-this / swap-this-for-that. Internally it walks the parent subtree with the raw collector (bypassing `filterIncludes` so it doesn't re-enter itself), finds which candidates are present, and folds `excludeAspect` over the losers. No code duplication with `collectPaths` thanks to the shared helpers from the previous commit.

### `feat(aspects): add has-aspect library primitives`

New file `nix/lib/aspects/has-aspect.nix` exporting:

- `hasAspectIn { tree; class; ref }` for any resolved tree, not just
  entity contexts
- `collectPathSet { tree; class }` for an attrset-as-set of visible
  paths
- `mkEntityHasAspect { tree; primaryClass; classes }` which builds the
  functor-plus-attrs value attached to entities. Per-class path sets
  are thunk-cached, so repeated calls share one traversal per class

`refKey` validates that its input has both `name` and `meta` before reaching for `aspectPath`, throwing loudly rather than silently producing an `<anon>` path key.

### `feat(context): add entity.hasAspect method via den.schema.conf`

The wiring. `modules/context/has-aspect.nix` is a flake-level module that self-wires into `den.schema.conf` via `config.den.schema.conf.imports`. Every entity type that imports `conf` (host, user, home, and any user-defined kind) inherits `.hasAspect` automatically. Zero changes to `nix/lib/types.nix`.

Class-protocol: prefers `classes` (list), falls back to `[ class ]`, throws otherwise. Entities without a matching `den.ctx.<kind>` (so no `config.resolved`) produce a call-time throw. The fallback value preserves the functor-plus-attrs shape so `forClass` / `forAnyClass` attribute access doesn't leak a cryptic error before reaching the real one.

### `test(has-aspect): full regression-class coverage for entity method`

31 tests organized by aspect-construction shape. Every shape that's produced a recent regression (`#408`, `#413`, `#423`, `#429`) has a lock-in test. A future regression in `parametric.nix` or `aspects/types.nix` that breaks any of these shapes trips a `has-aspect` test before it reaches user code.

Groups cover basic and transitive chains, parametric contexts including the static and bare-function sub-aspect shapes, factory functions, provider sub-aspects and identity disambiguation, mutual-provider and provides chains, `meta.adapter` composition, multi-class users, the extensibility contract, error cases, and the primary intended use case (calling `hasAspect` from inside a deferred `nixos` module body).

### `docs(example): add hasAspect + oneOfAspects worked examples`

User-facing pedagogical file in `templates/example/`. Three sections: reading structure via `host.hasAspect` from a class-config body, writing structure via `oneOfAspects` as a `meta.adapter`, and an anti-pattern section explaining why `hasAspect` can't decide an aspect's `includes` list with a pointer at the adapter library.

## Design guardrails

`hasAspect` is a read-only query on frozen structure. You call it from inside class-config module bodies (`nixos = ...`, `homeManager = ...`) or from lazy positions in aspect functor bodies. It's cycle-safe by construction because by the time deferred class modules evaluate, the aspect tree has already been resolved and frozen.

What it is not for: deciding an aspect's `includes` list. That's cyclic. The tree you want to query depends on the decision you want `hasAspect` to inform. Users who need that reach for `meta.adapter` composed via `oneOfAspects`, `excludeAspect`, `substituteAspect`, or `filter` / `filterIncludes`. Those run during the tree walk with full structural visibility, so they can't cycle. The template example file has an explicit anti-pattern section with the failing shape and the correct rewrite.

Two tools, two jobs:

| Need | Tool | When it runs |
|---|---|---|
| Read "is X in my tree?" from module config | `hasAspect` | After the tree is frozen, inside lazy class-module bodies |
| Decide tree structure based on "is X present?" | `meta.adapter` + `oneOfAspects` / friends | During the tree walk, with full structural visibility |

## Test plan

- [x] `just ci` passes 331/331 at branch tip
- [x] Each commit builds and passes tests on its own
- [x] `just fmt` is idempotent across the tree
- [x] The parametric fix doesn't regress `deadbugs/issue-413-*`,
      `deadbugs/issue-423-*`, or `issue-408` tests
- [x] Full regression-class matrix covers every aspect shape that's
      produced a recent bug

## Migration

None. Purely additive.

- `hasAspect` is a new option name, no conflict.
- No signature changes in `parametric.nix`, `resolve.nix`, `ctx-apply.nix`, `types.nix`, or the other core library files.
- `adapters.nix` gains new exports (`collectPaths`, `oneOfAspects`, `pathKey`, `toPathSet`). Nothing is renamed or removed.
- `nix/lib/aspects/default.nix` re-exports the new lib functions under `den.lib.aspects.*` at their canonical paths.
- `modules/context/has-aspect.nix` is a new file, picked up by the existing `import-tree` flake setup.
- Zero changes to `nix/lib/types.nix`.

## Follow-ups

- Docs pass on when to make aspects non-parametric. Users often reach for `perHost` / `perUser` wrappers when the aspect has no actual ctx dependence, which makes structural tooling less reliable than it could be. Docs-only, separate PR.
- Conditional-include wrapper `onlyIf guard target`. A small adapter sitting next to `oneOfAspects` that lets users write `includes = [ (onlyIf <zfs-root> <zfs-impermanence>) ]` for "include target iff guard is structurally present." Same cycle-avoidance trick (decision runs in the wrapper's own meta.adapter, walks the subtree with the raw `collectPathsInner` collector so it doesn't re-enter itself). Reuses every helper this PR exports. Rough spec is written up, scoped as its own follow-up PR.
