### PR TITLE
fix: forward provides children onto aspect root

### DIFF
--- a/nix/lib/aspects/fx/key-classification.nix
+++ b/nix/lib/aspects/fx/key-classification.nix
@@ -25,6 +25,7 @@ let
     "__parametricResolvedArgs"
     "__contentValues"
     "__provider"
+    "__providesForwarded"
     "_module"
     "_"
   ] (_: true);
@@ -68,7 +69,10 @@ let
   classifyKeys =
     targetClass: aspect:
     let
-      allKeys = builtins.filter (k: !(structuralKeysSet ? ${k})) (builtins.attrNames aspect);
+      forwardedSet = lib.genAttrs (aspect.__providesForwarded or [ ]) (_: true);
+      allKeys = builtins.filter (k: !(structuralKeysSet ? ${k}) && !(forwardedSet ? ${k})) (
+        builtins.attrNames aspect
+      );
     in
     if classRegistry == { } && pipeRegistry == { } then
       {

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -88,12 +88,19 @@ let
           }
         ]
       );
+      # Forward provides children onto the merged aspect so
+      # aspect.docker resolves to aspect.provides.docker.
+      # provides-first so direct freeform keys on merged take priority.
+      # __providesForwarded tells the pipeline to skip these during classification.
+      providesChildren = builtins.removeAttrs (merged.provides or { }) [ "_module" ];
     in
     # __functor makes merged aspects callable (aspect { host = ...; }).
     # Explicit functors (e.g. den.batteries.forward) take priority.
-    merged
+    providesChildren
+    // merged
     // {
       __functor = if originalFunctor != null then originalFunctor else resolveAspectWith;
+      __providesForwarded = builtins.attrNames providesChildren;
     };
 
   aspectMeta =


### PR DESCRIPTION
## Summary

- Forward `provides` children onto the merged aspect root in `mergeWithAspectMeta`, so `aspect.docker` resolves to `aspect.provides.docker` without requiring the `_.docker` accessor
- Tag forwarded keys via `__providesForwarded` so the pipeline's key classification skips them — prevents double-processing alongside includes
- Add `__providesForwarded` to `structuralKeysSet`

Fixes regression from #504 which removed `_.docker` usage but did not implement the forwarding, breaking `den.aspects.virtualization.docker` access in diagram-demo template.

## Test plan

- [x] 771/771 CI tests pass
- [x] diagram-demo template evaluates (148 checks)
- [x] den-configs helix.enable = true
- [x] `aspect-path.test-excludeAspect-by-provider` passes (validates forwarded keys don't affect pipeline classification)