### PR TITLE
feat: policy foundations — as field, activation, provide-to, inspect

### DIFF
--- a/modules/aspects/provides/hjem.nix
+++ b/modules/aspects/provides/hjem.nix
@@ -41,4 +41,9 @@ in
       resolve = mkIntoClassUsers "hjem";
     };
   };
+
+  den.schema.host.policies = [
+    "host-to-hjem-host"
+    "hjem-host-to-hjem-user"
+  ];
 }

--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -44,4 +44,9 @@ in
       resolve = mkIntoClassUsers "homeManager";
     };
   };
+
+  den.schema.host.policies = [
+    "host-to-hm-host"
+    "hm-host-to-hm-user"
+  ];
 }

--- a/modules/aspects/provides/maid.nix
+++ b/modules/aspects/provides/maid.nix
@@ -44,4 +44,9 @@ in
       resolve = mkIntoClassUsers "maid";
     };
   };
+
+  den.schema.host.policies = [
+    "host-to-maid-host"
+    "maid-host-to-maid-user"
+  ];
 }

--- a/modules/aspects/provides/wsl.nix
+++ b/modules/aspects/provides/wsl.nix
@@ -67,4 +67,6 @@ in
       { host, ... }:
       lib.optional (host.class == "nixos" && (host.wsl or { }).enable or false) { inherit host; };
   };
+
+  den.schema.host.policies = [ "host-to-wsl-host" ];
 }

--- a/modules/context/entity-policies.nix
+++ b/modules/context/entity-policies.nix
@@ -1,0 +1,25 @@
+# Defines `policies` on every entity that imports den.schema.conf
+# (host, user, home, and user-defined kinds). Allows per-entity-kind
+# and per-entity-instance policy activation.
+#
+# Usage:
+#   den.schema.host.policies = [ "host-to-peers" ];
+#   den.hosts.x86_64-linux.igloo.policies = [ "host-to-peers" ];
+{ lib, ... }:
+let
+  entityModule = {
+    options.policies = lib.mkOption {
+      description = ''
+        Policy names activated for this entity or entity kind.
+        Core policies (_core = true) are always active regardless.
+        Policies listed here are activated when this entity is resolved.
+      '';
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "host-to-peers" ];
+    };
+  };
+in
+{
+  config.den.schema.conf.imports = [ entityModule ];
+}

