### PR TITLE
fix: resolve host-aspects for homeManager class only

### DIFF
--- a/modules/aspects/provides/host-aspects.nix
+++ b/modules/aspects/provides/host-aspects.nix
@@ -12,11 +12,23 @@ let
 
     Any host aspect that defines a `homeManager` key will have that
     config forwarded to the user's homeManager evaluation. Other class
-    keys (nixos, darwin) are ignored — the pipeline resolves with
-    class = "homeManager" so only homeManager modules are collected.
+    keys (nixos, darwin) are ignored — host.aspect is resolved
+    specifically for class "homeManager", so only homeManager modules
+    are collected. This avoids duplicating nixos modules that are
+    already applied via the host's own resolution.
   '';
 
-  from-host = { host, user }: parametric.fixedTo { inherit host user; } host.aspect;
+  # Resolve host.aspect for homeManager class only, producing a single
+  # homeManager module. This prevents nixos/darwin class keys from
+  # being collected again when the user context contributes to the
+  # host's resolution.
+  from-host =
+    { host, user }:
+    {
+      homeManager = den.lib.aspects.resolve "homeManager" (
+        parametric.fixedTo { inherit host user; } host.aspect
+      );
+    };
 
 in
 {

--- a/templates/ci/modules/features/host-aspects.nix
+++ b/templates/ci/modules/features/host-aspects.nix
@@ -97,6 +97,47 @@
       }
     );
 
+    # Host nixos modules are NOT duplicated when user includes host-aspects.
+    # Uses a listOf option to detect double-application.
+    test-no-nixos-duplication = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.default.nixos.imports = [
+          {
+            options.tags = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+          }
+        ];
+
+        den.aspects.igloo = {
+          nixos.tags = [ "host" ];
+          homeManager.programs.vim.enable = true;
+        };
+
+        den.aspects.tux.includes = [ den._.host-aspects ];
+
+        expr = {
+          tags = igloo.tags;
+          vim = tuxHm.programs.vim.enable;
+        };
+        expected = {
+          # "host" should appear exactly once — not duplicated
+          tags = [ "host" ];
+          vim = true;
+        };
+      }
+    );
+
     # User who does NOT include den._.host-aspects does not receive host homeManager.
     test-opt-in-only = denTest (
       {


### PR DESCRIPTION
## Summary
- `host-aspects` battery was including the raw `host.aspect` tree via `fixedTo`, which caused host nixos modules to be collected again when the user context contributed to the host's resolution
- Now resolves `host.aspect` specifically for class `"homeManager"` and emits only a homeManager module, preventing nixos/darwin duplication

## Test plan
- [x] All existing host-aspects tests pass (6/6)
- [x] New `test-no-nixos-duplication`: verifies host nixos tags appear exactly once, not duplicated
- [x] Full CI passes (499/499)