### PR TITLE
feat: add pipe.as stage for cross-quirk adaptation

### DIFF
--- a/docs/src/content/docs/explanation/quirks-and-pipes.mdx
+++ b/docs/src/content/docs/explanation/quirks-and-pipes.mdx
@@ -172,6 +172,25 @@ den.policies.expose-prefs = { host, user, ... }:
   [ (pipe.from "prefs" [ pipe.expose ]) ];
 ```
 
+### Renaming with `pipe.as`
+
+`pipe.as` delivers data under a different quirk name. This creates
+**derived quirks** — quirks with no native emitters, populated entirely
+from other pipes via collect + transform + rename:
+
+```nix
+den.policies.derive-targets = { host, ... }:
+  let inherit (den.lib.policy) pipe; in
+  [ (pipe.from "backends" [
+      (pipe.transform (b: "${b.addr}:${toString b.port}"))
+      (pipe.as "monitoring-targets")
+    ])
+  ];
+```
+
+Consumers of `monitoring-targets` receive the transformed data. Consumers
+of `backends` are unaffected. Composes with `pipe.to` and `pipe.collect`.
+
 ### Cross-scope with `pipe.collect`
 
 `pipe.collect` harvests data from sibling scopes matching a predicate.

--- a/docs/src/content/docs/guides/quirks.mdx
+++ b/docs/src/content/docs/guides/quirks.mdx
@@ -328,6 +328,79 @@ den.aspects.postgres = {
 This pattern works because `pipe.for` replaces the list with the fold
 result, and `pipe.to` delivers only to the named aspect.
 
+## Derived quirks with `pipe.as`
+
+`pipe.as` renames pipe output, delivering data under a different quirk name.
+This lets you create **derived quirks** — quirks with no native emitters,
+populated entirely from other pipes:
+
+```nix
+den.quirks.backends = { description = "Backend addresses"; };
+den.quirks.monitoring-targets = { description = "Monitoring targets"; };
+
+den.aspects.web = {
+  backends = [
+    { addr = "10.0.0.1"; port = 80; }
+    { addr = "10.0.0.2"; port = 443; }
+  ];
+};
+
+den.aspects.monitor = {
+  nixos = { monitoring-targets, lib, ... }: {
+    networking.hostName =
+      lib.concatStringsSep "," monitoring-targets;
+  };
+};
+
+den.policies.backends-to-monitoring = { host, ... }:
+  let inherit (den.lib.policy) pipe; in
+  [ (pipe.from "backends" [
+      (pipe.transform (b: "${b.addr}:${toString b.port}"))
+      (pipe.as "monitoring-targets")
+    ])
+  ];
+```
+
+The `monitor` aspect consumes `monitoring-targets` which has no native
+emitters — it's entirely populated via `pipe.as` from `backends`. The
+`web` aspect's data is transformed and renamed, while any direct consumers
+of `backends` see the original data unmodified.
+
+### Combining `pipe.as` with `pipe.collect`
+
+Collect data across hosts, transform it, and deliver under a new name:
+
+```nix
+den.policies.collect-as-urls = { host, ... }:
+  let inherit (den.lib.policy) pipe; in
+  [ (pipe.from "http-addrs" [
+      (pipe.collect ({ host, ... }: true))
+      (pipe.transform (a: "http://${a.addr}:${toString a.port}"))
+      (pipe.as "peer-urls")
+    ])
+  ];
+```
+
+### Combining `pipe.as` with `pipe.to`
+
+Target specific aspects with renamed data:
+
+```nix
+den.policies.targeted-derived = { host, ... }:
+  let inherit (den.lib.policy) pipe; in
+  [ (pipe.from "raw-data" [
+      (pipe.transform (v: "d-${v}"))
+      (pipe.as "derived-data")
+      (pipe.to [ den.aspects.targeted-consumer ])
+    ])
+  ];
+```
+
+<Aside type="caution">
+`pipe.as` must target a different quirk than its source. Self-targeting
+(`pipe.as "same-pipe"`) throws an error.
+</Aside>
+
 ## Config-dependent thunks
 
 Quirk values can depend on a host's NixOS `config`. Declare a function

--- a/docs/src/content/docs/reference/quirks.mdx
+++ b/docs/src/content/docs/reference/quirks.mdx
@@ -171,8 +171,26 @@ pipe.for (vals: lib.reverseList vals)
 
 ## Routing stages
 
-Routing stages control where data flows. They are terminal — no transform
-stages should follow them.
+Routing stages control where data flows. They are declarative directives —
+transform stages should appear before them, not after.
+
+### `pipe.as targetPipeName`
+
+Rename pipe output. Data from the source pipe is delivered under
+`targetPipeName` instead. The target must be a different pipe than the
+source -- self-targeting throws an error.
+
+```nix
+pipe.from "http-backends" [
+  (pipe.collect ({ host, ... }: true))
+  (pipe.transform (b: "${b.addr}:${toString b.port}"))
+  (pipe.as "monitoring-targets")
+]
+```
+
+Consumers of `monitoring-targets` receive the transformed data.
+Consumers of `http-backends` are unaffected. Composes with `pipe.to`
+for aspect-targeted delivery under the renamed name.
 
 ### `pipe.expose`
 
@@ -270,7 +288,8 @@ wrapping. The sequence:
    - Merge exposed data from children
    - Mark local config thunks
    - Apply untargeted pipe effects
-   - Build targeted data (`pipe.to`)
+   - Route inbound `pipe.as` effects from other pipes
+   - Build targeted data (`pipe.to`, `pipe.as` + `pipe.to`)
 3. **Inject into scope contexts** — pipe data becomes available as
    function args in `wrapClassModule`
 

--- a/nix/lib/aspects/fx/assemble-pipes.nix
+++ b/nix/lib/aspects/fx/assemble-pipes.nix
@@ -653,7 +653,7 @@ let
               combinedBase = markedBase ++ markedExposed;
               relevantEffects = builtins.filter (e: e.pipeName == pipeName) scopeEffects;
               # Validate no pipe.as self-targeting in this scope.
-              _asCheck = builtins.seq (map (
+              _asCheck = builtins.deepSeq (map (
                 e:
                 assert assertNoSelfAs e;
                 null

--- a/nix/lib/aspects/fx/assemble-pipes.nix
+++ b/nix/lib/aspects/fx/assemble-pipes.nix
@@ -641,16 +641,8 @@ let
           pipeData = lib.genAttrs pipeNames (
             pipeName:
             let
-              rawEntries = scopeImports.${pipeName} or [ ];
-              baseValues = flattenAndExtract rawEntries;
-              # Resolve local pipeline-parametric values eagerly, then mark
-              # config-dependent thunks for deferred resolution inside evalModules.
-              resolvedBase = builtins.concatMap (resolveLocalParametric scopeCtx) baseValues;
-              markedBase = markConfigThunks resolvedBase;
-              # Merge exposed data from children (also mark any thunks).
+              combinedBase = mkCombinedBase pipeName;
               exposedValues = exposedForScope.${pipeName} or [ ];
-              markedExposed = markConfigThunks exposedValues;
-              combinedBase = markedBase ++ markedExposed;
               relevantEffects = builtins.filter (e: e.pipeName == pipeName) scopeEffects;
               # Validate no pipe.as self-targeting in this scope.
               _asCheck = builtins.deepSeq (map (
@@ -695,7 +687,7 @@ let
 
               normalResult =
                 if untargetedEffects == [ ] && relevantEffects == [ ] && exposedValues == [ ] then
-                  markedBase
+                  combinedBase
                 else if untargetedEffects == [ ] then
                   # All effects are targeted, expose, or pipe.as — scope-wide data is base values unchanged.
                   combinedBase
@@ -719,13 +711,7 @@ let
               perPipe = lib.genAttrs pipeNames (
                 pipeName:
                 let
-                  rawEntries = scopeImports.${pipeName} or [ ];
-                  baseValues = flattenAndExtract rawEntries;
-                  resolvedBase = builtins.concatMap (resolveLocalParametric scopeCtx) baseValues;
-                  markedBase = markConfigThunks resolvedBase;
-                  exposedValues = exposedForScope.${pipeName} or [ ];
-                  markedExposed = markConfigThunks exposedValues;
-                  combinedBase = markedBase ++ markedExposed;
+                  combinedBase = mkCombinedBase pipeName;
                   relevantEffects = builtins.filter (e: e.pipeName == pipeName) scopeEffects;
                   # Targeted effects on this pipe WITHOUT pipe.as (they stay under this pipeName).
                   targetedEffects = builtins.filter (e: hasToStage e && !hasAsStage e) relevantEffects;

--- a/nix/lib/aspects/fx/assemble-pipes.nix
+++ b/nix/lib/aspects/fx/assemble-pipes.nix
@@ -624,6 +624,19 @@ let
           scopeEffects = scopedPipeEffects.${scopeId} or [ ];
           exposedForScope = allExposed.${scopeId} or { };
 
+          # Resolve and mark a pipe's base values (imports + exposed), used by pipe.as routing.
+          mkCombinedBase =
+            pn:
+            let
+              rawEntries = scopeImports.${pn} or [ ];
+              baseValues = flattenAndExtract rawEntries;
+              resolvedBase = builtins.concatMap (resolveLocalParametric scopeCtx) baseValues;
+              markedBase = markConfigThunks resolvedBase;
+              exposedValues = exposedForScope.${pn} or [ ];
+              markedExposed = markConfigThunks exposedValues;
+            in
+            markedBase ++ markedExposed;
+
           # For each pipe, separate untargeted and targeted effects.
           pipeData = lib.genAttrs pipeNames (
             pipeName:
@@ -665,13 +678,7 @@ let
               asResults = lib.concatMap (
                 e:
                 let
-                  srcEntries = scopeImports.${e.pipeName} or [ ];
-                  srcBase = flattenAndExtract srcEntries;
-                  resolvedSrc = builtins.concatMap (resolveLocalParametric scopeCtx) srcBase;
-                  markedSrc = markConfigThunks resolvedSrc;
-                  srcExposed = exposedForScope.${e.pipeName} or [ ];
-                  markedSrcExposed = markConfigThunks srcExposed;
-                  combinedSrc = markedSrc ++ markedSrcExposed;
+                  combinedSrc = mkCombinedBase e.pipeName;
                 in
                 applyEffectStages {
                   inherit
@@ -690,6 +697,7 @@ let
                 if untargetedEffects == [ ] && relevantEffects == [ ] && exposedValues == [ ] then
                   markedBase
                 else if untargetedEffects == [ ] then
+                  # All effects are targeted, expose, or pipe.as — scope-wide data is base values unchanged.
                   combinedBase
                 else
                   applyPipeEffects {
@@ -753,14 +761,7 @@ let
                   asTargetedResults = lib.foldl' (
                     acc: e:
                     let
-                      srcEntries = scopeImports.${e.pipeName} or [ ];
-                      srcBase = flattenAndExtract srcEntries;
-                      resolvedSrc = builtins.concatMap (resolveLocalParametric scopeCtx) srcBase;
-                      markedSrc = markConfigThunks resolvedSrc;
-                      srcExposed = exposedForScope.${e.pipeName} or [ ];
-                      markedSrcExposed = markConfigThunks srcExposed;
-                      combinedSrc = markedSrc ++ markedSrcExposed;
-                      # Strip pipe.as from stages before applying (it's routing, not transform).
+                      combinedSrc = mkCombinedBase e.pipeName;
                       result = buildTargetedData {
                         inherit
                           scopeContexts

--- a/nix/lib/aspects/fx/assemble-pipes.nix
+++ b/nix/lib/aspects/fx/assemble-pipes.nix
@@ -350,6 +350,31 @@ let
     in
     map (a: den.lib.aspects.fx.identity.key a) toStage.aspects;
 
+  # Check whether a pipe effect has a pipe.as renaming stage.
+  hasAsStage = e: builtins.any (s: (s.__pipeStage or "") == "as") (e.stages or [ ]);
+
+  # Extract target pipe name from a pipe.as stage.
+  getAsTarget =
+    e:
+    let
+      asStage = lib.findFirst (s: (s.__pipeStage or "") == "as") null (e.stages or [ ]);
+    in
+    if asStage == null then null else asStage.targetPipeName;
+
+  # Filter out pipe.as stage from a stage list (it's a routing directive, not a transform).
+  stripAsStage = stages: builtins.filter (s: (s.__pipeStage or "") != "as") stages;
+
+  # Validate pipe.as does not target its own source pipe (would silently drop data).
+  assertNoSelfAs =
+    effect:
+    let
+      target = getAsTarget effect;
+    in
+    if target != null && target == effect.pipeName then
+      throw "den: pipe.as targets its own pipe '${effect.pipeName}' — this is a no-op that silently drops data. Remove the pipe.as stage or target a different pipe."
+    else
+      true;
+
   # Choose the right stage processor for an effect's stages.
   # Uses processStagesWithCollect when collect or withProvenance stages are present.
   applyEffectStages =
@@ -614,24 +639,70 @@ let
               markedExposed = markConfigThunks exposedValues;
               combinedBase = markedBase ++ markedExposed;
               relevantEffects = builtins.filter (e: e.pipeName == pipeName) scopeEffects;
-              # Exclude expose effects from untargeted processing — they route upward, not locally.
-              untargetedEffects = builtins.filter (e: !hasToStage e && !hasExposeStage e) relevantEffects;
+              # Validate no pipe.as self-targeting in this scope.
+              _asCheck = builtins.seq (map (
+                e:
+                assert assertNoSelfAs e;
+                null
+              ) (builtins.filter hasAsStage relevantEffects)) null;
+              # Exclude expose, targeted, and pipe.as effects from untargeted processing.
+              untargetedEffects = builtins.seq _asCheck (
+                builtins.filter (e: !hasToStage e && !hasExposeStage e && !hasAsStage e) relevantEffects
+              );
+
+              # Find pipe.as effects from OTHER pipes that target this pipeName (untargeted only).
+              # Exclude pipe.expose effects — they route upward, not laterally.
+              asInbound = builtins.filter (
+                e:
+                hasAsStage e
+                && !hasToStage e
+                && !hasExposeStage e
+                && getAsTarget e == pipeName
+                && e.pipeName != pipeName
+              ) scopeEffects;
+
+              # Process each inbound pipe.as effect against its SOURCE pipe's base values.
+              asResults = lib.concatMap (
+                e:
+                let
+                  srcEntries = scopeImports.${e.pipeName} or [ ];
+                  srcBase = flattenAndExtract srcEntries;
+                  resolvedSrc = builtins.concatMap (resolveLocalParametric scopeCtx) srcBase;
+                  markedSrc = markConfigThunks resolvedSrc;
+                  srcExposed = exposedForScope.${e.pipeName} or [ ];
+                  markedSrcExposed = markConfigThunks srcExposed;
+                  combinedSrc = markedSrc ++ markedSrcExposed;
+                in
+                applyEffectStages {
+                  inherit
+                    scopeContexts
+                    scopeParent
+                    scopeEntityKind
+                    scopedClassImports
+                    hostConfigs
+                    ;
+                  currentScopeId = scopeId;
+                  pipeName = e.pipeName;
+                } combinedSrc (stripAsStage (e.stages or [ ]))
+              ) asInbound;
+
+              normalResult =
+                if untargetedEffects == [ ] && relevantEffects == [ ] && exposedValues == [ ] then
+                  markedBase
+                else if untargetedEffects == [ ] then
+                  combinedBase
+                else
+                  applyPipeEffects {
+                    inherit
+                      scopeContexts
+                      scopeParent
+                      scopeEntityKind
+                      scopedClassImports
+                      hostConfigs
+                      ;
+                  } pipeName scopeId combinedBase untargetedEffects;
             in
-            if untargetedEffects == [ ] && relevantEffects == [ ] && exposedValues == [ ] then
-              markedBase
-            else if untargetedEffects == [ ] then
-              # All effects are targeted/expose — scope-wide data is combined base values.
-              combinedBase
-            else
-              applyPipeEffects {
-                inherit
-                  scopeContexts
-                  scopeParent
-                  scopeEntityKind
-                  scopedClassImports
-                  hostConfigs
-                  ;
-              } pipeName scopeId combinedBase untargetedEffects
+            normalResult ++ asResults
           );
 
           # Build __pipeTargeted: { aspectName → { pipeName → values } }
@@ -648,21 +719,71 @@ let
                   markedExposed = markConfigThunks exposedValues;
                   combinedBase = markedBase ++ markedExposed;
                   relevantEffects = builtins.filter (e: e.pipeName == pipeName) scopeEffects;
-                  targetedEffects = builtins.filter hasToStage relevantEffects;
+                  # Targeted effects on this pipe WITHOUT pipe.as (they stay under this pipeName).
+                  targetedEffects = builtins.filter (e: hasToStage e && !hasAsStage e) relevantEffects;
+
+                  # Targeted pipe.as effects from OTHER pipes that rename to this pipeName.
+                  # Exclude pipe.expose effects — they route upward, not laterally.
+                  asTargetedInbound = builtins.filter (
+                    e:
+                    hasAsStage e
+                    && hasToStage e
+                    && !hasExposeStage e
+                    && getAsTarget e == pipeName
+                    && e.pipeName != pipeName
+                  ) scopeEffects;
+
+                  # Build targeted data from native targeted effects.
+                  nativeTargeted =
+                    if targetedEffects == [ ] then
+                      { }
+                    else
+                      buildTargetedData {
+                        inherit
+                          scopeContexts
+                          scopeParent
+                          scopeEntityKind
+                          scopedClassImports
+                          hostConfigs
+                          ;
+                        currentScopeId = scopeId;
+                      } combinedBase targetedEffects;
+
+                  # Build targeted data from inbound pipe.as effects (using source pipe's base).
+                  asTargetedResults = lib.foldl' (
+                    acc: e:
+                    let
+                      srcEntries = scopeImports.${e.pipeName} or [ ];
+                      srcBase = flattenAndExtract srcEntries;
+                      resolvedSrc = builtins.concatMap (resolveLocalParametric scopeCtx) srcBase;
+                      markedSrc = markConfigThunks resolvedSrc;
+                      srcExposed = exposedForScope.${e.pipeName} or [ ];
+                      markedSrcExposed = markConfigThunks srcExposed;
+                      combinedSrc = markedSrc ++ markedSrcExposed;
+                      # Strip pipe.as from stages before applying (it's routing, not transform).
+                      result = buildTargetedData {
+                        inherit
+                          scopeContexts
+                          scopeParent
+                          scopeEntityKind
+                          scopedClassImports
+                          hostConfigs
+                          ;
+                        currentScopeId = scopeId;
+                      } combinedSrc [ (e // { stages = stripAsStage (e.stages or [ ]); }) ];
+                    in
+                    # Merge: concatenate values per aspect name.
+                    lib.foldl' (
+                      a: aspectName: a // { ${aspectName} = (a.${aspectName} or [ ]) ++ result.${aspectName}; }
+                    ) acc (builtins.attrNames result)
+                  ) { } asTargetedInbound;
+
                 in
-                if targetedEffects == [ ] then
-                  { }
-                else
-                  buildTargetedData {
-                    inherit
-                      scopeContexts
-                      scopeParent
-                      scopeEntityKind
-                      scopedClassImports
-                      hostConfigs
-                      ;
-                    currentScopeId = scopeId;
-                  } combinedBase targetedEffects
+                # Merge native targeted + inbound pipe.as targeted.
+                lib.foldl' (
+                  acc: aspectName:
+                  acc // { ${aspectName} = (acc.${aspectName} or [ ]) ++ (asTargetedResults.${aspectName} or [ ]); }
+                ) nativeTargeted (builtins.attrNames asTargetedResults)
               );
               # Invert: { pipeName → { aspectName → vals } } → { aspectName → { pipeName → vals } }
               allAspectNames = lib.unique (

--- a/nix/lib/policy-effects.nix
+++ b/nix/lib/policy-effects.nix
@@ -125,6 +125,10 @@
       __pipeStage = "to";
       inherit aspects;
     };
+    as = targetPipeName: {
+      __pipeStage = "as";
+      inherit targetPipeName;
+    };
     expose = {
       __pipeStage = "expose";
     };

--- a/templates/ci/modules/features/pipe-policy.nix
+++ b/templates/ci/modules/features/pipe-policy.nix
@@ -731,5 +731,351 @@
         expected = "443";
       }
     );
+
+    # pipe.as renames pipe output to a different quirk name.
+    test-pipe-as-basic = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.source = {
+          description = "Source pipe";
+        };
+        den.quirks.target = {
+          description = "Target pipe (no native emitters)";
+        };
+
+        den.aspects.igloo = {
+          includes = [
+            den.aspects.producer
+            den.aspects.consumer
+          ];
+        };
+
+        den.aspects.producer = {
+          source = [
+            { name = "a"; }
+            { name = "b"; }
+          ];
+        };
+
+        den.aspects.consumer = {
+          nixos =
+            { target, ... }:
+            {
+              networking.hostName = lib.concatMapStringsSep "-" (i: i.name) target;
+            };
+        };
+
+        den.policies.rename-pipe =
+          { host, ... }:
+          let
+            inherit (den.lib.policy) pipe;
+          in
+          [
+            (pipe.from "source" [
+              (pipe.as "target")
+            ])
+          ];
+
+        den.default.includes = [ den.policies.rename-pipe ];
+
+        expr = igloo.networking.hostName;
+        expected = "a-b";
+      }
+    );
+
+    # pipe.as with transform: data reshaped before renaming.
+    test-pipe-as-with-transform = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.raw-ports = {
+          description = "Raw port data";
+        };
+        den.quirks.firewall-rules = {
+          description = "Derived firewall rules";
+        };
+
+        den.aspects.igloo = {
+          includes = [
+            den.aspects.producer
+            den.aspects.consumer
+          ];
+        };
+
+        den.aspects.producer = {
+          raw-ports = [
+            {
+              port = 80;
+              proto = "tcp";
+            }
+            {
+              port = 443;
+              proto = "tcp";
+            }
+          ];
+        };
+
+        den.aspects.consumer = {
+          nixos =
+            { firewall-rules, ... }:
+            {
+              networking.domain = lib.concatStringsSep "-" firewall-rules;
+            };
+        };
+
+        den.policies.derive-rules =
+          { host, ... }:
+          let
+            inherit (den.lib.policy) pipe;
+          in
+          [
+            (pipe.from "raw-ports" [
+              (pipe.transform (p: "${p.proto}:${toString p.port}"))
+              (pipe.as "firewall-rules")
+            ])
+          ];
+
+        den.default.includes = [ den.policies.derive-rules ];
+
+        expr = igloo.networking.domain;
+        expected = "tcp:80-tcp:443";
+      }
+    );
+
+    # pipe.as + pipe.collect: cross-host collection delivered under target name.
+    test-pipe-as-with-collect = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.iceberg.users.alice = { };
+
+        den.quirks.http-addrs = {
+          description = "HTTP addresses";
+        };
+        den.quirks.peer-urls = {
+          description = "Derived peer URLs (no native emitters)";
+        };
+
+        den.policies.collect-as-urls =
+          { host, ... }:
+          let
+            inherit (den.lib.policy) pipe;
+          in
+          [
+            (pipe.from "http-addrs" [
+              (pipe.collect ({ host, ... }: true))
+              (pipe.transform (a: "http://${a.addr}:${toString a.port}"))
+              (pipe.as "peer-urls")
+            ])
+          ];
+
+        den.schema.host.includes = [ den.policies.collect-as-urls ];
+
+        den.aspects.iceberg = {
+          http-addrs = {
+            addr = "10.0.0.2";
+            port = 80;
+          };
+        };
+
+        den.aspects.igloo = {
+          includes = [ den.aspects.url-consumer ];
+          http-addrs = {
+            addr = "10.0.0.1";
+            port = 80;
+          };
+        };
+
+        den.aspects.url-consumer = {
+          nixos =
+            { peer-urls, lib, ... }:
+            {
+              networking.hostName = toString (builtins.length peer-urls);
+              networking.domain = lib.concatStringsSep "," (lib.sort (a: b: a < b) peer-urls);
+            };
+        };
+
+        expr = {
+          count = igloo.networking.hostName;
+          urls = igloo.networking.domain;
+        };
+        expected = {
+          count = "2";
+          urls = "http://10.0.0.1:80,http://10.0.0.2:80";
+        };
+      }
+    );
+
+    # pipe.as + pipe.to: aspect-targeted delivery under renamed pipe.
+    test-pipe-as-with-to = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.raw-data = {
+          description = "Raw data";
+        };
+        den.quirks.derived-data = {
+          description = "Derived data (no native emitters)";
+        };
+
+        den.aspects.igloo = {
+          includes = [
+            den.aspects.producer
+            den.aspects.targeted-consumer
+            den.aspects.normal-consumer
+          ];
+        };
+
+        den.aspects.producer = {
+          raw-data = [
+            "x"
+            "y"
+          ];
+        };
+
+        # This aspect gets derived-data via pipe.as + pipe.to.
+        den.aspects.targeted-consumer = {
+          nixos =
+            { derived-data, ... }:
+            {
+              networking.hostName = lib.concatStringsSep "-" derived-data;
+            };
+        };
+
+        # This aspect reads raw-data normally (unaffected by pipe.as).
+        den.aspects.normal-consumer = {
+          nixos =
+            { raw-data, ... }:
+            {
+              networking.domain = lib.concatStringsSep "-" raw-data;
+            };
+        };
+
+        den.policies.as-and-to =
+          { host, ... }:
+          let
+            inherit (den.lib.policy) pipe;
+          in
+          [
+            (pipe.from "raw-data" [
+              (pipe.transform (v: "d-${v}"))
+              (pipe.as "derived-data")
+              (pipe.to [ den.aspects.targeted-consumer ])
+            ])
+          ];
+
+        den.default.includes = [ den.policies.as-and-to ];
+
+        expr = {
+          targeted = igloo.networking.hostName;
+          normal = igloo.networking.domain;
+        };
+        expected = {
+          # targeted-consumer gets derived-data via pipe.as + pipe.to
+          targeted = "d-x-d-y";
+          # normal-consumer gets raw-data unmodified
+          normal = "x-y";
+        };
+      }
+    );
+
+    # No-emitter quirk: entirely populated by pipe.as from another pipe.
+    test-pipe-as-no-emitter-quirk = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.backends = {
+          description = "Backend addresses";
+        };
+        den.quirks.monitoring-targets = {
+          description = "Monitoring targets (no native emitters)";
+        };
+
+        den.aspects.igloo = {
+          includes = [
+            den.aspects.web
+            den.aspects.monitor
+          ];
+        };
+
+        # web emits backends, never mentions monitoring-targets.
+        den.aspects.web = {
+          backends = [
+            {
+              addr = "10.0.0.1";
+              port = 80;
+            }
+            {
+              addr = "10.0.0.2";
+              port = 443;
+            }
+          ];
+        };
+
+        # monitor consumes monitoring-targets — which has no native emitters.
+        den.aspects.monitor = {
+          nixos =
+            { monitoring-targets, lib, ... }:
+            {
+              networking.domain = lib.concatStringsSep "," (lib.sort (a: b: a < b) monitoring-targets);
+            };
+        };
+
+        # Policy derives monitoring-targets from backends via pipe.as.
+        den.policies.backends-to-monitoring =
+          { host, ... }:
+          let
+            inherit (den.lib.policy) pipe;
+          in
+          [
+            (pipe.from "backends" [
+              (pipe.transform (b: "${b.addr}:${toString b.port}"))
+              (pipe.as "monitoring-targets")
+            ])
+          ];
+
+        den.default.includes = [ den.policies.backends-to-monitoring ];
+
+        expr = igloo.networking.domain;
+        expected = "10.0.0.1:80,10.0.0.2:443";
+      }
+    );
+
+    # pipe.as targeting own pipe throws an error.
+    test-pipe-as-self-error = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.quirks.items = {
+          description = "Items";
+        };
+
+        den.aspects.igloo = {
+          items = [ "a" ];
+          nixos =
+            { items, ... }:
+            {
+              networking.hostName = lib.concatStringsSep "-" items;
+            };
+        };
+
+        den.policies.self-as =
+          { host, ... }:
+          let
+            inherit (den.lib.policy) pipe;
+          in
+          [
+            (pipe.from "items" [
+              (pipe.as "items")
+            ])
+          ];
+
+        den.default.includes = [ den.policies.self-as ];
+
+        expr = !(builtins.tryEval (builtins.seq igloo.networking.hostName null)).success;
+        expected = true;
+      }
+    );
   };
 }


### PR DESCRIPTION
## Summary

- Adds `pipe.as` stage that renames pipe output so data from one quirk can be delivered under a different quirk name
- Enables derived quirks — quirks with no native emitters, populated entirely via collect + transform + rename from other pipes
- Composes with all existing stages (`pipe.collect`, `pipe.transform`, `pipe.filter`, `pipe.to`)
- Self-targeting (`pipe.as "same-pipe"`) throws a clear error

## Changes

- `nix/lib/policy-effects.nix`: `pipe.as` stage constructor
- `nix/lib/aspects/fx/assemble-pipes.nix`: Assembly logic for untargeted and targeted `pipe.as` routing, `mkCombinedBase` helper extraction
- `templates/ci/modules/features/pipe-policy.nix`: 6 new tests (basic, transform, collect, pipe.to, no-emitter quirk, self-error)
- `docs/`: Updated explanation, guide, and reference docs for `pipe.as`

## Test plan

- [x] 767/767 CI tests pass
- [x] 6 new pipe-policy tests cover all `pipe.as` combinations
- [x] Existing pipe tests unaffected (no regressions)