### PR TITLE
fix: insecure provider for non-module-system user classes

### DIFF
--- a/modules/aspects/provides/insecure/insecure.nix
+++ b/modules/aspects/provides/insecure/insecure.nix
@@ -18,21 +18,39 @@ let
       "provides"
     ];
     __fn =
-      { class, ... }:
-      if
-        (builtins.elem class [
+      {
+        class,
+        host ? null,
+        ...
+      }:
+      let
+        validClasses = [
           "nixos"
           "darwin"
           "homeManager"
-        ])
-      then
-        {
-          ${class}.permittedInsecurePackages.packages = allowed-names;
-        }
-      else
-        { };
+        ];
+        classModule =
+          if builtins.elem class validClasses then
+            { ${class}.permittedInsecurePackages.packages = allowed-names; }
+          else
+            { };
+        # When resolving for homeManager or a non-module-system class (e.g.
+        # "user"), also emit to the host's OS class so
+        # nixpkgs.config.permittedInsecurePackages covers these packages.
+        hostModule =
+          if
+            (class == "homeManager" || !builtins.elem class validClasses)
+            && host != null
+            && builtins.elem host.class validClasses
+          then
+            { ${host.class}.permittedInsecurePackages.packages = allowed-names; }
+          else
+            { };
+      in
+      classModule // hostModule;
     __args = {
       class = true;
+      host = true;
     };
   };
 in


### PR DESCRIPTION
## Summary
- Same bug as #495 (unfree): when a user has `classes = ["user"]` (no homeManager), `den.provides.insecure` resolved with `class = "user"` — not in `validClasses` — silently dropping the `permittedInsecurePackages` emission
- Fix: add `host` arg and emit to the host's OS class for any non-module-system class, matching the unfree provider fix
- Audited all other providers in `modules/aspects/provides/` — none are affected

## Test plan
- [x] Existing `insecure` test suite passes
- [x] Verified: user aspect with `classes = ["user"]` now correctly populates `igloo.permittedInsecurePackages.packages`