### PR TITLE
feat(core): add typing of core aspect keys in strict mode

### DIFF
--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -25,15 +25,12 @@ let
     home.provides.home = { home }: den.lib.parametric.fixedTo { inherit home; } home.aspect;
     home.into.default = lib.singleton;
   };
-
-  aspectSchema.options.homeManager = lib.mkOption {
-    type = lib.types.deferredModule;
-    default = { };
-  };
-
 in
 {
   den.ctx = result.ctx // homeCtx;
   den.schema.host.imports = [ result.hostConf ];
-  den.schema.aspect.imports = [ aspectSchema ];
+  den.schema.aspect.options.homeManager = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+  };
 }

--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -26,8 +26,14 @@ let
     home.into.default = lib.singleton;
   };
 
+  aspectSchema.options.homeManager = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+  };
+
 in
 {
   den.ctx = result.ctx // homeCtx;
   den.schema.host.imports = [ result.hostConf ];
+  den.schema.aspect.imports = [ aspectSchema ];
 }

--- a/modules/aspects/provides/os-class.nix
+++ b/modules/aspects/provides/os-class.nix
@@ -30,4 +30,8 @@ let
 in
 {
   den.ctx.default.includes = [ os-class ];
+  den.schema.aspect.options.os = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+  };
 }

--- a/modules/aspects/provides/os-user.nix
+++ b/modules/aspects/provides/os-user.nix
@@ -47,4 +47,8 @@ let
 in
 {
   den.ctx.user.includes = [ fwd ];
+  den.schema.aspect.options.user = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+  };
 }

--- a/modules/aspects/provides/wsl.nix
+++ b/modules/aspects/provides/wsl.nix
@@ -64,4 +64,8 @@ in
 {
   den.ctx = ctx;
   den.schema.host.imports = [ hostConf ];
+  den.schema.aspect.options.wsl = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+  };
 }

--- a/nix/denTest.nix
+++ b/nix/denTest.nix
@@ -109,7 +109,9 @@ let
       iceberg = config.flake.nixosConfigurations.iceberg.config;
       apple = config.flake.darwinConfigurations.apple.config;
       igloo = config.flake.nixosConfigurations.igloo.config;
+      tux = igloo.users.users.tux;
       tuxHm = igloo.home-manager.users.tux;
+      pingu = igloo.users.users.pingu;
       pinguHm = igloo.home-manager.users.pingu;
 
       sort = lib.sort (a: b: a < b);
@@ -149,7 +151,9 @@ let
           apple
           igloo
           iceberg
+          tux
           tuxHm
+          pingu
           pinguHm
           trace
           ;

--- a/nix/flakeOutputs.nix
+++ b/nix/flakeOutputs.nix
@@ -18,7 +18,7 @@ let
       }
       ```
 
-    Same applies to `homeConfigurations`, `packages`, or any other 
+    Same applies to `homeConfigurations`, `packages`, or any other
     flake output attribute that might need merge-semantics for
     multiple values.
 
@@ -35,7 +35,7 @@ let
       }
       ```
 
-    See also flake-parts related error messaage: 
+    See also flake-parts related error messaage:
     https://github.com/hercules-ci/flake-parts/blob/main/modules/flake.nix
   '';
 
@@ -114,7 +114,7 @@ let
     }) systemNames
   );
 
