### PR TITLE
fix: parametric functions at direct freeform children leak through providerType.merge

### DIFF
--- a/nix/lib/aspects/fx/aspect/normalize.nix
+++ b/nix/lib/aspects/fx/aspect/normalize.nix
@@ -65,6 +65,34 @@ let
         wrapFunctorChild child
       else
         wrapBareFn child
+    # Content wrapper from aspectContentType (has __contentValues but no name
+    # yet).  Inject identity from __provider and extract parametric functions
+    # into includes so the pipeline resolves them.  listOf doesn't call
+    # providerType.merge per-element, so inner wrappers in includes lists
+    # arrive here unprocessed.
+    else if builtins.isAttrs child && child ? __contentValues && !(child ? name) then
+      let
+        prov = child.__provider or [ ];
+        provName = if prov != [ ] then lib.last prov else null;
+        fns = builtins.filter (
+          d:
+          lib.isFunction d.value
+          && (
+            let
+              args = builtins.functionArgs d.value;
+            in
+            args != { } && !(args ? config) && !(args ? options)
+          )
+        ) child.__contentValues;
+      in
+      child
+      // lib.optionalAttrs (provName != null) {
+        name = provName;
+        meta.provider = lib.init prov;
+      }
+      // lib.optionalAttrs (fns != [ ]) {
+        includes = (child.includes or [ ]) ++ map (d: d.value) fns;
+      }
     else
       child;
 in

--- a/nix/lib/aspects/fx/key-classification.nix
+++ b/nix/lib/aspects/fx/key-classification.nix
@@ -23,6 +23,8 @@ let
     "__ctxId"
     "__entityKind"
     "__parametricResolvedArgs"
+    "__contentValues"
+    "__provider"
     "_module"
     "_"
   ] (_: true);

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -204,6 +204,12 @@ let
           # through aspectSubmodule and the function is buried as a freeform
           # key.  Extract the function so existing dispatch handles it.
           isContentWrapper = d: builtins.isAttrs d.value && d.value ? __contentValues && !(d.value ? __fn);
+          nameFromProvider =
+            v:
+            let
+              prov = v.__provider or [ ];
+            in
+            if prov != [ ] then lib.last prov else null;
           unwrapContent =
             d:
             let
@@ -217,8 +223,23 @@ let
                   args != { } && !(args ? config) && !(args ? options)
                 )
               ) d.value.__contentValues;
+              provName = nameFromProvider d.value;
             in
-            if builtins.length fns == 1 then d // { value = (builtins.head fns).value; } else d;
+            if builtins.length fns == 1 then
+              d // { value = (builtins.head fns).value; }
+            else if provName != null then
+              # Preserve identity: inject name and provider chain from
+              # __provider so aspectSubmodule.merge produces a meaningful
+              # identity instead of an anonymous include index.
+              d
+              // {
+                value = d.value // {
+                  name = provName;
+                  meta.provider = lib.init d.value.__provider;
+                };
+              }
+            else
+              d;
           defs' = map (d: if isContentWrapper d then unwrapContent d else d) defs;
           listDefs = builtins.filter (d: builtins.isList d.value) defs';
           policyDefs = builtins.filter (d: builtins.isAttrs d.value && d.value.__isPolicy or false) defs';
@@ -395,7 +416,14 @@ let
     lib.types.submodule (
       { name, config, ... }:
       {
-        freeformType = lib.types.lazyAttrsOf (aspectKeyType typeCfg);
+        freeformType = lib.types.lazyAttrsOf (
+          aspectKeyType (
+            typeCfg
+            // {
+              providerPrefix = (typeCfg.providerPrefix or [ ]) ++ [ config.name ];
+            }
+          )
+        );
         imports = [
           (lib.mkAliasOptionModule [ "_" ] [ "provides" ])
           (den.schema.aspect or { })

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -199,8 +199,29 @@ let
       merge =
         loc: defs:
         let
-          listDefs = builtins.filter (d: builtins.isList d.value) defs;
-          policyDefs = builtins.filter (d: builtins.isAttrs d.value && d.value.__isPolicy or false) defs;
+          # Normalize __contentValues wrappers (from aspectContentType) that
+          # contain parametric functions.  Without this, the wrapper merges
+          # through aspectSubmodule and the function is buried as a freeform
+          # key.  Extract the function so existing dispatch handles it.
+          isContentWrapper = d: builtins.isAttrs d.value && d.value ? __contentValues && !(d.value ? __fn);
+          unwrapContent =
+            d:
+            let
+              fns = builtins.filter (
+                cv:
+                lib.isFunction cv.value
+                && (
+                  let
+                    args = builtins.functionArgs cv.value;
+                  in
+                  args != { } && !(args ? config) && !(args ? options)
+                )
+              ) d.value.__contentValues;
+            in
+            if builtins.length fns == 1 then d // { value = (builtins.head fns).value; } else d;
+          defs' = map (d: if isContentWrapper d then unwrapContent d else d) defs;
+          listDefs = builtins.filter (d: builtins.isList d.value) defs';
+          policyDefs = builtins.filter (d: builtins.isAttrs d.value && d.value.__isPolicy or false) defs';
         in
         # Policy list (from policy.when/policy.for with list input) — pass through as-is.
         if listDefs != [ ] then
@@ -212,11 +233,11 @@ let
           p // { name = p.name or (lib.last loc); }
         else
           let
-            parametrics = builtins.filter (d: isParametricWrapper d.value) defs;
+            parametrics = builtins.filter (d: isParametricWrapper d.value) defs';
           in
           if parametrics != [ ] then
             let
-              nonParametrics = builtins.filter (d: !isParametricWrapper d.value) defs;
+              nonParametrics = builtins.filter (d: !isParametricWrapper d.value) defs';
             in
             # Single wrapper with no other defs: return wrapper directly.
             # Avoid baseType.merge here — it triggers a full aspectSubmodule evaluation
@@ -245,7 +266,7 @@ let
               )
           else
             let
-              nonParametrics = builtins.filter (d: !isParametricWrapper d.value) defs;
+              nonParametrics = builtins.filter (d: !isParametricWrapper d.value) defs';
               # Error on conflicting __functor defs (callable aspect factories).
               # Two factories at the same path is ambiguous — can't be mechanically composed.
               explicitFunctors = builtins.filter (

--- a/templates/ci/modules/features/angle-brackets.nix
+++ b/templates/ci/modules/features/angle-brackets.nix
@@ -95,6 +95,34 @@
       }
     );
 
