### PR TITLE
fix: nested classification, hm-host bridge, bare aspect access

### DIFF
--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -1,10 +1,12 @@
 {
   den,
+  config,
+  lib,
   inputs,
   ...
 }:
 let
-  inherit (den.lib.home-env) makeHomeEnv;
+  inherit (den.lib.home-env) makeHomeEnv mkDetectHost;
 
   result = makeHomeEnv {
     className = "homeManager";
@@ -20,10 +22,30 @@ let
       ];
   };
 
+  # Bridge den.schema.hm-host includes into host resolution via policy.include.
+  # Guarded by policy.when — only fires when the host has homeManager users.
+  hmHostSchemaIncludes = config.den.schema.hm-host.includes or [ ];
+  hasHmUsers =
+    { host, ... }:
+    mkDetectHost {
+      className = "homeManager";
+      optionPath = "home-manager";
+    } { inherit host; };
+  hmHostBridge = den.lib.policy.when hasHmUsers (
+    den.lib.policy.mkPolicy "hm-host-schema" (
+      _: map (inc: den.lib.policy.include inc) hmHostSchemaIncludes
+    )
+  );
+
 in
 {
   den.schema.host.imports = [ result.hostConf ];
-  den.schema.host.includes = [ result.battery ];
+  den.schema.host.includes = [
+    result.battery
+  ]
+  ++ lib.optional (hmHostSchemaIncludes != [ ]) {
+    includes = [ hmHostBridge ];
+  };
 
   den.classes.homeManager.description = "Home Manager user environment";
 }

--- a/modules/aspects/provides/home-manager.nix
+++ b/modules/aspects/provides/home-manager.nix
@@ -43,9 +43,9 @@ in
   den.schema.host.includes = [
     result.battery
   ]
-  ++ lib.optional (hmHostSchemaIncludes != [ ]) {
-    includes = [ hmHostBridge ];
-  };
+  ++ lib.optionals (hmHostSchemaIncludes != [ ]) [
+    { includes = [ hmHostBridge ]; }
+  ];
 
   den.classes.homeManager.description = "Home Manager user environment";
 }

--- a/nix/lib/aspects/fx/key-classification.nix
+++ b/nix/lib/aspects/fx/key-classification.nix
@@ -36,11 +36,25 @@ let
   # wrapped as class modules by wrapCollectedClasses.
   pipeRegistry = den.quirks or { };
 
+  # Check whether a value looks like class content (a module or config attrset)
+  # rather than plain data.  Rejects flat-scalar attrsets like { name = "…"; }
+  # that happen to sit under a key matching a registered class name.
+  looksLikeClassContent =
+    v:
+    lib.isFunction v
+    || (builtins.isAttrs v && v ? __contentValues)
+    || (
+      builtins.isAttrs v
+      && builtins.any (k: builtins.isAttrs v.${k} || lib.isFunction v.${k}) (builtins.attrNames v)
+    );
+
   hasRecognizedSubKeys =
     depth: val:
     builtins.isAttrs val
     && builtins.any (
-      sk: classRegistry ? ${sk} || (depth > 0 && hasRecognizedSubKeys (depth - 1) val.${sk})
+      sk:
+      (classRegistry ? ${sk} && looksLikeClassContent val.${sk})
+      || (depth > 0 && builtins.isAttrs (val.${sk} or null) && hasRecognizedSubKeys (depth - 1) val.${sk})
     ) (builtins.attrNames val);
 
   isNestedKey =

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -274,6 +274,11 @@ let
   # Multi-site definitions are preserved as a list with file attribution.
   # Already-wrapped values (from cross-submodule propagation) are flattened
   # to prevent double-wrapping.
+  #
+  # Attrset definition values are shallow-merged onto the wrapper so that
+  # nested attribute access works (e.g. `gloom.apps.polybar.razermon`).
+  # Pipeline consumers use __contentValues for processing; the forwarded
+  # attributes are a convenience for direct config access and includes.
   aspectContentType =
     typeCfg:
     lib.types.mkOptionType {
@@ -293,8 +298,13 @@ let
             else
               [ { inherit (d) value file; } ]
           ) defs;