-  all.includes = builtins.attrValues (flakeBased // systemBased);
+  all.imports = builtins.attrValues (flakeBased // systemBased);
 
   flake =
     { lib, config, ... }:

--- a/nix/lib/namespace-types.nix
+++ b/nix/lib/namespace-types.nix
@@ -10,6 +10,8 @@ let
       inherit (den.lib.ctxTypes nsCtxApply) ctxTreeType;
     in
     {
+      imports = [ (den.schema.namespace or { }) ];
+
       options.ctx = lib.mkOption {
         description = "namespace context pipeline";
         defaultText = lib.literalExpression "{ }";

--- a/nix/lib/strict.nix
+++ b/nix/lib/strict.nix
@@ -14,24 +14,66 @@
               lib.head
             ];
 
-            optionPath =
+            explanation =
               if lib.lists.hasPrefix [ "flake" ] path then
-                "den.schema.flake.options.${decl.name}"
-              else if lib.lists.hasPrefix [ "den" "default" ] path then
-                "den.schema.aspect.options.${decl.name}"
+                ''
+                  Attempted to set the flake output option "${decl.name}" but no definition exists.
+                  If this wasn't a mistake, disable STRICT mode, import the flake output or configure an option. e.g.
+
+                  # Import the flake output from den
+                  imports = [ inputs.den.flakeOutputs.${decl.name} ];
+
+                  # Import all flake outputs from den
+                  imports = [ inputs.den.flakeOuputs.all ];
+
+                  # Configure a custom flake output
+                  den.schema.flake.options.${decl.name} = lib.mkOption { ... };
+                ''
+              else if lib.lists.hasPrefix [ "den" "aspects" ] path then
+                ''
+                  Attempted to set the option "${decl.name}" on the aspect "${lib.join "." path}" but no definition exists.
+                  If this wasn't a mistake, disable STRICT mode or configure an option. e.g.
+
+                  # For all aspects
+                  den.schema.aspect.options.${decl.name} = lib.mkOption { ... };
+
+                  # For a specific aspect
+                  den.aspect.${lib.last path}.options.${decl.name} = lib.mkOption { ... };
+
+                  # As a reusable option
+                  den._.option.options.${decl.name} = lib.mkOption { ... };
+                  den.aspect.${lib.last path}.includes = [ den._.option ];
+                ''
               else if lib.lists.hasPrefix [ "den" "ful" ] path then
-                "den.schema.namespace.options.${lib.last path}.${decl.name}"
+                ''
+                  Attempted to set the option "${lib.last path}.${decl.name}" on the namespace "${lib.elemAt path 2}" but no definition exists.
+                  If this wasn't a mistake, disable STRICT mode or configure an option. e.g.
+
+                  # If you're attempting to set up a non-aspect part of the namespace like schema, ctx, or lib
+                  den.schema.namespace.options.${lib.last path}.${decl.name} = lib.mkOption { ... };
+                ''
               else
-                lib.elemAt path 1;
+                let
+                  kind = if lib.lists.any (x: x == "users") path then "user" else "host";
+                in
+                ''
+                  Attempted to set the option "${decl.name}" on the ${kind} "${lib.join "." path}" but no definition exists.
+                  If this wasn't a mistake, disable STRICT mode or configure an option. e.g.
+
+                  # For all ${kind}s
+                  den.schema.${kind}.options.${decl.name} = lib.mkOption { ... };
+
+                  # For all entities
+                  den.schema.conf.options.${decl.name} = lib.mkOption { ... };
+
+                  # For a specific ${kind}
+                  ${lib.join "." path}.options.${decl.name} = lib.mkOption { ... };
+                '';
           in
           throw ''
             STRICT MODE
-
-            Attempted to set the option "${decl.name}" in "${lib.join "." path}" but no explicit definition exists. If this wasn't a mistake, disable STRICT mode or configure an option. e.g.
-
-            ${optionPath} = lib.mkOption { ... };
-
-            See https://documentation.example
+            ${explanation}
+            See https://den.oeiuwq.com/reference/schema/
           ''
         );
     };

--- a/nix/lib/strict.nix
+++ b/nix/lib/strict.nix
@@ -14,11 +14,13 @@
               lib.head
             ];
 
-            kind =
-              if (lib.elemAt path 0) == "flake" then
-                "flake"
-              else if (lib.elemAt path 1) == "default" then
-                "aspect"
+            optionPath =
+              if lib.lists.hasPrefix [ "flake" ] path then
+                "den.schema.flake.options.${decl.name}"
+              else if lib.lists.hasPrefix [ "den" "default" ] path then
+                "den.schema.aspect.options.${decl.name}"
+              else if lib.lists.hasPrefix [ "den" "ful" ] path then
+                "den.schema.namespace.options.${lib.last path}.${decl.name}"
               else
                 lib.elemAt path 1;
           in
@@ -27,7 +29,7 @@
 
             Attempted to set the option "${decl.name}" in "${lib.join "." path}" but no explicit definition exists. If this wasn't a mistake, disable STRICT mode or configure an option. e.g.
 
-            den.schema.${kind}.options.${decl.name} = lib.mkOption { ... };
+            ${optionPath} = lib.mkOption { ... };
 
             See https://documentation.example
           ''

--- a/nix/lib/strict.nix
+++ b/nix/lib/strict.nix
@@ -14,7 +14,13 @@
               lib.head
             ];
 
-            kind = if (lib.head path) == "flake" then "flake" else lib.elemAt path 1;
+            kind =
+              if (lib.elemAt path 0) == "flake" then
+                "flake"
+              else if (lib.elemAt path 1) == "default" then
+                "aspect"
+              else
+                lib.elemAt path 1;
           in
           throw ''
             STRICT MODE

