### PR TITLE
fix: unfree provider for non-module-system user classes

### DIFF
--- a/modules/aspects/provides/unfree/unfree.nix
+++ b/modules/aspects/provides/unfree/unfree.nix
@@ -31,11 +31,17 @@ let
         ];
         classModule =
           if builtins.elem class validClasses then { ${class}.unfree.packages = allowed-names; } else { };
-        # When resolving for homeManager at user scope, also emit to the
-        # host's OS class. This ensures nixpkgs.config.allowUnfreePredicate
-        # covers these packages when home-manager.useGlobalPkgs = true.
+        # When resolving for homeManager or a non-module-system class (e.g.
+        # "user"), also emit to the host's OS class.  This ensures
+        # nixpkgs.config.allowUnfreePredicate covers these packages:
+        #   - homeManager + useGlobalPkgs = true → OS-level predicate needed
+        #   - "user" class (no HM) → only the host's OS config exists
         hostModule =
-          if class == "homeManager" && host != null && builtins.elem host.class validClasses then
+          if
+            (class == "homeManager" || !builtins.elem class validClasses)
+            && host != null
+            && builtins.elem host.class validClasses
+          then
             { ${host.class}.unfree.packages = allowed-names; }
           else
             { };


### PR DESCRIPTION
## Summary
- When a user has `classes = ["user"]` (no homeManager), `den.provides.unfree` resolved with `class = "user"` — not in `validClasses` — silently dropping the `unfree.packages` emission entirely
- Fix: extend the `hostModule` condition to emit to the host's OS class for any non-module-system class, not just `homeManager`
- All existing unfree tests pass; verified with a reproduction case matching the reported config

## Test plan
- [x] Existing `unfree` test suite passes (test-packages-set-on-nixos, test-packages-set-on-home-manager, test-user-class-works)
- [x] Reproduced: user aspect chain (user → development → ollama → unfree) with `classes = ["user"]` now correctly populates `igloo.unfree.packages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)