+    # Regression: non-parametric direct freeform child must not duplicate content.
+    # Without __contentValues in structuralKeysSet, the content wrapper's
+    # __contentValues key is classified as class content and emitted alongside
+    # the forwarded nixos attr — applying overlays/config twice.
+    test-direct-child-no-duplication = denTest (
+      {
+        den,
+        __findFile,
+        ns,
+        igloo,
+        ...
+      }:
+      {
+        _module.args.__findFile = den.lib.__findFile;
+
+        imports = [ (inputs.den.namespace "ns" false) ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        ns.overlays.openrazer.nixos.networking.hostName = "overlay-host";
+
+        den.aspects.igloo.includes = [ <ns/overlays/openrazer> ];
+
+        expr = igloo.networking.hostName;
+        expected = "overlay-host";
+      }
+    );
+
     # Regression: parametric function as direct freeform child of a namespace
     # aspect must resolve via angle-brackets identically to provides path.
     test-namespace-parametric-direct-child = denTest (

--- a/templates/ci/modules/features/angle-brackets.nix
+++ b/templates/ci/modules/features/angle-brackets.nix
@@ -95,6 +95,98 @@
       }
     );
 
+    # Regression: parametric function as direct freeform child of a namespace
+    # aspect must resolve via angle-brackets identically to provides path.
+    test-namespace-parametric-direct-child = denTest (
+      {
+        den,
+        __findFile,
+        ns,
+        igloo,
+        ...
+      }:
+      {
+        _module.args.__findFile = den.lib.__findFile;
+
+        imports = [ (inputs.den.namespace "ns" false) ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        ns.apps.helix =
+          { host, ... }:
+          {
+            nixos.networking.hostName = "${host.name}-helix";
+          };
+
+        den.aspects.igloo.includes = [ <ns/apps/helix> ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo-helix";
+      }
+    );
+
+    # homeManager class via direct parametric freeform child + intermediate aspect
+    # included at user scope (matching the real pattern: user aspect → everywhere → helix).
+    test-namespace-parametric-hm-via-user-aspect = denTest (
+      {
+        den,
+        __findFile,
+        ns,
+        tuxHm,
+        ...
+      }:
+      {
+        _module.args.__findFile = den.lib.__findFile;
+
+        imports = [ (inputs.den.namespace "ns" false) ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        ns.apps.helix =
+          { host, ... }:
+          {
+            homeManager = _: {
+              programs.helix.enable = true;
+            };
+          };
+
+        ns.everywhere.includes = [ <ns/apps/helix> ];
+        den.aspects.tux.includes = [ ns.everywhere ];
+
+        expr = tuxHm.programs.helix.enable;
+        expected = true;
+      }
+    );
+
+    # Same as above but with provides path (should already work).
+    test-namespace-parametric-provides-child = denTest (
+      {
+        den,
+        __findFile,
+        ns,
+        igloo,
+        ...
+      }:
+      {
+        _module.args.__findFile = den.lib.__findFile;
+
+        imports = [ (inputs.den.namespace "ns" false) ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        ns.apps.provides.helix =
+          { host, ... }:
+          {
+            nixos.networking.hostName = "${host.name}-helix";
+          };
+
+        den.aspects.igloo.includes = [ <ns/apps/helix> ];
+
+        expr = igloo.networking.hostName;
+        expected = "igloo-helix";
+      }
+    );
+
   };
 
 }


### PR DESCRIPTION
## Summary

- Fixes parametric functions (`{ host, user }: { ... }`) placed as direct freeform children of namespace aspects (e.g. `ns.apps.helix` instead of `ns.apps.provides.helix`) being silently dropped during pipeline resolution
- The `__contentValues` wrapper from `aspectContentType` was promoted to a full aspect by `listOf (providerType ...)` element-level merge, burying the parametric function as a freeform key unreachable by bind/compile-parametric
- Normalizes `__contentValues` wrappers in `providerType.merge` before dispatch: extracts single parametric functions (non-empty args, no `config`/`options`) so existing merge dispatch creates proper `__fn/__args` wrappers

## Test plan

- [x] `test-namespace-parametric-direct-child` — nixos class via direct freeform child + angle brackets
- [x] `test-namespace-parametric-hm-via-user-aspect` — homeManager class via intermediate aspect at user scope (matches real dotfiles pattern)
- [x] `test-namespace-parametric-provides-child` — provides fallback path (was already working, verifies no regression)
- [x] Full CI suite: 770/770 passing
- [x] Verified against real config: `nixosConfigurations.evo-x2.config.home-manager.users.loom.programs.helix.enable` → `true`