### PR TITLE
fix: stable identity for bracket-resolved bare attrsets

### DIFF
--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -210,7 +210,11 @@ let
           # contain parametric functions.  Without this, the wrapper merges
           # through aspectSubmodule and the function is buried as a freeform
           # key.  Extract the function so existing dispatch handles it.
-          isContentWrapper = d: builtins.isAttrs d.value && d.value ? __contentValues && !(d.value ? __fn);
+          isContentWrapper =
+            d:
+            builtins.isAttrs d.value
+            && (d.value ? __contentValues || d.value ? __provider)
+            && !(d.value ? __fn);
           nameFromProvider =
             v:
             let
@@ -220,16 +224,20 @@ let
           unwrapContent =
             d:
             let
-              fns = builtins.filter (
-                cv:
-                lib.isFunction cv.value
-                && (
-                  let
-                    args = builtins.functionArgs cv.value;
-                  in
-                  args != { } && !(args ? config) && !(args ? options)
-                )
-              ) d.value.__contentValues;
+              fns =
+                if d.value ? __contentValues then
+                  builtins.filter (
+                    cv:
+                    lib.isFunction cv.value
+                    && (
+                      let
+                        args = builtins.functionArgs cv.value;
+                      in
+                      args != { } && !(args ? config) && !(args ? options)
+                    )
+                  ) d.value.__contentValues
+                else
+                  [ ];
               provName = nameFromProvider d.value;
             in
             if builtins.length fns == 1 then

--- a/nix/lib/den-brackets.nix
+++ b/nix/lib/den-brackets.nix
@@ -26,6 +26,17 @@ let
     in
     if tail == [ ] then resolved else resolveWithProvidesFallback resolved tail;
 
+  # Ensure bare attrset results from bracket resolution carry __provider
+  # so the pipeline can compute stable identity.  Forwarded attrs from
+  # content wrappers are bare attrsets that lack __provider — without
+  # this, they get anonymous identities and dedup fails.
+  tagProvider =
+    path: result:
+    if builtins.isAttrs result && !(result ? __provider) && !(result ? __fn) then
+      result // { __provider = path; }
+    else
+      result;
+
   findAspect =
     path:
     let
@@ -44,14 +55,14 @@ let
           provider = config.den.batteries.${firstTail};
           rest = lib.tail tail;
         in
-        if rest == [ ] then provider else resolveWithProvidesFallback provider rest
+        if rest == [ ] then provider else tagProvider path (resolveWithProvidesFallback provider rest)
       else
         lib.getAttrFromPath ([ "den" ] ++ tail) config
     else if builtins.hasAttr head config.den.aspects then
       let
         aspect = config.den.aspects.${head};
       in
-      if tail == [ ] then aspect else resolveWithProvidesFallback aspect tail
+      if tail == [ ] then aspect else tagProvider path (resolveWithProvidesFallback aspect tail)
     else if lib.hasAttrByPath [ "ful" head ] config.den then
       let
         ns = config.den.ful.${head};
@@ -70,7 +81,7 @@ let
         else if rest == [ ] then
           nsAspect
         else
-          resolveWithProvidesFallback nsAspect rest
+          tagProvider path (resolveWithProvidesFallback nsAspect rest)
     else
       throw "Aspect not found: ${lib.concatStringsSep "." path}";
 in


### PR DESCRIPTION
## Summary

Bracket resolution through forwarded attrs on content wrappers (e.g. `<gloom/apps/polybar/razermon>`) produces bare attrsets without `__contentValues` or `__provider`. Without identity, these get anonymous names and dedup fails when the same content is reached via multiple resolution paths.

- **den-brackets.nix**: `tagProvider` injects `__provider` from the full bracket path onto bare attrset results
- **types.nix**: `providerType.merge` normalization detects `__provider` (not just `__contentValues`) and injects `name` + `meta.provider` for stable identity

Fixes module duplication where entries appeared twice — once from the direct include path and once from host-aspects re-resolution with anonymous identity.

## Test plan

- [x] 771/771 CI tests pass
- [x] den-configs polybar `modules-right` shows each module exactly once
- [x] diagram-demo template evaluates (148 checks)