--- a/nix/strict.nix
+++ b/nix/strict.nix
@@ -1,8 +1,23 @@
-{ den, ... }:
+{ den, lib, ... }:
+let
+  moduleOption = lib.mkOption {
+    type = lib.types.deferredModule;
+    default = { };
+  };
+
+  defaultClasses.options = {
+    nixos = moduleOption;
+    darwin = moduleOption;
+  };
+in
 {
   den.schema.host = den.lib.strict;
   den.schema.user = den.lib.strict;
-  den.schema.aspect = den.lib.strict;
   den.schema.home = den.lib.strict;
   den.schema.flake = den.lib.strict;
+
+  den.schema.aspect.imports = [
+    den.lib.strict
+    defaultClasses
+  ];
 }

--- a/templates/ci/modules/features/strict.nix
+++ b/templates/ci/modules/features/strict.nix
@@ -277,6 +277,74 @@
           };
         }
       );
+
+      test-namespace = denTest (
+        {
+          inputs,
+          test,
+          lib,
+          ...
+        }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            (inputs.den.namespace "test" true)
+          ];
+
+          test.lib.flatMap = f: arr: lib.concatMap f arr;
+
+          expr = test.lib.flatMap (x: [ x ]) [
+            1
+            2
+            3
+          ];
+          expectedError = {
+            type = "ThrownError";
+            msg = "Attempted to set the option \"flatMap\" in \"den.ful.test.lib\"";
+          };
+        }
+      );
+
+      test-namespace-fix = denTest (
+        {
+          inputs,
+          test,
+          lib,
+          ...
+        }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            (inputs.den.namespace "test" true)
+          ];
+
+          den.schema.namespace.options.lib = lib.mkOption {
+            type = lib.types.lazyAttrsOf lib.types.unspecified;
+          };
+
+          test.lib.flatMap = f: arr: lib.concatMap f arr;
+
+          expr =
+            test.lib.flatMap
+              (x: [
+                x
+                x
+              ])
+              [
+                1
+                2
+                3
+              ];
+          expected = [
+            1
+            1
+            2
+            2
+            3
+            3
+          ];
+        }
+      );
     };
   };
 }

--- a/templates/ci/modules/features/strict.nix
+++ b/templates/ci/modules/features/strict.nix
@@ -28,7 +28,7 @@
         expr = den.hosts.x86_64-linux.igloo.arbitrary;
         expectedError = {
           type = "ThrownError";
-          msg = "Attempted to set the option \"arbitrary\" in \"den.hosts.x86_64-linux.igloo\"";
+          msg = "Attempted to set the option \"arbitrary\" on the host \"den.hosts.x86_64-linux.igloo\" but no definition exists.";
         };
       }
     );
@@ -43,7 +43,7 @@
         expr = den.hosts.x86_64-linux.igloo.users.tux.arbitrary;
         expectedError = {
           type = "ThrownError";
-          msg = "Attempted to set the option \"arbitrary\" in \"den.hosts.x86_64-linux.igloo.users.tux\"";
+          msg = "Attempted to set the option \"arbitrary\" on the user \"den.hosts.x86_64-linux.igloo.users.tux\" but no definition exists.";
         };
       }
     );
@@ -59,7 +59,7 @@
         expr = den.aspects.igloo.arbitrary;
         expectedError = {
           type = "ThrownError";
-          msg = "Attempted to set the option \"arbitrary\" in \"den.aspects.igloo\"";
+          msg = "Attempted to set the option \"arbitrary\" on the aspect \"den.aspects.igloo\" but no definition exists.";
         };
       }
     );
@@ -73,7 +73,7 @@
         expr = config.flake.arbitray;
         expectedError = {
           type = "ThrownError";
-          msg = "Attempted to set the option \"arbitray\" in \"flake\"";
+          msg = "Attempted to set the flake output option \"arbitray\" but no definition exists.";
         };
       }
     );
@@ -228,7 +228,7 @@
           expr = den.hosts.x86_64-linux.igloo.arbitrary;
           expectedError = {
             type = "ThrownError";
-            msg = "Attempted to set the option \"arbitrary\" in \"den.hosts.x86_64-linux.igloo\"";
+            msg = "Attempted to set the option \"arbitrary\" on the host \"den.hosts.x86_64-linux.igloo\"";
           };
         }
       );
@@ -243,7 +243,7 @@
           expr = den.hosts.x86_64-linux.igloo.users.tux.arbitrary;
           expectedError = {
             type = "ThrownError";
-            msg = "Attempted to set the option \"arbitrary\" in \"den.hosts.x86_64-linux.igloo.users.tux\"";
+            msg = "Attempted to set the option \"arbitrary\" on the user \"den.hosts.x86_64-linux.igloo.users.tux\"";
           };
         }
       );
