### PR TITLE
fix: preserve unresolvable includes in applyDeep

### DIFF
--- a/nix/lib/parametric.nix
+++ b/nix/lib/parametric.nix
@@ -74,7 +74,18 @@ let
           if canTake.upTo ctx sub then
             carryMeta sub (take.upTo sub ctx)
           else if builtins.isAttrs sub && sub ? __functor && sub ? includes then
-            sub // { includes = map (applyDeep takeFn ctx) (sub.includes or [ ]); }
+            sub
+            // {
+              includes = map (
+                i:
+                let
+                  r = applyDeep takeFn ctx i;
+                in
+                # Preserve includes that applyDeep couldn't resolve (wrong context).
+                # They'll be resolved later by the statics path with { class, aspect-chain }.
+                if r == { } then i else r
+              ) (sub.includes or [ ]);
+            }
           else
             sub
         ) rRaw.includes;

--- a/templates/ci/modules/features/deadbugs/issue-460-parametric-dedup.nix
+++ b/templates/ci/modules/features/deadbugs/issue-460-parametric-dedup.nix
@@ -1,0 +1,109 @@
+# Issue #460: Parametric aspects with non-context args (like unfree) were
+# silently dropped when included via a parametric wrapper function.
+#
+# Root cause: applyDeep eagerly replaced includes it couldn't resolve with
+# the current context ({host,user}) with {}, destroying them before the
+# statics path could resolve them with {class, aspect-chain}.
+{ denTest, ... }:
+{
+  flake.tests.deadbugs-issue-460 = {
+
+    # Baseline: static includes work (never broken).
+    test-unfree-static-includes = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.apps._.app-a.includes = [ (den._.unfree [ "drawio" ]) ];
+        den.aspects.apps._.app-b.includes = [ (den._.unfree [ "obsidian" ]) ];
+
+        den.aspects.tux.includes = [
+          den.aspects.apps._.app-a
+          den.aspects.apps._.app-b
+        ];
+
+        expr = lib.sort (a: b: a < b) tuxHm.unfree.packages;
+        expected = [
+          "drawio"
+          "obsidian"
+        ];
+      }
+    );
+
+    # Regression: parametric wrapper { host, ... }: { includes = [...] }
+    # around sub-aspects whose includes need { class, aspect-chain }.
+    test-unfree-parametric-wrapper-fx = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.apps._.app-a.includes = [ (den._.unfree [ "drawio" ]) ];
+        den.aspects.apps._.app-b.includes = [ (den._.unfree [ "obsidian" ]) ];
+
+        den.aspects.tux.includes = [
+          (
+            { host, ... }:
+            {
+              includes = [
+                den.aspects.apps._.app-a
+                den.aspects.apps._.app-b
+              ];
+            }
+          )
+        ];
+
+        expr = lib.sort (a: b: a < b) tuxHm.unfree.packages;
+        expected = [
+          "drawio"
+          "obsidian"
+        ];
+      }
+    );
+
+    # Same regression on legacy pipeline.
+    test-unfree-parametric-wrapper-legacy = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.fxPipeline = false;
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.apps._.app-a.includes = [ (den._.unfree [ "drawio" ]) ];
+        den.aspects.apps._.app-b.includes = [ (den._.unfree [ "obsidian" ]) ];
+
+        den.aspects.tux.includes = [
+          (
+            { host, ... }:
+            {
+              includes = [
+                den.aspects.apps._.app-a
+                den.aspects.apps._.app-b
+              ];
+            }
+          )
+        ];
+
+        expr = lib.sort (a: b: a < b) tuxHm.unfree.packages;
+        expected = [
+          "drawio"
+          "obsidian"
+        ];
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Summary
- `applyDeep` eagerly replaced sub-aspect includes it couldn't resolve with the current context (`{host,user}`) with `{}`, destroying parametric includes like `den._.unfree` that need `{class, aspect-chain}`
- Preserve the original include when `applyDeep` returns `{}` so the statics path can resolve it with the correct context

## Test plan
- [x] `deadbugs-issue-460` tests: parametric wrapper around unfree calls on both fx and legacy pipelines
- [x] Full CI suite passes (491/491)

Fixes #460