--- a/modules/policies/core.nix
+++ b/modules/policies/core.nix
@@ -6,6 +6,7 @@
 {
   den.policies = {
     host-to-users = {
+      _core = true;
       from = "host";
       to = "user";
       resolve =
@@ -15,16 +16,19 @@
         }) (lib.attrValues host.users);
     };
     host-to-default = {
+      _core = true;
       from = "host";
       to = "default";
       resolve = lib.singleton;
     };
     user-to-default = {
+      _core = true;
       from = "user";
       to = "default";
       resolve = lib.singleton;
     };
     home-to-default = {
+      _core = true;
       from = "home";
       to = "default";
       resolve = lib.singleton;

--- a/modules/policies/flake.nix
+++ b/modules/policies/flake.nix
@@ -19,6 +19,7 @@ let
   systemOutputPolicies = map (output: {
     name = "flake-system-to-flake-${output}";
     value = {
+      _core = true;
       from = "flake-system";
       to = "flake-${output}";
       resolve =
@@ -32,12 +33,14 @@ in
 {
   den.policies = lib.listToAttrs systemOutputPolicies // {
     flake-to-flake-system = {
+      _core = true;
       from = "flake";
       to = "flake-system";
       resolve = _: map (system: { inherit system; }) den.systems;
     };
 
     flake-system-to-flake-os = {
+      _core = true;
       from = "flake-system";
       to = "flake-os";
       resolve =
@@ -45,6 +48,7 @@ in
     };
 
     flake-system-to-flake-hm = {
+      _core = true;
       from = "flake-system";
       to = "flake-hm";
       resolve =

--- a/nix/lib/aspects/fx/aspect.nix
+++ b/nix/lib/aspects/fx/aspect.nix
@@ -14,7 +14,9 @@ let
     "description"
     "meta"
     "includes"
+    "policies"
     "provides"
+    "provide-to"
     "into"
     "__fn"
     "__args"
@@ -242,14 +244,35 @@ let
     let
       scopeHandlers = aspect.__scopeHandlers or null;
       ctxId = aspect.__ctxId or null;
+      # Emit provide-to effects for cross-entity data routing.
+      provideToData = aspect."provide-to" or { };
+      emitProvideTo =
+        if provideToData == { } then
+          fx.pure null
+        else
+          fx.seq (
+            map (
+              label:
+              fx.send "provide-to" {
+                inherit label;
+                content = provideToData.${label};
+                emitterCtx = aspect.__ctx or { };
+                aspectName = aspect.name or "<anon>";
+                targetEntity = null;
+              }
+            ) (builtins.attrNames provideToData)
+          );
       childResolution = fx.bind (emitSelfProvide aspect) (
         selfProvResults:
-        fx.bind (emitTransitions aspect) (
-          transitionResults:
-          fx.bind (emitIncludes {
-            __parentScopeHandlers = scopeHandlers;
-            __parentCtxId = ctxId;
-          } (aspect.includes or [ ])) (children: fx.pure (selfProvResults ++ transitionResults ++ children))
+        fx.bind emitProvideTo (
+          _:
+          fx.bind (emitTransitions aspect) (
+            transitionResults:
+            fx.bind (emitIncludes {
+              __parentScopeHandlers = scopeHandlers;
+              __parentCtxId = ctxId;
+            } (aspect.includes or [ ])) (children: fx.pure (selfProvResults ++ transitionResults ++ children))
+          )
         )
       );
     in

--- a/nix/lib/aspects/fx/handlers/default.nix
+++ b/nix/lib/aspects/fx/handlers/default.nix
@@ -8,3 +8,4 @@
 // (import ./include.nix args)
 // (import ./transition.nix args)
 // (import ./forward.nix args)
+// (import ./provide-to.nix args)

--- a/nix/lib/aspects/fx/handlers/provide-to.nix
+++ b/nix/lib/aspects/fx/handlers/provide-to.nix
@@ -1,0 +1,16 @@
+# Handler for cross-entity provide-to data collection.
+# Aspects declare provide-to.${label} = data; this handler accumulates
+# emissions in state.provideTo (thunk-wrapped) for phase 2 distribution.
+{ ... }:
+{
+  provideToHandler = {
+    "provide-to" =
+      { param, state }:
+      {
+        resume = null;
+        state = state // {
+          provideTo = _: ((state.provideTo or (_: [ ])) null) ++ [ param ];
+        };
+      };
+  };
+}

--- a/nix/lib/aspects/fx/pipeline.nix
+++ b/nix/lib/aspects/fx/pipeline.nix
@@ -70,6 +70,7 @@ let
     // resolvePolicyHandler
     // resolveTargetHandler
     // handlers.forwardHandler
+    // handlers.provideToHandler
     // fx.effects.state.handler;
 
   resolvePolicyHandler = {
@@ -128,6 +129,7 @@ let
     pathSet = _: { };
     includesChain = _: [ ];
     deferredIncludes = _: [ ];
+    provideTo = _: [ ];
   };
 
   mkPipeline =

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -251,6 +251,12 @@ let
             default = { };
           };
 
+          policies = lib.mkOption {
+            description = "Policy names activated when this aspect is the resolution root.";
+            type = lib.types.listOf lib.types.str;
+            default = [ ];
+          };
+
           includes = lib.mkOption {
             description = "Providers to ask aspects from";
             type = lib.types.listOf (providerType typeCfg);

--- a/nix/lib/default.nix
+++ b/nix/lib/default.nix
@@ -32,6 +32,7 @@ let
     resolveStage = ./resolve-stage.nix;
     stageTypes = ./stage-types.nix;
     strict = ./strict.nix;
+    policyInspect = ./policy-inspect.nix;
     synthesizePolicies = ./synthesize-policies.nix;
     fx = ./fx.nix;
   };

--- a/nix/lib/policy-inspect.nix
+++ b/nix/lib/policy-inspect.nix
@@ -1,0 +1,42 @@
+# Lightweight policy inspection utility.
+# Calls resolve functions directly — no full pipeline run.
+# Essential for debugging "why did host X get this module?"
+{
+  lib,
+  den,
+  ...
+}:
+let
+  inherit (den.lib.synthesizePolicies) ctxSatisfies resolveArgsSatisfied activePoliciesFor;
+
+  # Inspect all applicable policies for a given entity kind and context.
+  # Returns: { policyName = { targetKey, targets, from, to, as, routing }; }
+  #
+  # Cheap: only calls resolve functions, no pipeline execution.
+  inspect =
+    { kind, context }:
+    let
+      active = activePoliciesFor kind context;
+      matching = lib.filterAttrs (
+        _: policy:
+        policy.from == kind && ctxSatisfies policy.from context && resolveArgsSatisfied policy context
+      ) active;
+    in
+    lib.mapAttrs (
+      _name: policy:
+      let
+        targetKey = if policy.as != "" then policy.as else policy.to;
+        rawResult = policy.resolve context;
+        targets = if builtins.isList rawResult then rawResult else [ rawResult ];
+      in
+      {
+        inherit targetKey targets;
+        inherit (policy) from to;
+        as = policy.as;
+        routing = if policy.from == policy.to then "sibling" else "child";
+      }
+    ) matching;
+in
+{
+  inherit inspect;
+}

--- a/nix/lib/policy-types.nix
+++ b/nix/lib/policy-types.nix
@@ -12,6 +12,15 @@ let
         type = lib.types.str;
         description = "Target entity kind or stage name (e.g., 'user', 'hm-host')";
       };
+      as = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = ''
+          Context key used for the synthesized output attrset entry.
+          Defaults to the `to` value when empty.
+          Useful for sibling routing (e.g., host→host where `as = "peer"` avoids collision).
+        '';
+      };
       resolve = lib.mkOption {
         type = lib.types.raw;
         description = ''
@@ -24,6 +33,13 @@ let
         type = lib.types.lazyAttrsOf lib.types.raw;
         default = { };
         description = "Named effect handlers installed when this policy fires.";
+      };
+      _core = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        internal = true;
+        visible = false;
+        description = "When true, policy is always active without explicit opt-in.";
       };
     };
   };