@@ -258,7 +258,7 @@
           expr = den.aspects.test.arbitrary;
           expectedError = {
             type = "ThrownError";
-            msg = "Attempted to set the option \"arbitrary\" in \"den.aspects.test\"";
+            msg = "Attempted to set the option \"arbitrary\" on the aspect \"den.aspects.test\"";
           };
         }
       );
@@ -273,7 +273,7 @@
           expr = config.flake.arbitrary;
           expectedError = {
             type = "ThrownError";
-            msg = "Attempted to set the option \"arbitrary\" in \"flake\"";
+            msg = "Attempted to set the flake output option \"arbitrary\" but no definition exists";
           };
         }
       );
@@ -300,7 +300,7 @@
           ];
           expectedError = {
             type = "ThrownError";
-            msg = "Attempted to set the option \"flatMap\" in \"den.ful.test.lib\"";
+            msg = "Attempted to set the option \"lib.flatMap\" on the namespace \"test\"";
           };
         }
       );

--- a/templates/ci/modules/features/strict.nix
+++ b/templates/ci/modules/features/strict.nix
@@ -96,7 +96,128 @@
       }
     );
 
-    flakeModule.strict = {
+    flakeModule = {
+      test-aspect-nixos = denTest (
+        { inputs, igloo, ... }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            inputs.den.flakeOutputs.all
+          ];
+
+          den.hosts.x86_64-linux.igloo = { };
+          den.aspects.igloo.nixos.networking.hostName = "igloo";
+
+          expr = igloo.networking.hostName;
+          expected = "igloo";
+        }
+      );
+
+      test-aspect-darwin = denTest (
+        { inputs, apple, ... }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            inputs.den.flakeOutputs.all
+          ];
+
+          den.hosts.aarch64-darwin.apple = { };
+          den.aspects.apple.darwin.networking.hostName = "apple";
+
+          expr = apple.networking.hostName;
+          expected = "apple";
+        }
+      );
+
+      test-aspect-os = denTest (
+        {
+          inputs,
+          igloo,
+          apple,
+          ...
+        }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            inputs.den.flakeOutputs.all
+          ];
+
+          den.hosts.x86_64-linux.igloo = { };
+          den.aspects.igloo.os.networking.hostName = "igloo";
+
+          den.hosts.aarch64-darwin.apple = { };
+          den.aspects.apple.os.networking.hostName = "apple";
+
+          expr = {
+            apple = apple.networking.hostName;
+            igloo = igloo.networking.hostName;
+          };
+          expected = {
+            apple = "apple";
+            igloo = "igloo";
+          };
+        }
+      );
+
+      test-aspect-homeManager = denTest (
+        { inputs, tuxHm, ... }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            inputs.den.flakeOutputs.all
+          ];
+
+          den.schema.user.classes = [ "homeManager" ];
+
+          den.hosts.x86_64-linux.igloo.users.tux = { };
+          den.aspects.tux.homeManager.programs.vim.enable = true;
+
+          expr = tuxHm.programs.vim.enable;
+          expected = true;
+        }
+      );
+
+      test-aspect-user = denTest (
+        { inputs, tux, ... }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            inputs.den.flakeOutputs.all
+          ];
+
+          den.hosts.x86_64-linux.igloo.users.tux = { };
+
+          den.aspects.tux.user.extraGroups = [ "test" ];
+
+          expr = tux.extraGroups;
+          expected = [ "test" ];
+        }
+      );
+
+      test-aspect-wsl = denTest (
+        { inputs, igloo, ... }:
+        {
+          imports = [
+            inputs.den.flakeModules.strict
+            inputs.den.flakeOutputs.all
+          ];
+
+          den.hosts.x86_64-linux.igloo = {
+            wsl.enable = true;
+            users.tux = { };
+          };
+
+          den.aspects.igloo.wsl.defaultUser = "igloo";
+
+          expr =
+            if inputs ? nixos-wsl then
+              igloo.wsl.defaultUser
+            else
+              lib.warn "nixos-wsl not found in inputs, skipping test `strict-mode.flakeModule.test-aspect-wsl" "igloo";
+          expected = "igloo";
+        }
+      );
+
       test-host = denTest (
         { inputs, den, ... }:
         {


### PR DESCRIPTION
Follow up from #428, when I actually went to use this in my config I found that all the core aspect classes were missing explicit typing.