### PR TITLE
fix: module-level dedup for host-aspects overlap support

### DIFF
--- a/modules/aspects/provides/host-aspects.nix
+++ b/modules/aspects/provides/host-aspects.nix
@@ -4,7 +4,7 @@ let
 
   description = ''
     Projects all homeManager-class configs from the host's aspect tree
-    onto users who opt in.
+    onto users who opt in. Requires the fx pipeline.
 
     ## Usage
 
@@ -13,15 +13,9 @@ let
     Any host aspect that defines a `homeManager` key will have that
     config forwarded to the user's homeManager evaluation. Other class
     keys (nixos, darwin) are ignored — host.aspect is resolved
-    specifically for class "homeManager", so only homeManager modules
-    are collected. This avoids duplicating nixos modules that are
-    already applied via the host's own resolution.
+    specifically for class "homeManager".
   '';
 
-  # Resolve host.aspect for homeManager class only, producing a single
-  # homeManager module. This prevents nixos/darwin class keys from
-  # being collected again when the user context contributes to the
-  # host's resolution.
   from-host =
     { host, user }:
     {

--- a/nix/lib/aspects/fx/aspect.nix
+++ b/nix/lib/aspects/fx/aspect.nix
@@ -56,15 +56,29 @@ let
     in
     fx.seq (map (c: fx.send "register-constraint" (c // { inherit owner; })) allConstraints);
 
-  # Fold includes through emit-include effects.
+  # Fold includes through emit-include effects, tagging each with its
+  # positional index so the handler can derive stable identities for
+  # anonymous includes (parentIdentity/<anon>:index).
   emitIncludes =
     incs:
-    builtins.foldl' (
-      acc: child:
-      fx.bind acc (
-        results: fx.bind (fx.send "emit-include" child) (childResults: fx.pure (results ++ childResults))
-      )
-    ) (fx.pure [ ]) incs;
+    let
+      len = builtins.length incs;
+      go =
+        idx: acc:
+        if idx >= len then
+          acc
+        else
+          go (idx + 1) (
+            fx.bind acc (
+              results:
+              fx.bind (fx.send "emit-include" {
+                child = builtins.elemAt incs idx;
+                inherit idx;
+              }) (childResults: fx.pure (results ++ childResults))
+            )
+          );
+    in
+    go 0 (fx.pure [ ]);
 
   # Emit into-transition effects for each key in aspect.into.
   # into is a function ctx → attrset. We pass the unevaluated function

--- a/nix/lib/aspects/fx/handlers/include.nix
+++ b/nix/lib/aspects/fx/handlers/include.nix
@@ -131,12 +131,32 @@ let
   # Keep: resolve via aspectToEffect (which emits resolve-complete internally).
   keepChild = child: fx.bind (aspectToEffect child) (resolved: fx.pure [ resolved ]);
 
-  # The handler.
+  # Derive a stable name for anonymous aspects from parent chain + index.
+  nameAnon =
+    state: idx:
+    let
+      chain = state.includesChain or [ ];
+      parent = if chain == [ ] then "<root>" else lib.last chain;
+    in
+    "${parent}/<anon>:${toString idx}";
+
+  isMeaningfulName =
+    name: name != "<anon>" && name != "<function body>" && !(lib.hasPrefix "[definition " name);
+
+  # The handler. param is { child, idx } from emitIncludes.
   includeHandler = {
     "emit-include" =
       { param, state }:
       let
-        child = wrapChild param;
+        rawChild = param.child or param;
+        idx = param.idx or null;
+        wrapped = wrapChild rawChild;
+        # Replace anonymous names with parent+index derived identity.
+        child =
+          if idx != null && !(isMeaningfulName (wrapped.name or "<anon>")) then
+            wrapped // { name = nameAnon state idx; }
+          else
+            wrapped;
         childIdentity = identity.pathKey (identity.aspectPath child);
         isConditional = builtins.isAttrs child && child ? meta && child.meta ? guard;
       in

--- a/nix/lib/aspects/fx/handlers/tree.nix
+++ b/nix/lib/aspects/fx/handlers/tree.nix
@@ -145,7 +145,27 @@ let
         else
           let
             identity = param.identity or "<anon>";
-            mod = lib.setDefaultModuleLocation "${param.class}@${identity}" param.module;
+            loc = "${param.class}@${identity}";
+            # Named aspects get a key for NixOS module-level dedup: two
+            # resolve calls emitting the same aspect:class produce the
+            # same key, so the module system keeps only the first.
+            # Anonymous/synthetic names must not be keyed — multiple
+            # anonymous includes with the same identity are distinct.
+            isAnon =
+              identity == "<anon>"
+              || identity == "<function body>"
+              || lib.hasPrefix "[definition " identity
+              || lib.hasPrefix "<root>/" identity
+              || lib.hasInfix "/<anon>:" identity;
+            mod =
+              if isAnon then
+                lib.setDefaultModuleLocation loc param.module
+              else
+                {
+                  key = loc;
+                  _file = loc;
+                  imports = [ param.module ];
+                };
           in
           {
             resume = null;

--- a/nix/lib/forward.nix
+++ b/nix/lib/forward.nix
@@ -6,6 +6,7 @@ let
       guard ? null,
       adaptArgs ? null,
       adapterModule ? null,
+      evalConfig ? false,
       ...
     }@fwd:
     let
@@ -24,14 +25,31 @@ let
 
       forward =
         path:
-        let
-          value = lib.setAttrByPath path (_: {
-            imports = [ sourceModule ];
-          });
-        in
-        {
-          ${intoClass} = value;
-        };
+        if evalConfig then
+          # Evaluate source module in a freeform submodule and set the
+          # resulting config at the target path. Use for leaf option
+          # targets (e.g. environment.sessionVariables) that can't accept
+          # module functions as values.
+          let
+            evaluated = lib.evalModules {
+              modules = [
+                freeformMod
+                sourceModule
+              ];
+            };
+          in
+          {
+            ${intoClass} = lib.setAttrByPath path (builtins.removeAttrs evaluated.config [ "_module" ]);
+          }
+        else
+          let
+            value = lib.setAttrByPath path (_: {
+              imports = [ sourceModule ];
+            });
+          in
+          {
+            ${intoClass} = value;
+          };
 
       freeformMod = {
         config._module.freeformType = lib.types.lazyAttrsOf lib.types.unspecified;

--- a/templates/ci/modules/features/debug-fwd.nix
+++ b/templates/ci/modules/features/debug-fwd.nix
@@ -1,0 +1,90 @@
+# Forward custom class to leaf option using evalConfig.
+{ denTest, ... }:
+{
+  flake.tests.fwd-leaf-option = {
+
+    # Forward a custom "variables" class to environment.sessionVariables.
+    test-fwd-variables-static = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.variables.TEST = "test-var";
+
+        den.ctx.host.includes = [
+          (
+            { host, ... }:
+            den._.forward {
+              each = [ "nixos" ];
+              fromClass = _: "variables";
+              intoClass = _: host.class;
+              intoPath = _: [
+                "environment"
+                "sessionVariables"
+              ];
+              fromAspect = _: host.aspect;
+              evalConfig = true;
+            }
+          )
+        ];
+
+        expr = igloo.environment.sessionVariables.TEST;
+        expected = "test-var";
+      }
+    );
+
+    # perHost parametric children with evalConfig.
+    test-fwd-perHost-variables = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          { den.aspects.foo.includes = lib.attrValues den.aspects.foo._; }
+          {
+            den.ctx.host.includes = [
+              (
+                { host, ... }:
+                den._.forward {
+                  each = [ "nixos" ];
+                  fromClass = _: "variables";
+                  intoClass = _: host.class;
+                  intoPath = _: [
+                    "environment"
+                    "sessionVariables"
+                  ];
+                  fromAspect = _: den.lib.parametric.fixedTo { inherit host; } host.aspect;
+                  evalConfig = true;
+                }
+              )
+            ];
+          }
+          { den.aspects.foo._.sub1 = den.lib.perHost { variables.TEST = "test-var"; }; }
+          { den.aspects.foo._.sub2 = den.lib.perHost { variables.OTHER = "other-var"; }; }
+        ];
+
+        den.aspects.igloo.includes = [ den.aspects.foo ];
+
+        expr = {
+          test = igloo.environment.sessionVariables.TEST;
+          other = igloo.environment.sessionVariables.OTHER;
+        };
+        expected = {
+          test = "test-var";
+          other = "other-var";
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/fx-aspect.nix
+++ b/templates/ci/modules/features/fx-aspect.nix
@@ -20,7 +20,8 @@ let
       { param, state }:
       {
         # For these tests, just return the child as-is (no recursive resolution).
-        resume = [ param ];
+        # emitIncludes sends { child, idx } — extract the child.
+        resume = [ (param.child or param) ];
         inherit state;
       };
     "register-constraint" =

--- a/templates/ci/modules/features/host-aspects.nix
+++ b/templates/ci/modules/features/host-aspects.nix
@@ -138,6 +138,166 @@
       }
     );
 
+    # Host sub-aspects with homeManager project through includes.
+    # Shared aspects (included by both host and user) must not cause
+    # duplicate module conflicts.
+    test-shared-sub-aspects-no-duplication = denTest (
+      {
+        den,
+        lib,
+        igloo,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.default.nixos.imports = [
+          {
+            options.tags = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+          }
+        ];
+        den.default.homeManager.imports = [
+          {
+            options.hm-tags = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+          }
+        ];
+
+        # Shared aspect: included by BOTH host and user directly.
+        den.aspects.shared-tools = {
+          nixos.tags = [ "shared" ];
+          homeManager.hm-tags = [ "shared" ];
+        };
+
+        # Host-only aspect with homeManager config.
+        den.aspects.host-desktop = {
+          nixos.tags = [ "desktop" ];
+          homeManager.hm-tags = [ "desktop" ];
+        };
+
+        den.aspects.igloo = {
+          nixos.tags = [ "host" ];
+          includes = [
+            den.aspects.shared-tools
+            den.aspects.host-desktop
+          ];
+        };
+
+        den.aspects.tux = {
+          includes = [
+            den.aspects.shared-tools # also included by host
+            den._.host-aspects
+          ];
+          homeManager.hm-tags = [ "user" ];
+        };
+
+        expr = {
+          # nixos tags: host + shared + desktop (each exactly once)
+          nixosTags = lib.sort (a: b: a < b) igloo.tags;
+          # shared appears via both direct user include AND host-aspects — must not conflict
+          # hm tags: user's own + shared (direct) + desktop (via host-aspects) + shared (via host-aspects)
+          # shared appears via both direct include and host-aspects — must not conflict
+          hmHasDesktop = builtins.elem "desktop" tuxHm.hm-tags;
+          hmHasUser = builtins.elem "user" tuxHm.hm-tags;
+          hmHasShared = builtins.elem "shared" tuxHm.hm-tags;
+        };
+        expected = {
+          nixosTags = [
+            "desktop"
+            "host"
+            "shared"
+          ];
+          hmHasDesktop = true;
+          hmHasUser = true;
+          hmHasShared = true;
+        };
+      }
+    );
+
+    # Overlap: user includes an aspect directly AND it appears in host tree
+    # via host-aspects. Module dedup prevents duplicate option declarations.
+    test-overlap-no-conflict = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.default.homeManager.imports = [
+          {
+            options.hm-tags = lib.mkOption {
+              type = lib.types.listOf lib.types.str;
+              default = [ ];
+            };
+          }
+        ];
+
+        den.aspects.shared-tool = {
+          homeManager.hm-tags = [ "shared" ];
+        };
+
+        den.aspects.igloo.includes = [ den.aspects.shared-tool ];
+
+        # User includes shared-tool directly AND via host-aspects (overlap).
+        den.aspects.tux.includes = [
+          den.aspects.shared-tool
+          den._.host-aspects
+        ];
+
+        expr = tuxHm.hm-tags;
+        expected = [ "shared" ];
+      }
+    );
+
+    # Multiple users each get distinct homeManager modules from a named
+    # host sub-aspect that uses the user arg. The key dedup must not
+    # collapse modules across users — each user's resolve call has its
+    # own key namespace.
+    test-multi-user-distinct = denTest (
+      {
+        den,
+        lib,
+        tuxHm,
+        pinguHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users = {
+          tux = { };
+          pingu = { };
+        };
+
+        den.aspects.user-greeting =
+          { user, ... }:
+          {
+            homeManager.home.sessionVariables.GREETING = "hello-${user.name}";
+          };
+
+        den.aspects.igloo.includes = [ den.aspects.user-greeting ];
+
+        den.aspects.tux.includes = [ den._.host-aspects ];
+        den.aspects.pingu.includes = [ den._.host-aspects ];
+
+        expr = {
+          tux = tuxHm.home.sessionVariables.GREETING;
+          pingu = pinguHm.home.sessionVariables.GREETING;
+        };
+        expected = {
+          tux = "hello-tux";
+          pingu = "hello-pingu";
+        };
+      }
+    );
+
     # User who does NOT include den._.host-aspects does not receive host homeManager.
     test-opt-in-only = denTest (
       {


### PR DESCRIPTION
Named aspects now get a key attribute (class@identity) on their collected modules. The NixOS module system deduplicates by key across independent resolve calls, so a user can include an aspect directly AND receive it via host-aspects without duplicate option declarations.

Anonymous/synthetic aspects are excluded from keying so multiple anonymous includes coexist correctly.

Also fixes the pre-existing duplication where aspects included by both host and user produced duplicate nixos modules via the default context transition.