### PR TITLE
fix: policy.for accepts list of entities and hardens id_hash matching

### DIFF
--- a/modules/options.nix
+++ b/modules/options.nix
@@ -102,8 +102,11 @@ let
                 default =
                   let
                     isPrimitive =
-                      _: opt:
-                      (opt ? type) && builtins.elem (opt.type.name or "") primitiveTypeNames && !(opt.internal or false);
+                      name: opt:
+                      !(lib.hasPrefix "_" name)
+                      && (opt ? type)
+                      && builtins.elem (opt.type.name or "") primitiveTypeNames
+                      && !(opt.internal or false);
                     identityKeys = lib.sort (a: b: a < b) (builtins.attrNames (lib.filterAttrs isPrimitive options));
                     encode =
                       k:

--- a/nix/lib/policy-effects.nix
+++ b/nix/lib/policy-effects.nix
@@ -149,11 +149,14 @@
         collisionPolicy = "class-wins";
       };
 
-  # Wrap a policy (or list of policies) to only fire for a specific entity.
+  # Wrap a policy (or list of policies) to only fire for specific entities.
+  # Accepts a single entity or a list of entities as the first argument.
   # Uses id_hash for robust identity matching.
   for =
-    entity: policiesOrSingle:
+    entityOrEntities: policiesOrSingle:
     let
+      entities = if builtins.isList entityOrEntities then entityOrEntities else [ entityOrEntities ];
+      entityHashes = builtins.filter (h: h != null) (map (e: e.id_hash or null) entities);
       policies = if builtins.isList policiesOrSingle then policiesOrSingle else [ policiesOrSingle ];
       wrap =
         p:
@@ -176,11 +179,9 @@
             let
               entityKind = ctx.__entityKind or null;
               ctxEntity = if entityKind != null then ctx.${entityKind} or null else null;
+              ctxHash = if ctxEntity != null then ctxEntity.id_hash or null else null;
             in
-            if ctxEntity != null && (ctxEntity.id_hash or null) == (entity.id_hash or null) then
-              inner.fn ctx
-            else
-              [ ];
+            if ctxHash != null && builtins.elem ctxHash entityHashes then inner.fn ctx else [ ];
         };
     in
     if builtins.isList policiesOrSingle then map wrap policies else wrap policiesOrSingle;

--- a/templates/ci/modules/features/policy-combinators.nix
+++ b/templates/ci/modules/features/policy-combinators.nix
@@ -260,6 +260,113 @@
       }
     );
 
+    # policy.for — list of entities matches any
+    test-for-entity-list = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.h.users.u = { };
+        expr =
+          let
+            p = {
+              __isPolicy = true;
+              name = "multi-target";
+              fn = _: [ "matched" ];
+            };
+            wrapped = den.lib.policy.for [
+              { id_hash = "aaa"; }
+              { id_hash = "bbb"; }
+            ] p;
+            ctxFirst = {
+              __entityKind = "host";
+              host.id_hash = "aaa";
+            };
+            ctxSecond = {
+              __entityKind = "host";
+              host.id_hash = "bbb";
+            };
+            ctxNeither = {
+              __entityKind = "host";
+              host.id_hash = "ccc";
+            };
+          in
+          {
+            matchFirst = wrapped.fn ctxFirst;
+            matchSecond = wrapped.fn ctxSecond;
+            matchNeither = wrapped.fn ctxNeither;
+            name = wrapped.name;
+          };
+        expected = {
+          matchFirst = [ "matched" ];
+          matchSecond = [ "matched" ];
+          matchNeither = [ ];
+          name = "multi-target";
+        };
+      }
+    );
+
+    # policy.for — list with mixed id_hash presence
+    test-for-mixed-hash-list = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.h.users.u = { };
+        expr =
+          let
+            p = {
+              __isPolicy = true;
+              name = "mixed";
+              fn = _: [ "hit" ];
+            };
+            wrapped = den.lib.policy.for [
+              { id_hash = "aaa"; }
+              { name = "no-hash"; }
+            ] p;
+            ctxMatch = {
+              __entityKind = "host";
+              host.id_hash = "aaa";
+            };
+            ctxNoHash = {
+              __entityKind = "host";
+              host = {
+                name = "no-hash";
+              };
+            };
+          in
+          {
+            matchesFirst = wrapped.fn ctxMatch;
+            noHashNeverMatches = wrapped.fn ctxNoHash;
+          };
+        expected = {
+          matchesFirst = [ "hit" ];
+          noHashNeverMatches = [ ];
+        };
+      }
+    );
+
+    # policy.for — entity without id_hash never matches
+    test-for-no-id-hash = denTest (
+      { den, ... }:
+      {
+        den.hosts.x86_64-linux.h.users.u = { };
+        expr =
+          let
+            p = {
+              __isPolicy = true;
+              name = "no-hash";
+              fn = _: [ "should-not-fire" ];
+            };
+            wrapped = den.lib.policy.for { name = "bare"; } p;
+            ctx = {
+              __entityKind = "host";
+              host = {
+                name = "bare";
+              };
+            };
+          in
+          wrapped.fn ctx;
+        expected = [ ];
+      }
+    );
+
     # Raw function input — unwrapped fn gets name = "<inline>"
     test-raw-function-input = denTest (
       { den, ... }:


### PR DESCRIPTION
## Summary
- `policy.for` now accepts a single entity or a list of entities as its first argument — matching fires if the context entity's `id_hash` matches any entity in the list
- Fixes `policy.for` never applying when users pass `policy.for [ host1 host2 ] (policy.include ...)` — the list had no `id_hash` attribute, so the comparison always failed
- Hardens `id_hash` to require non-null on both sides (prevents `null == null` false positives) and filters `_`-prefixed options from the identity hash computation

## Test plan
- [x] 760/760 CI tests pass
- [x] New test: `test-for-entity-list` — list of entities matches any member
- [x] New test: `test-for-mixed-hash-list` — list with mixed `id_hash` presence, hash-less entries silently dropped
- [x] New test: `test-for-no-id-hash` — entities without `id_hash` never match
- [ ] Manual verification with the reported user pattern: `policy.for [ x86_64-linux.yalova ] (policy.include aspects.tlp)`