+          # Shallow-merge attrset definition values so sub-keys are directly
+          # accessible on the wrapper (enables bare nested aspect access).
+          attrVals = builtins.filter builtins.isAttrs (map (d: d.value) flatDefs);
+          forwarded = builtins.foldl' (a: b: a // b) { } attrVals;
         in
-        {
+        forwarded
+        // {
           __contentValues = flatDefs;
           __provider = (typeCfg.providerPrefix or [ ]) ++ [ keyName ];
         };

--- a/templates/ci/modules/features/structural-detection.nix
+++ b/templates/ci/modules/features/structural-detection.nix
@@ -360,6 +360,60 @@
       }
     );
 
+    # Freeform data key whose sub-key name collides with a registered class
+    # must NOT be treated as a nested aspect.  Regression test: git.user data
+    # was misclassified because "user" matched den.classes.user.
+    test-class-name-collision-not-nested = denTest (
+      { den, ... }:
+      let
+        fx = den.lib.fx;
+        aspect = {
+          name = "dev";
+          meta = { };
+          nixos = {
+            networking.hostName = "test";
+          };
+          # "git" is not a class; its child "user" collides with den.classes.user
+          # but the value is flat data, not a module — must be ignored.
+          git = {
+            user = {
+              name = "Alice";
+              email = "alice@example.com";
+            };
+          };
+          includes = [ ];
+        };
+        comp = fx.send "resolve" {
+          inherit aspect;
+          identity = den.lib.aspects.fx.identity.key aspect;
+          ctx = { };
+        };
+        result = fx.handle {
+          handlers = den.lib.aspects.fx.pipeline.defaultHandlers {
+            class = "nixos";
+            ctx = { };
+          };
+          state = den.lib.aspects.fx.pipeline.defaultState;
+        } comp;
+      in
+      {
+        den.classes.nixos.description = "NixOS";
+        den.classes.user.description = "User environment";
+
+        # Only nixos produces an import; git.user data is not dispatched as user class
+        expr = builtins.length (
+          (builtins.foldl' (
+            acc: sd:
+            lib.zipAttrsWith (_: builtins.concatLists) [
+              acc
+              sd
+            ]
+          ) { } (builtins.attrValues (result.state.scopedClassImports null))).nixos or [ ]
+        );
+        expected = 1;
+      }
+    );
+
     # funnyNames helper works with funny class registered in provider.
     test-funny-class-registered = denTest (
       { den, funnyNames, ... }:


### PR DESCRIPTION
## Summary

Three post-fx-pipeline regressions reported by a user after updating:

- **Nested classification false positive** — freeform data keys with sub-keys matching registered class names (e.g. `git.user` colliding with `den.classes.user`) were misclassified as nested aspects, causing content to leak into class routing (`users.users.loom.email` does not exist). Added `looksLikeClassContent` guard to `hasRecognizedSubKeys`.

- **`den.schema.hm-host` not consumed** — the ctx-shim forwarded `den.ctx.hm-host` to `den.schema.hm-host.includes`, but nothing in the pipeline read that schema. Added a `policy.when`-guarded bridge in the HM battery that injects `hm-host` schema includes via `policy.include` when the host has homeManager users.

- **Bare nested aspect access** — `aspectContentType` wrapped all freeform values into opaque `__contentValues` wrappers, preventing direct attribute access like `gloom.apps.polybar.razermon`. Shallow-merge attrset definition values onto the wrapper so sub-keys are accessible for config access and includes.

## Test plan

- [x] 758/758 CI tests pass (`nix develop -c just ci`)
- [x] New regression test `test-class-name-collision-not-nested`
- [x] User's dotfiles: all 8 nixosConfigurations eval on both `main` and `new_den` (migration) branches
- [x] `den.ctx.hm-host` deprecation warning fires and `useGlobalPkgs` propagates correctly