### PR TITLE
feat: context stage tagging + __ctxTrace on ctxApply output

### DIFF
--- a/nix/lib/ctx-apply.nix
+++ b/nix/lib/ctx-apply.nix
@@ -77,17 +77,39 @@ let
     in
     [ args ] ++ lib.concatMap expandOne intoList;
 
+  # Tag an include with its context stage for tracing.
+  tagStage =
+    stage: kind: aspectName: val:
+    if builtins.isAttrs val then
+      val
+      // {
+        __ctxStage = stage;
+        __ctxKind = kind;
+        __ctxAspect = aspectName;
+      }
+    else
+      val;
+
   buildIncludes =
     item:
     let
       isFirst = !(item.seen ? ${item.key});
       selfProvider = item.self.provides.${item.self.name} or noop;
       crossProvider = getCrossProvider item;
+      stage = item.key;
+    in
+    let
+      aspect =
+        if isFirst then parametric.fixedTo item.ctx item.self else parametric.atLeast item.self item.ctx;
+      selfProv = selfProvider item.ctx;
+      crossProv = crossProvider item.ctx;
     in
     [
-      (if isFirst then parametric.fixedTo item.ctx item.self else parametric.atLeast item.self item.ctx)
-      (selfProvider item.ctx)
-      (crossProvider item.ctx)
+      (tagStage stage "aspect" (item.self.name or "<anon>") aspect)
+      (tagStage stage "self-provide" (item.self.name or "<anon>") selfProv)
+      (tagStage stage "cross-provide" (
+        if item.prev != null then item.prev.name or "<anon>" else "<anon>"
+      ) crossProv)
     ];
 
   assembleIncludes =
@@ -105,15 +127,47 @@ let
       result = [ ];
     } items).result;
 
+  # Serializable summary of traversal items for tracing.
+  traceItem =
+    item:
+    let
+      ctx = if builtins.isAttrs item.ctx then item.ctx else { };
+      ctxKeys = builtins.attrNames ctx;
+      entityNames = lib.concatMap (
+        k:
+        let
+          v = ctx.${k} or null;
+        in
+        lib.optional (builtins.isAttrs v && v ? name) {
+          kind = k;
+          name = v.name;
+          aspect = v.aspect or v.name;
+        }
+      ) ctxKeys;
+    in
+    {
+      key = item.key;
+      selfName = item.self.name or "<anon>";
+      prevName = if item.prev == null then null else item.prev.name or "<anon>";
+      hasSelfProvider = (item.self.provides or { }) ? ${item.self.name or ""};
+      hasCrossProvider = item.prev != null && (item.prev.provides or { }) ? ${item.key};
+      inherit ctxKeys entityNames;
+      provideNames = builtins.attrNames (item.self.provides or { });
+    };
+
   ctxApply =
     self: ctx:
-    parametric.withIdentity self {
-      includes = assembleIncludes (traverse {
+    let
+      items = traverse {
         prev = null;
         prevCtx = null;
         key = self.name;
         inherit self ctx;
-      });
+      };
+    in
+    parametric.withIdentity self {
+      includes = assembleIncludes items;
+      __ctxTrace = builtins.map traceItem items;
     };
 
 in

--- a/templates/ci/modules/features/ctx-trace.nix
+++ b/templates/ci/modules/features/ctx-trace.nix
@@ -1,0 +1,80 @@
+# Tests for context stage tagging and __ctxTrace.
+{ denTest, lib, ... }:
+{
+  flake.tests.ctx-trace = {
+
+    # ctxApply produces __ctxTrace with traversal items.
+    test-ctxTrace-present = denTest (
+      { den, ... }:
+      let
+        host = (builtins.head (builtins.attrValues (builtins.head (builtins.attrValues den.hosts))));
+        root = den.ctx.host { inherit host; };
+      in
+      {
+        den.hosts.x86_64-linux.test-host.users.tux = { };
+        den.aspects.test-host.nixos =
+          { ... }:
+          {
+            networking.hostName = "test";
+          };
+        expr = builtins.isList (root.__ctxTrace or null) && builtins.length root.__ctxTrace >= 1;
+        expected = true;
+      }
+    );
+
+    # __ctxTrace items have required fields.
+    test-ctxTrace-item-shape = denTest (
+      { den, ... }:
+      let
+        host = (builtins.head (builtins.attrValues (builtins.head (builtins.attrValues den.hosts))));
+        root = den.ctx.host { inherit host; };
+        firstItem = builtins.head root.__ctxTrace;
+      in
+      {
+        den.hosts.x86_64-linux.test-host.users.tux = { };
+        den.aspects.test-host.nixos =
+          { ... }:
+          {
+            networking.hostName = "test";
+          };
+        expr = {
+          hasKey = firstItem ? key;
+          hasSelfName = firstItem ? selfName;
+          hasPrevName = firstItem ? prevName;
+          hasCtxKeys = firstItem ? ctxKeys;
+          hasEntityNames = firstItem ? entityNames;
+          hasProvideNames = firstItem ? provideNames;
+        };
+        expected = {
+          hasKey = true;
+          hasSelfName = true;
+          hasPrevName = true;
+          hasCtxKeys = true;
+          hasEntityNames = true;
+          hasProvideNames = true;
+        };
+      }
+    );
+
+    # Includes carry __ctxStage and __ctxKind tags.
+    test-includes-have-stage-tags = denTest (
+      { den, ... }:
+      let
+        host = (builtins.head (builtins.attrValues (builtins.head (builtins.attrValues den.hosts))));
+        root = den.ctx.host { inherit host; };
+        tagged = builtins.filter (i: builtins.isAttrs i && i ? __ctxStage) (root.includes or [ ]);
+      in
+      {
+        den.hosts.x86_64-linux.test-host.users.tux = { };
+        den.aspects.test-host.nixos =
+          { ... }:
+          {
+            networking.hostName = "test";
+          };
+        expr = builtins.length tagged >= 1;
+        expected = true;
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
tagStage marks includes with __ctxStage, __ctxKind, __ctxAspect for tracing which context stage produced each include.

traceItem produces serializable summaries of traversal items with key, selfName, prevName, provider flags, ctxKeys, entityNames.

ctxApply now emits __ctxTrace alongside includes — a list of traceItem records for downstream consumers (diag pipeline, structuredTrace).