--- a/nix/lib/synthesize-policies.nix
+++ b/nix/lib/synthesize-policies.nix
@@ -6,20 +6,20 @@
 }:
 let
   # Infer the required entity key from a stage name.
+  # Derived from den.schema so user-defined entity kinds are supported.
   # from = "host" or "hm-host" implies ctx.host must be an attrset entity.
-  # from = "user" or "hm-user" implies ctx.user must be an attrset entity.
-  # from = "home" implies ctx.home must be an attrset entity.
   # Other stages (flake, flake-system, etc.) have no entity requirement.
+  schemaKinds = builtins.filter (n: n != "conf" && !(lib.hasPrefix "_" n)) (
+    builtins.attrNames (den.schema or { })
+  );
   entityKeyFor =
     stage:
-    if stage == "host" || lib.hasSuffix "-host" stage then
-      "host"
-    else if stage == "user" || lib.hasSuffix "-user" stage then
-      "user"
-    else if stage == "home" then
-      "home"
-    else
-      null;
+    let
+      # Check exact match first, then suffix match (-host → host, -user → user)
+      exact = lib.findFirst (k: stage == k) null schemaKinds;
+      suffix = lib.findFirst (k: lib.hasSuffix "-${k}" stage) null schemaKinds;
+    in
+    if exact != null then exact else suffix;
 
   # Check if context satisfies the scope implied by the stage name.
   #
@@ -59,6 +59,42 @@ let
     in
     builtins.all (k: ctx ? ${k}) requiredArgs;
 
