### PR TITLE
fix: make home hostName nullable for standalone homes

### DIFF
--- a/nix/lib/types.nix
+++ b/nix/lib/types.nix
@@ -200,7 +200,11 @@ let
         options = {
           name = strOpt "home configuration name" userName;
           userName = strOpt "user account name" userName;
-          hostName = strOpt "host name" hostName;
+          hostName = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = hostName;
+            description = "host name (null for unbound standalone homes)";
+          };
           user = lib.mkOption {
             default = userByName;
             defaultText = lib.literalExpression "user";


### PR DESCRIPTION
Standalone home-manager configurations may not have a bound host. Change hostName from strOpt to nullOr str so it defaults to null when no host is associated.