### PR TITLE
docs: fix some provides → batteries issues

### DIFF
--- a/docs/src/content/docs/reference/aspects.mdx
+++ b/docs/src/content/docs/reference/aspects.mdx
@@ -91,7 +91,7 @@ Deeply nested providers accumulate: `foo.bar.baz` has
 The `meta.provider` list can be used to distinguish aspects by origin
 during pipeline resolution.
 
-## `den.batteries` (aliased as `den.batteries`)
+## `den.batteries` (compat: aliased as `den.provides`)
 
 This is the place for Den built-in batteries, reusable aspects that serve
 as basic utilities and examples.


### PR DESCRIPTION
I did another scan against `batteries` usages, and didn't find any other stragglers.