+  # Build the set of active policies for a given stage and context.
+  #
+  # Activation levels (all additive):
+  #   1. Core: policy._core == true → always active
+  #   2. Default: policy name in den.default.policies → active globally
+  #   3. Schema-kind + entity-instance: entity.policies (merged by module system)
+  #      Setting den.schema.host.policies = [...] applies to all hosts.
+  #      Setting den.hosts.*.policies = [...] applies to one host.
+  #      Both merge via the NixOS module system into entity.policies.
+  #
+  # Context-aware: when ctx contains entity attrsets, their `.policies`
+  # lists are checked for activation.
+  #
+  # A policy not activated at any level is excluded from the returned set.
+  activePoliciesFor =
+    stageName: ctx:
+    let
+      policies = den.policies or { };
+      defaultActive = den.default.policies or [ ];
+      # Entity activation: read from the entity in context.
+      # Schema-kind policies merge into entity.policies via module system.
+      entityKind = entityKeyFor stageName;
+      entityActive =
+        if entityKind != null && ctx ? ${entityKind} && builtins.isAttrs ctx.${entityKind} then
+          ctx.${entityKind}.policies or [ ]
+        else
+          [ ];
+      activeNames = defaultActive ++ entityActive;
+      activeSet = lib.genAttrs activeNames (_: true);
+    in
+    lib.filterAttrs (name: policy: policy._core or false || activeSet ? ${name}) policies;
+
+  # NOTE: synthesize does not filter by activation model — all matching
+  # policies fire. Activation is enforced by activePoliciesFor and
+  # inspect. Per-policy dispatch will replace this path with
+  # activation-aware handlers.
   synthesize =
     stageName:
     let
@@ -75,12 +111,16 @@ let
           scopeOk = ctxSatisfies policy.from rCtx;
           argsOk = resolveArgsSatisfied policy rCtx;
           targets = if scopeOk && argsOk then policy.resolve rCtx else [ ];
-          targetList = if builtins.isList targets then targets else [ targets ];
+          targetList =
+            if builtins.isList targets then
+              targets
+            else
+              builtins.trace
+                "den: policy ${policy.from}->${policy.to}: resolve returned a non-list; coercing to singleton"
+                [ targets ];
+          key = if policy.as != "" then policy.as else policy.to;
         in
-        if targetList == [ ] then
-          acc
-        else
-          acc // { ${policy.to} = (acc.${policy.to} or [ ]) ++ targetList; }
+        if targetList == [ ] then acc else acc // { ${key} = (acc.${key} or [ ]) ++ targetList; }
       ) { } matching;
 
   # Merge an existing into function with synthesized policies for a stage.
@@ -103,5 +143,11 @@ let
       policyInto;
 in
 {
-  inherit synthesize mergePolicyInto;
+  inherit
+    synthesize
+    mergePolicyInto
+    activePoliciesFor
+    ctxSatisfies
+    resolveArgsSatisfied
+    ;
 }

--- a/nix/nixModule/policies.nix
+++ b/nix/nixModule/policies.nix
@@ -9,4 +9,7 @@ in
     defaultText = lib.literalExpression "{ }";
     type = lib.types.lazyAttrsOf policyType;
   };
+
+  # Global policy activation lives on den.default.policies (aspect schema).
+  # No separate option needed — den.default is an aspect with freeform + typed options.
 }

