### PR TITLE
fix: import-tree class resolution and _ alias on batteries

### DIFF
--- a/modules/aspects/batteries/import-tree.nix
+++ b/modules/aspects/batteries/import-tree.nix
@@ -1,5 +1,6 @@
 {
   inputs,
+  lib,
   den,
   ...
 }:
@@ -59,23 +60,29 @@
       you are also free to create your own auto-imports layout following the implementation of these.
   '';
 
-  den.batteries.import-tree.__functor = _: root: {
-    name = "import-tree(${baseNameOf (toString root)})";
-    meta.provider = [
-      "den"
-      "provides"
-    ];
-    __fn =
-      { class, ... }:
-      let
-        path = "${toString root}/_${class}";
-        aspect.${class}.imports = [ (inputs.import-tree path) ];
-      in
-      if builtins.pathExists path then aspect else { };
-    __args = {
-      class = true;
-    };
-  };
+  den.batteries.import-tree.__functor =
+    _: root:
+    let
+      # Scan for _<class> directories under root and emit per-class imports.
+      # This avoids depending on the scope's `class` argument, which the
+      # fx-pipeline only provides once per scope (not once per class).
+      rootStr = toString root;
+      exists = builtins.pathExists rootStr;
+      entries = if exists then builtins.readDir rootStr else { };
+      classEntries = lib.filterAttrs (name: type: type == "directory" && lib.hasPrefix "_" name) entries;
+      aspect = lib.mapAttrs' (dirName: _: {
+        name = lib.removePrefix "_" dirName;
+        value.imports = [ (inputs.import-tree "${rootStr}/${dirName}") ];
+      }) classEntries;
+    in
+    {
+      name = "import-tree(${baseNameOf rootStr})";
+      meta.provider = [
+        "den"
+        "batteries"
+      ];
+    }
+    // aspect;
 
   den.batteries.import-tree.provides = {
     host = root: { host, ... }: den.batteries.import-tree "${toString root}/${host.name}";

--- a/modules/aspects/batteries/import-tree.nix
+++ b/modules/aspects/batteries/import-tree.nix
@@ -67,8 +67,7 @@
       # This avoids depending on the scope's `class` argument, which the
       # fx-pipeline only provides once per scope (not once per class).
       rootStr = toString root;
-      exists = builtins.pathExists rootStr;
-      entries = if exists then builtins.readDir rootStr else { };
+      entries = lib.optionalAttrs (builtins.pathExists rootStr) (builtins.readDir rootStr);
       classEntries = lib.filterAttrs (name: type: type == "directory" && lib.hasPrefix "_" name) entries;
       aspect = lib.mapAttrs' (dirName: _: {
         name = lib.removePrefix "_" dirName;

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -154,7 +154,13 @@ let
         fn = (builtins.head paramFns).value;
       in
       if builtins.isAttrs fn then
-        fn
+        # Attrset with __functor (e.g. batteries like import-tree, forward).
+        # Forward provides children and add _ alias so aspect._.child and
+        # aspect.child both work, matching mergeWithAspectMeta behavior.
+        let
+          providesChildren = builtins.removeAttrs (fn.provides or { }) [ "_module" ];
+        in
+        providesChildren // fn // { _ = fn.provides or { }; }
       else
         let
           args = lib.functionArgs fn;


### PR DESCRIPTION
## Summary

- import-tree battery now scans `_<class>` directories eagerly via `builtins.readDir` instead of relying on the `class` scope parameter, which the fx-pipeline only provides once per scope (not once per class)
- Batteries with `__functor` (import-tree, forward, etc.) now forward `provides` children and the `_` alias in the `mergeFunctions` single-def fast path, matching `mergeWithAspectMeta` behavior

## Test plan

- [x] 771/771 CI tests pass
- [x] andrewix config evaluates correctly — `fileSystems."/"` and `"/boot"` populated on andrew-laptop/andrew-pc
- [x] WSL hosts correctly have empty fileSystems (no `_nixos` dir)
- [x] `import-tree.test-no-import-for-missing-dir` passes (pathExists guard)
- [x] `den._.import-tree._.host` resolves correctly (no `attribute '_' missing`)