### PR TITLE
fix: guard home.class access in battery homeAspect functions

### DIFF
--- a/modules/aspects/batteries/flake-parts/inputs.nix
+++ b/modules/aspects/batteries/flake-parts/inputs.nix
@@ -1,4 +1,4 @@
-{ withSystem, ... }:
+{ lib, withSystem, ... }:
 let
   description = ''
     Provides the `flake-parts` `inputs'` (the flake's `inputs` with system pre-selected)
@@ -56,7 +56,7 @@ let
     {
       name = "inputs'/home";
     }
-    // mkAspect home.class home.system;
+    // lib.optionalAttrs (home ? class) (mkAspect home.class home.system);
 
 in
 {

--- a/modules/aspects/batteries/flake-parts/self.nix
+++ b/modules/aspects/batteries/flake-parts/self.nix
@@ -1,4 +1,4 @@
-{ withSystem, ... }:
+{ lib, withSystem, ... }:
 let
   description = ''
     Provides the `flake-parts` `self'` (the flake's `self` with system pre-selected)
@@ -56,7 +56,7 @@ let
     {
       name = "self'/home";
     }
-    // mkAspect home.class home.system;
+    // lib.optionalAttrs (home ? class) (mkAspect home.class home.system);
 in
 {
   den.batteries.self' = {

--- a/modules/aspects/batteries/insecure/insecure-predicate-builder.nix
+++ b/modules/aspects/batteries/insecure/insecure-predicate-builder.nix
@@ -47,6 +47,8 @@ let
     { home }:
     {
       name = "insecure-predicate/home";
+    }
+    // lib.optionalAttrs (home ? class) {
       ${home.class}.imports = [ insecureModule ];
     };
 

--- a/modules/aspects/batteries/unfree/unfree-predicate-builder.nix
+++ b/modules/aspects/batteries/unfree/unfree-predicate-builder.nix
@@ -47,6 +47,8 @@ let
     { home }:
     {
       name = "unfree-predicate/home";
+    }
+    // lib.optionalAttrs (home ? class) {
       ${home.class}.imports = [ unfreeModule ];
     };
 


### PR DESCRIPTION
## Summary

- Guard `home.class` access in all battery `homeAspect` functions with conditional checks
- Prevents crash when `home` entity lacks a `class` attribute (e.g. no `den.homes` defined)
- Affects: unfree-predicate-builder, insecure-predicate-builder, flake-parts/self, flake-parts/inputs

## Test plan

- [x] 771/771 CI tests pass
- [x] unfree and standalone-homes suites pass