--- a/templates/ci/modules/features/policy-activation.nix
+++ b/templates/ci/modules/features/policy-activation.nix
@@ -1,0 +1,206 @@
+{ denTest, ... }:
+{
+  flake.tests.policy-activation = {
+
+    # Core policies (_core = true) appear in activePoliciesFor without opt-in.
+    test-core-policies-always-active = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+
+        expr =
+          let
+            active = den.lib.synthesizePolicies.activePoliciesFor "host" { };
+          in
+          active ? host-to-users && active ? host-to-default;
+        expected = true;
+      }
+    );
+
+    # Non-core policies are excluded from activePoliciesFor by default.
+    test-non-core-excluded-from-active = denTest (
+      { den, ... }:
+      {
+        den.stages.test-act-src = {
+          includes = [ ];
+        };
+        den.stages.test-act-tgt = {
+          includes = [ ];
+        };
+
+        den.policies.test-act-src-to-tgt = {
+          from = "test-act-src";
+          to = "test-act-tgt";
+          resolve = _: [ { } ];
+        };
+
+        expr =
+          let
+            active = den.lib.synthesizePolicies.activePoliciesFor "test-act-src" { };
+          in
+          active ? test-act-src-to-tgt;
+        expected = false;
+      }
+    );
+
+    # Policies in den.default.policies activates globally.
+    test-default-policies-activates = denTest (
+      { den, ... }:
+      {
+        den.stages.test-dflt-src = {
+          includes = [ ];
+        };
+        den.stages.test-dflt-tgt = {
+          includes = [ ];
+        };
+
+        den.policies.test-dflt-src-to-tgt = {
+          from = "test-dflt-src";
+          to = "test-dflt-tgt";
+          resolve = _: [ { } ];
+        };
+
+        den.default.policies = [ "test-dflt-src-to-tgt" ];
+
+        expr =
+          let
+            active = den.lib.synthesizePolicies.activePoliciesFor "test-dflt-src" { };
+          in
+          active ? test-dflt-src-to-tgt;
+        expected = true;
+      }
+    );
+
+    # Policies in den.schema.<kind>.policies flow to all entities of that kind
+    # via module system merging, and activate when the entity is in context.
+    test-schema-policies-activates-for-kind = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+
+        den.policies.test-skind-host-pol = {
+          from = "host";
+          to = "user";
+          resolve = _: [ { } ];
+        };
+
+        # Schema-level: applies to all hosts via module merge
+        den.schema.host.policies = [ "test-skind-host-pol" ];
+
+        # Must pass an actual host entity — schema policies merge into it
+        expr =
+          let
+            igloo = den.hosts.x86_64-linux.igloo;
+            active = den.lib.synthesizePolicies.activePoliciesFor "host" { host = igloo; };
+          in
+          active ? test-skind-host-pol;
+        expected = true;
+      }
+    );
+
+    # Schema-kind activation is scoped — host policies don't appear on users.
+    test-schema-policies-scoped-to-kind = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = { };
+
+        den.policies.test-scope-host-only = {
+          from = "host";
+          to = "user";
+          resolve = _: [ { } ];
+        };
+
+        den.schema.host.policies = [ "test-scope-host-only" ];
+
+        # Querying for "user" kind with no user entity → not active
+        expr =
+          let
+            active = den.lib.synthesizePolicies.activePoliciesFor "user" { };
+          in
+          active ? test-scope-host-only;
+        expected = false;
+      }
+    );
+
+    # Entity-instance policies: entity.policies activates for that entity.
+    test-entity-instance-policies = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = {
+          policies = [ "test-inst-host-pol" ];
+        };
+
+        den.policies.test-inst-host-pol = {
+          from = "host";
+          to = "user";
+          resolve = _: [ { } ];
+        };
+
+        expr =
+          let
+            igloo = den.hosts.x86_64-linux.igloo;
+            active = den.lib.synthesizePolicies.activePoliciesFor "host" { host = igloo; };
+          in
+          active ? test-inst-host-pol;
+        expected = true;
+      }
+    );
+
+    # Entity-instance policies don't leak to other entities.
+    test-entity-instance-policies-scoped = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = {
+          policies = [ "test-inst-scoped-pol" ];
+        };
+        den.hosts.x86_64-linux.iceberg = { };
+
+        den.policies.test-inst-scoped-pol = {
+          from = "host";
+          to = "user";
+          resolve = _: [ { } ];
+        };
+
+        # iceberg does NOT have the policy — only igloo does.
+        expr =
+          let
+            iceberg = den.hosts.x86_64-linux.iceberg;
+            active = den.lib.synthesizePolicies.activePoliciesFor "host" { host = iceberg; };
+          in
+          active ? test-inst-scoped-pol;
+        expected = false;
+      }
+    );
+
+    # ctxSatisfies and resolveArgsSatisfied are exported and callable.
+    test-exported-helpers = denTest (
+      { den, ... }:
+      {
+        expr =
+          let
+            inherit (den.lib.synthesizePolicies) ctxSatisfies resolveArgsSatisfied;
+            hostOk = ctxSatisfies "host" { host = { }; };
+            hostBad = ctxSatisfies "host" { };
+            policy = {
+              resolve = { x, ... }: [ ];
+            };
+            argsOk = resolveArgsSatisfied policy { x = 1; };
+            argsBad = resolveArgsSatisfied policy { };
+          in
+          [
+            hostOk
+            hostBad
+            argsOk
+            argsBad
+          ];
+        expected = [
+          true
+          false
+          true
+          false
+        ];
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/policy-as-field.nix
+++ b/templates/ci/modules/features/policy-as-field.nix
@@ -1,0 +1,67 @@
+{ denTest, ... }:
+{
+  flake.tests.policy-as-field = {
+
+    # Policy with `as` field keys synthesized output by `as`, not by `to`.
+    # The `as` field is for sibling routing (e.g., host→host where the
+    # context key "peer" avoids collision with the source "host" key).
+    test-policy-as-renames-key = denTest (
+      { den, ... }:
+      {
+        den.stages.test-as-source = {
+          includes = [ ];
+        };
+
+        den.stages.test-as-target = {
+          includes = [ ];
+        };
+
+        den.policies.test-as-source-to-target = {
+          from = "test-as-source";
+          to = "test-as-target";
+          as = "peer";
+          resolve = _: [ { } ];
+        };
+
+        # synthesize "test-as-source" should produce { peer = [{}] }, not { test-as-target = [{}] }
+        expr =
+          let
+            intoFn = den.lib.synthesizePolicies.synthesize "test-as-source";
+            result = intoFn { };
+          in
+          builtins.attrNames result;
+        expected = [ "peer" ];
+      }
+    );
+
+    # Policy without `as` field defaults key to `to`.
+    test-policy-as-defaults-to-to = denTest (
+      { den, ... }:
+      {
+        den.stages.test-as-default-source = {
+          includes = [ ];
+        };
+
+        den.stages.test-as-default-target = {
+          includes = [ ];
+        };
+
+        den.policies.test-as-default-source-to-target = {
+          from = "test-as-default-source";
+          to = "test-as-default-target";
+          resolve = _: [ { } ];
+        };
+
+        # synthesize "test-as-default-source" should produce { test-as-default-target = [{}] }
+        expr =
+          let
+            intoFn = den.lib.synthesizePolicies.synthesize "test-as-default-source";
+            result = intoFn { };
+          in
+          builtins.attrNames result;
+        expected = [ "test-as-default-target" ];
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/policy-inspect.nix
+++ b/templates/ci/modules/features/policy-inspect.nix
@@ -1,0 +1,161 @@
+{ denTest, ... }:
+{
+  flake.tests.policy-inspect = {
+
+    # inspect returns core policies matching the kind.
+    test-inspect-core-policies = denTest (
+      { den, lib, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = {
+          users.tux = { };
+        };
+
+        expr =
+          let
+            igloo = den.hosts.x86_64-linux.igloo;
+            result = den.lib.policyInspect.inspect {
+              kind = "host";
+              context = {
+                host = igloo;
+              };
+            };
+          in
+          {
+            hasHostToUsers = result ? host-to-users;
+            hasHostToDefault = result ? host-to-default;
+            hostToUsersRouting = result.host-to-users.routing;
+            hostToUsersTargetKey = result.host-to-users.targetKey;
+          };
+        expected = {
+          hasHostToUsers = true;
+          hasHostToDefault = true;
+          hostToUsersRouting = "child";
+          hostToUsersTargetKey = "user";
+        };
+      }
+    );
+
+    # inspect returns resolved targets from the policy.
+    test-inspect-returns-targets = denTest (
+      { den, lib, ... }:
+      {
+        den.hosts.x86_64-linux.igloo = {
+          users.tux = { };
+          users.alice = { };
+        };
+
+        expr =
+          let
+            igloo = den.hosts.x86_64-linux.igloo;
+            result = den.lib.policyInspect.inspect {
+              kind = "host";
+              context = {
+                host = igloo;
+              };
+            };
+          in
+          builtins.length result.host-to-users.targets;
+        expected = 2;
+      }
+    );
+
+    # inspect only returns active policies.
+    test-inspect-respects-activation = denTest (
+      { den, ... }:
+      {
+        den.stages.test-insp-src = {
+          includes = [ ];
+        };
+        den.stages.test-insp-tgt = {
+          includes = [ ];
+        };
+
+        den.policies.test-insp-inactive = {
+          from = "test-insp-src";
+          to = "test-insp-tgt";
+          resolve = _: [ { } ];
+        };
+
+        # Not activated — should not appear in inspect
+        expr =
+          let
+            result = den.lib.policyInspect.inspect {
+              kind = "test-insp-src";
+              context = { };
+            };
+          in
+          result ? test-insp-inactive;
+        expected = false;
+      }
+    );
+
+    # inspect shows activated policy.
+    test-inspect-shows-activated = denTest (
+      { den, ... }:
+      {
+        den.stages.test-insp-act-src = {
+          includes = [ ];
+        };
+        den.stages.test-insp-act-tgt = {
+          includes = [ ];
+        };
+
+        den.policies.test-insp-act-pol = {
+          from = "test-insp-act-src";
+          to = "test-insp-act-tgt";
+          resolve = _: [ { } ];
+        };
+
+        den.default.policies = [ "test-insp-act-pol" ];
+
+        expr =
+          let
+            result = den.lib.policyInspect.inspect {
+              kind = "test-insp-act-src";
+              context = { };
+            };
+          in
+          result ? test-insp-act-pol;
+        expected = true;
+      }
+    );
+
+    # inspect reports sibling routing for same-type policies.
+    test-inspect-sibling-routing = denTest (
+      { den, ... }:
+      {
+        den.policies.test-insp-sibling = {
+          _core = true;
+          from = "host";
+          to = "host";
+          as = "peer";
+          resolve = _: [ { } ];
+        };
+
+        den.hosts.x86_64-linux.igloo = { };
+
+        expr =
+          let
+            igloo = den.hosts.x86_64-linux.igloo;
+            result = den.lib.policyInspect.inspect {
+              kind = "host";
+              context = {
+                host = igloo;
+              };
+            };
+          in
+          {
+            routing = result.test-insp-sibling.routing;
+            targetKey = result.test-insp-sibling.targetKey;
+            as = result.test-insp-sibling.as;
+          };
+        expected = {
+          routing = "sibling";
+          targetKey = "peer";
+          as = "peer";
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/provide-to.nix
+++ b/templates/ci/modules/features/provide-to.nix
@@ -1,0 +1,161 @@
+{ denTest, ... }:
+{
+  flake.tests.provide-to = {
+
+    # Aspect with provide-to has data collected in pipeline state.
+    test-provide-to-collects-in-state = denTest (
+      { den, ... }:
+      let
+        self = {
+          name = "web-server";
+          meta = { };
+          nixos = { };
+          "provide-to" = {
+            http-backends = [
+              {
+                address = "10.0.0.1";
+                port = 8080;
+              }
+            ];
+          };
+          includes = [ ];
+        };
+        result = den.lib.aspects.fx.pipeline.fxFullResolve {
+          class = "nixos";
+          inherit self;
+          ctx = { };
+        };
+        emissions = result.state.provideTo null;
+      in
+      {
+        expr = builtins.length emissions;
+        expected = 1;
+      }
+    );
+
+    # Collected emission has correct shape.
+    test-provide-to-emission-shape = denTest (
+      { den, ... }:
+      let
+        self = {
+          name = "web-server";
+          meta = { };
+          nixos = { };
+          "provide-to" = {
+            http-backends = [
+              {
+                address = "10.0.0.1";
+                port = 8080;
+              }
+            ];
+          };
+          includes = [ ];
+        };
+        result = den.lib.aspects.fx.pipeline.fxFullResolve {
+          class = "nixos";
+          inherit self;
+          ctx = { };
+        };
+        emission = builtins.head (result.state.provideTo null);
+      in
+      {
+        expr = {
+          label = emission.label;
+          aspectName = emission.aspectName;
+          hasContent = emission.content != [ ];
+          targetIsNull = emission.targetEntity == null;
+        };
+        expected = {
+          label = "http-backends";
+          aspectName = "web-server";
+          hasContent = true;
+          targetIsNull = true;
+        };
+      }
+    );
+
+    # Multiple provide-to labels produce multiple emissions.
+    test-provide-to-multiple-labels = denTest (
+      { den, ... }:
+      let
+        self = {
+          name = "multi-provider";
+          meta = { };
+          nixos = { };
+          "provide-to" = {
+            http-backends = [ { port = 80; } ];
+            dns-records = [ { type = "A"; } ];
+          };
+          includes = [ ];
+        };
+        result = den.lib.aspects.fx.pipeline.fxFullResolve {
+          class = "nixos";
+          inherit self;
+          ctx = { };
+        };
+        emissions = result.state.provideTo null;
+        labels = builtins.sort (a: b: a < b) (map (e: e.label) emissions);
+      in
+      {
+        expr = labels;
+        expected = [
+          "dns-records"
+          "http-backends"
+        ];
+      }
+    );
+
+    # Aspect without provide-to produces no emissions.
+    test-no-provide-to-no-emissions = denTest (
+      { den, ... }:
+      let
+        self = {
+          name = "plain-aspect";
+          meta = { };
+          nixos = {
+            x = 1;
+          };
+          includes = [ ];
+        };
+        result = den.lib.aspects.fx.pipeline.fxFullResolve {
+          class = "nixos";
+          inherit self;
+          ctx = { };
+        };
+      in
+      {
+        expr = builtins.length (result.state.provideTo null);
+        expected = 0;
+      }
+    );
+
+    # provide-to is a structural key — not treated as a class key.
+    test-provide-to-not-class-key = denTest (
+      { den, ... }:
+      let
+        self = {
+          name = "structural-test";
+          meta = { };
+          nixos = {
+            x = 1;
+          };
+          "provide-to" = {
+            http-backends = [ { port = 80; } ];
+          };
+          includes = [ ];
+        };
+        result = den.lib.aspects.fx.pipeline.fxFullResolve {
+          class = "nixos";
+          inherit self;
+          ctx = { };
+        };
+        # Only 1 class module (nixos), not 2 (provide-to is structural, not a class)
+      in
+      {
+        expr = builtins.length (result.state.imports null);
+        expected = 1;
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Summary

- **Policy `as` field** — context key aliasing for sibling routing (e.g., host→host uses `as = "peer"` to avoid key collision)
- **4-level activation model** — core (`_core`), global (`den.default.policies`), schema-kind and entity-instance (`entity.policies` via `schema.conf` pattern)
- **provide-to structural key + collection handler** — cross-entity data routing infrastructure; aspects declare `provide-to.label = data`, handler accumulates in pipeline state
- **Policy inspect utility** — `den.lib.policyInspect.inspect` for lightweight debugging without full pipeline execution

## Test plan

- [x] 512/512 CI tests pass (`nix develop -c just ci`)
- [x] 20 new tests across 4 test files covering all features
- [x] Activation model: core always-active, default opt-in, schema-kind scoped, entity-instance scoped, non-activated excluded
- [x] provide-to: collection in state, emission shape, multiple labels, structural key not treated as class
- [x] Inspect: core policies, resolved targets, activation-aware, sibling routing detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)