### PR TITLE
fix: parametric - preserve meta on materialized parametric results

### DIFF
--- a/nix/lib/parametric.nix
+++ b/nix/lib/parametric.nix
@@ -20,6 +20,17 @@ let
     }
     // extra;
 
+  # Copy fn's meta onto a materialized functor result. Preserves
+  # meta.provider so provider sub-aspects keep their full aspectPath
+  # (e.g. ["foo","sub"]) after the user fn is invoked and returns a
+  # raw attrset that would otherwise drop it.
+  carryMeta =
+    fn: result:
+    if builtins.isAttrs result && fn ? meta && !(result ? meta) then
+      result // { inherit (fn) meta; }
+    else
+      result;
+
   # When takeFn succeeds and returns a result with sub-includes,
   # also try to resolve those sub-includes with takeFn. This handles
   # provider sub-aspect functions nested inside include results:
@@ -28,15 +39,17 @@ let
   applyDeep =
     takeFn: ctx: fn:
     let
-      r = takeFn fn ctx;
+      rRaw = takeFn fn ctx;
+      r = carryMeta fn rRaw;
       # Bare provider results carry only includes (+ name from carryAttrs).
       # Results from withOwn/withIdentity have meta; deferred deepRecurse
       # wrappers have __functor. Re-resolving either would double-apply
       # context and duplicate modules.
-      isBareResult = builtins.isAttrs r && r ? includes && !(r ? meta) && !(r ? __functor);
+      # Checked against rRaw (pre-carryMeta) so the recursion branch still fires.
+      isBareResult = builtins.isAttrs rRaw && rRaw ? includes && !(rRaw ? meta) && !(rRaw ? __functor);
     in
-    if r == { } then
-      r
+    if rRaw == { } then
+      rRaw
     else if isBareResult then
       r
       // {
@@ -46,7 +59,9 @@ let
         # class configs must be picked up later by the static resolve pass.
         # A user-provided provider fn (e.g. { host, ... }: { nixos = ...; })
         # has host in functionArgs; canTake.upTo fires and we materialize it.
-        includes = map (sub: if canTake.upTo ctx sub then take.upTo sub ctx else sub) r.includes;
+        includes = map (
+          sub: if canTake.upTo ctx sub then carryMeta sub (take.upTo sub ctx) else sub
+        ) rRaw.includes;
       }
     else
       r;


### PR DESCRIPTION
Parametric sub-aspects defined as bare functions
(`foo._.sub = { host, ... }: { nixos = ...; }`) lost their `foo` provider prefix in the resolved aspect tree: when the functor was invoked by applyDeep, the raw user return (`{ nixos = ...; }`) didn't carry the sub's `meta.provider = ["foo"]`, so downstream aspectPath-based queries saw the aspect as `["sub"]` instead of `["foo","sub"]`.

This was invisible as long as consumers only extracted classModule via `aspect.${class}` without caring about aspectPath — see deadbugs/issue-413-provider-sub-aspect-function, still passes. It surfaces the moment anything compares aspect references by their full `meta.provider ++ [name]` identity.

Fix: add a small `carryMeta fn result` helper in applyDeep that copies `meta` from the originating fn onto the materialized result when the result doesn't already carry its own. Applied to both:

- the outer `take` result (direct-include path)
- the inner re-recursion on bare-result.includes (parametric-parent path, where a functor returns `{ includes = [foo._.sub] }`)

`isBareResult` is checked against the pre-carryMeta value so the bare-result recursion branch still fires — carrying meta would otherwise mask it and skip the sub-recursion.

Scope kept narrow to applyDeep rather than touching `take.carryAttrs` globally: a broader fix there affects every take.* call site (including statics.nix and resolve.apply) and breaks unrelated tests that depend on take results being metaless.