### PR TITLE
fix: propagate context through named parametric includes

### DIFF
--- a/nix/lib/parametric.nix
+++ b/nix/lib/parametric.nix
@@ -59,8 +59,22 @@ let
         # class configs must be picked up later by the static resolve pass.
         # A user-provided provider fn (e.g. { host, ... }: { nixos = ...; })
         # has host in functionArgs; canTake.upTo fires and we materialize it.
+        #
+        # Named aspects (coerced from parametric fns by coercedProviderType)
+        # also have functionArgs = {} on their default functor, so
+        # canTake.upTo fails for them too. But their includes may contain
+        # unapplied parametric functions that need context. For these, recurse
+        # into the aspect's includes directly — applying context to each fn
+        # include without invoking the aspect's own functor (which would drop
+        # owned class configs on static aspects per #423).
         includes = map (
-          sub: if canTake.upTo ctx sub then carryMeta sub (take.upTo sub ctx) else sub
+          sub:
+          if canTake.upTo ctx sub then
+            carryMeta sub (take.upTo sub ctx)
+          else if builtins.isAttrs sub && sub ? __functor && sub ? includes then
+            sub // { includes = map (applyDeep takeFn ctx) (sub.includes or [ ]); }
+          else
+            sub
         ) rRaw.includes;
       }
     else

--- a/templates/ci/modules/features/deadbugs/issue-442-parametric-included-by-parametric.nix
+++ b/templates/ci/modules/features/deadbugs/issue-442-parametric-included-by-parametric.nix
@@ -1,0 +1,101 @@
+# Parametric aspects included by parametric aspects are not applied.
+# When a named parametric aspect (context-destructuring fn) includes another
+# named parametric aspect, the coercedProviderType wraps both into
+# { includes = [fn]; __functor = defaultFunctor; }. mapIncludes was skipping
+# includes that have __functor, so the inner parametric fn never received
+# user/host context and its config was silently dropped.
+# https://github.com/vic/den/issues/442
+{ denTest, ... }:
+{
+  flake.tests.deadbugs-issue-442 = {
+
+    # Exact reproducer from the issue: parametric dev includes parametric git.
+    test-parametric-aspect-included-by-parametric-aspect = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.git =
+          { user, ... }:
+          {
+            nixos =
+              { ... }:
+              {
+                programs.git.enable = true;
+              };
+          };
+
+        den.aspects.dev =
+          { user, ... }:
+          {
+            includes = [
+              den.aspects.git
+            ];
+          };
+
+        den.aspects.tux = {
+          includes = [
+            den.aspects.dev
+          ];
+        };
+
+        expr = igloo.programs.git.enable;
+        expected = true;
+      }
+    );
+
+    # Three-deep chain: static -> parametric -> parametric -> parametric.
+    test-triple-nested-parametric-includes = denTest (
+      {
+        den,
+        igloo,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.shell =
+          { user, ... }:
+          {
+            nixos =
+              { ... }:
+              {
+                programs.zsh.enable = true;
+              };
+          };
+
+        den.aspects.dev =
+          { user, ... }:
+          {
+            includes = [ den.aspects.shell ];
+            nixos =
+              { ... }:
+              {
+                programs.git.enable = true;
+              };
+          };
+
+        den.aspects.role =
+          { user, ... }:
+          {
+            includes = [ den.aspects.dev ];
+          };
+
+        den.aspects.tux = {
+          includes = [ den.aspects.role ];
+        };
+
+        expr = {
+          git = igloo.programs.git.enable;
+          zsh = igloo.programs.zsh.enable;
+        };
+        expected = {
+          git = true;
+          zsh = true;
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/parametric.nix
+++ b/templates/ci/modules/features/parametric.nix
@@ -90,6 +90,115 @@
       }
     );
 
+    # Parametric aspect including a static named aspect — owned configs
+    # on the static aspect must not be dropped by applyDeep recursion.
+    test-parametric-including-static-named-aspect = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.base.nixos =
+          { ... }:
+          {
+            programs.git.enable = true;
+          };
+
+        den.aspects.dev =
+          { user, ... }:
+          {
+            includes = [ den.aspects.base ];
+          };
+
+        den.aspects.tux.includes = [ den.aspects.dev ];
+
+        expr = igloo.programs.git.enable;
+        expected = true;
+      }
+    );
+
+    # Named aspect with both owned class config and parametric includes,
+    # referenced from inside a parametric function's bare result.
+    test-parametric-including-mixed-owned-and-parametric = denTest (
+      {
+        den,
+        igloo,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.tools = {
+          nixos =
+            { ... }:
+            {
+              programs.git.enable = true;
+            };
+          includes = [
+            (
+              { user, ... }:
+              {
+                nixos =
+                  { ... }:
+                  {
+                    programs.zsh.enable = true;
+                  };
+              }
+            )
+          ];
+        };
+
+        den.aspects.role =
+          { user, ... }:
+          {
+            includes = [ den.aspects.tools ];
+          };
+
+        den.aspects.tux.includes = [ den.aspects.role ];
+
+        expr = {
+          git = igloo.programs.git.enable;
+          zsh = igloo.programs.zsh.enable;
+        };
+        expected = {
+          git = true;
+          zsh = true;
+        };
+      }
+    );
+
+    # Factory function aspect called inside a nested parametric chain.
+    test-factory-in-nested-parametric-chain = denTest (
+      {
+        den,
+        igloo,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.greeter = greeting: {
+          nixos =
+            { ... }:
+            {
+              users.users.tux.description = greeting;
+            };
+        };
+
+        den.aspects.role =
+          { user, ... }:
+          {
+            includes = [ (den.aspects.greeter "hello") ];
+          };
+
+        den.aspects.tux.includes = [ den.aspects.role ];
+
+        expr = igloo.users.users.tux.description;
+        expected = "hello";
+      }
+    );
+
     test-never-matches-aspect-skipped = denTest (
       { den, igloo, ... }:
       let


### PR DESCRIPTION
Named aspects coerced from parametric fns (e.g. `den.aspects.git = { user, ... }: { nixos = ...; }`) had their context silently dropped when included from other parametric aspects. applyDeep's sub-recursion now reaches into named aspects' includes to apply context to the parametric functions inside.

Fixes #442.