### PR TITLE
fix: silence recurring 'drupol' error

### DIFF
--- a/modules/aspects/batteries/insecure/insecure.nix
+++ b/modules/aspects/batteries/insecure/insecure.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 let
   description = ''
     A class generic aspect that enables insecure packages by name and version.
@@ -29,23 +30,17 @@ let
           "darwin"
           "homeManager"
         ];
-        classModule =
-          if builtins.elem class validClasses then
-            { ${class}.permittedInsecurePackages.packages = allowed-names; }
-          else
-            { };
+        classModule = lib.optionalAttrs (builtins.elem class validClasses) {
+          ${class}.permittedInsecurePackages.packages = allowed-names;
+        };
         # When resolving for homeManager or a non-module-system class (e.g.
         # "user"), also emit to the host's OS class so
         # nixpkgs.config.permittedInsecurePackages covers these packages.
-        hostModule =
-          if
-            (class == "homeManager" || !builtins.elem class validClasses)
-            && host != null
-            && builtins.elem host.class validClasses
-          then
-            { ${host.class}.permittedInsecurePackages.packages = allowed-names; }
-          else
-            { };
+        hostModule = lib.optionalAttrs (
+          (class == "homeManager" || !builtins.elem class validClasses)
+          && host != null
+          && builtins.elem host.class validClasses
+        ) { ${host.class}.permittedInsecurePackages.packages = allowed-names; };
       in
       classModule // hostModule;
     __args = {

--- a/modules/aspects/batteries/unfree/unfree.nix
+++ b/modules/aspects/batteries/unfree/unfree.nix
@@ -1,3 +1,4 @@
+{ lib, ... }:
 let
   description = ''
     A class generic aspect that enables unfree packages by name.
@@ -29,22 +30,19 @@ let
           "darwin"
           "homeManager"
         ];
-        classModule =
-          if builtins.elem class validClasses then { ${class}.unfree.packages = allowed-names; } else { };
+        classModule = lib.optionalAttrs (builtins.elem class validClasses) {
+          ${class}.unfree.packages = allowed-names;
+        };
         # When resolving for homeManager or a non-module-system class (e.g.
         # "user"), also emit to the host's OS class.  This ensures
         # nixpkgs.config.allowUnfreePredicate covers these packages:
         #   - homeManager + useGlobalPkgs = true → OS-level predicate needed
         #   - "user" class (no HM) → only the host's OS config exists
-        hostModule =
-          if
-            (class == "homeManager" || !builtins.elem class validClasses)
-            && host != null
-            && builtins.elem host.class validClasses
-          then
-            { ${host.class}.unfree.packages = allowed-names; }
-          else
-            { };
+        hostModule = lib.optionalAttrs (
+          (class == "homeManager" || !builtins.elem class validClasses)
+          && host != null
+          && builtins.elem host.class validClasses
+        ) { ${host.class}.unfree.packages = allowed-names; };
       in
       classModule // hostModule;
     __args = {

--- a/modules/aspects/batteries/wsl.nix
+++ b/modules/aspects/batteries/wsl.nix
@@ -58,13 +58,10 @@ in
       host,
       ...
     }:
-    if host.class == "nixos" && (host.wsl or { }).enable or false then
-      [
-        (den.lib.policy.resolve.to "wsl-host" { inherit host; })
-        (den.lib.policy.include wsl-host-aspect)
-      ]
-    else
-      [ ];
+    lib.optionals (host.class == "nixos" && (host.wsl or { }).enable or false) [
+      (den.lib.policy.resolve.to "wsl-host" { inherit host; })
+      (den.lib.policy.include wsl-host-aspect)
+    ];
 
   den.schema.host.includes = [ den.policies.host-to-wsl-host ];
 

--- a/nix/lib/aspects/fx/handlers/bind.nix
+++ b/nix/lib/aspects/fx/handlers/bind.nix
@@ -2,6 +2,7 @@
 # Probes scope handlers for required args, calls compileFn or defers.
 {
   den,
+  lib,
   ...
 }:
 let
@@ -30,7 +31,7 @@ in
               ctxs = (state.scopeContexts or (_: { })) null;
               entityCls = ((state.scopeEntityClass or (_: { })) null).${currentScope} or null;
             in
-            (ctxs.${currentScope} or { }) // (if entityCls != null then { class = entityCls; } else { })
+            (ctxs.${currentScope} or { }) // lib.optionalAttrs (entityCls != null) { class = entityCls; }
           else
             { };
         keysAfterStateFallback = builtins.filter (k: !(scopeCtx ? ${k})) keysToProbe;

--- a/nix/lib/aspects/fx/resolve.nix
+++ b/nix/lib/aspects/fx/resolve.nix
@@ -342,10 +342,8 @@ let
             modules =
               if preWalkedModules != null then
                 preWalkedModules
-              else if spec ? mainModule then
-                [ spec.mainModule ]
               else
-                [ ];
+                lib.optional (spec ? mainModule) spec.mainModule;
             instantiateArgs =
               if spec ? pkgs then
                 {
@@ -479,10 +477,8 @@ let
             modules =
               if preWalkedModules != null then
                 preWalkedModules
-              else if spec ? mainModule then
-                [ spec.mainModule ]
               else
-                [ ];
+                lib.optional (spec ? mainModule) spec.mainModule;
             instantiateArgs =
               if spec ? pkgs then
                 {

--- a/nix/lib/aspects/fx/route/apply.nix
+++ b/nix/lib/aspects/fx/route/apply.nix
@@ -155,23 +155,20 @@ let
       adapterMod = route.adapterModule or null;
       modulesWithAdapter = if adapterMod == null then sourceModules else sourceModules ++ [ adapterMod ];
       ensureEntry =
-        if
-          !isFlakeRoute
-          && route.adaptArgs or null != null
-          && route.path or [ ] != [ ]
-          && modulesWithAdapter == [ ]
-        then
-          [
-            (_: {
-              config = lib.setAttrByPath route.path (_: {
-                imports = [ ];
-              });
-            })
-          ]
-        else
-          [ ];
+        lib.optional
+          (
+            !isFlakeRoute
+            && route.adaptArgs or null != null
+            && route.path or [ ] != [ ]
+            && modulesWithAdapter == [ ]
+          )
+          (_: {
+            config = lib.setAttrByPath route.path (_: {
+              imports = [ ];
+            });
+          });
       isAdapterRoute = route.adapterKey or null != null;
-      adapterWrapped = if !isAdapterRoute then [ ] else [ (mkAdapterFunctor route sourceModules) ];
+      adapterWrapped = lib.optional isAdapterRoute (mkAdapterFunctor route sourceModules);
       # Route with instantiate: collect modules, call instantiate function,
       # place the result (a derivation) at the target path.
       instantiateWrapped =

--- a/nix/lib/aspects/fx/route/wrap.nix
+++ b/nix/lib/aspects/fx/route/wrap.nix
@@ -92,7 +92,7 @@ let
   collectClassMods =
     cls: aspect:
     let
-      own = if aspect ? ${cls} then [ aspect.${cls} ] else [ ];
+      own = lib.optional (aspect ? ${cls}) aspect.${cls};
       nested = builtins.concatMap (collectClassMods cls) (aspect.includes or [ ]);
     in
     own ++ nested;

--- a/nix/lib/diag/filters/fold.nix
+++ b/nix/lib/diag/filters/fold.nix
@@ -128,15 +128,10 @@ in
           let
             pid = parentIdOf n;
           in
-          if pid != null then
-            [
-              {
-                name = n.id;
-                value = pid;
-              }
-            ]
-          else
-            [ ]
+          lib.optional (pid != null) {
+            name = n.id;
+            value = pid;
+          }
         else
           [ ]
       ) graph.nodes;

--- a/nix/lib/diag/filters/reshape.nix
+++ b/nix/lib/diag/filters/reshape.nix
@@ -85,17 +85,12 @@ in
           parentFull = lib.concatStringsSep "/" n.providerPath;
           parent = byFull.${parentFull} or null;
         in
-        if parent != null then
-          [
-            {
-              from = parent.id;
-              to = n.id;
-              style = "normal";
-              label = null;
-            }
-          ]
-        else
-          [ ];
+        lib.optional (parent != null) {
+          from = parent.id;
+          to = n.id;
+          style = "normal";
+          label = null;
+        };
       treeEdges = lib.concatMap edgeFor providerNodes;
       keptIds = lib.listToAttrs (
         map
@@ -146,7 +141,7 @@ in
               pc = n.perClass.${className} or { };
               from = pc.excludedFrom or null;
             in
-            if pc.excluded or false && from != null then [ from ] else [ ]
+            lib.optional (pc.excluded or false && from != null) from
           ) (builtins.attrNames (n.perClass or { }))
         ) filtered.nodes
       );
@@ -209,13 +204,10 @@ in
       # Also include the provider source (via provide-edges pointing to it).
       provideEdgeTargets = lib.concatMap (
         e:
-        if (e.style or "normal") == "provide" then
-          [
-            e.from
-            e.to
-          ]
-        else
-          [ ]
+        lib.optionals ((e.style or "normal") == "provide") [
+          e.from
+          e.to
+        ]
       ) filtered.edges;
 
       keepIds = lib.unique (providerIds ++ lib.concatMap childIdsOf providerIds ++ provideEdgeTargets);

--- a/nix/lib/diag/graph.nix
+++ b/nix/lib/diag/graph.nix
@@ -537,10 +537,9 @@ let
             prov = entry.provider or [ ];
             providerName = if prov != [ ] then builtins.head prov else null;
           in
-          if providerName != null && providerName != "den" && !(topLevelEntryByName ? ${providerName}) then
-            [ providerName ]
-          else
-            [ ]
+          lib.optional (
+            providerName != null && providerName != "den" && !(topLevelEntryByName ? ${providerName})
+          ) providerName
         ) nodes
       );
 

--- a/nix/lib/diag/sequence.nix
+++ b/nix/lib/diag/sequence.nix
@@ -140,11 +140,8 @@ let
           staticLabels = map (n: n.label) static;
           staticNote = wrapLabels staticLabels;
         in
-        (
-          if parametricLines != [ ] then
-            [ "    activate ${alias}" ] ++ parametricLines ++ [ "    deactivate ${alias}" ]
-          else
-            [ ]
+        lib.optionals (parametricLines != [ ]) (
+          [ "    activate ${alias}" ] ++ parametricLines ++ [ "    deactivate ${alias}" ]
         )
         ++ lib.optional (staticNote != "") "    Note over ${alias}: ${staticNote}";
     in
@@ -168,7 +165,7 @@ let
           map participantDecl ordered
           ++ [ "" ]
           ++ map messageDecl nonSelfEntityEdges
-          ++ (if policyMessages != [ ] then [ "" ] ++ policyMessages else [ ])
+          ++ lib.optionals (policyMessages != [ ]) ([ "" ] ++ policyMessages)
           ++ lib.concatMap (s: [ "" ] ++ entityBlock s) ordered
         );
 
@@ -289,11 +286,11 @@ let
         ]
         ++ parametricLines
         ++ lib.optional (staticNote != "") "    Note over ${alias}: ${staticNote}"
-        ++ (if bridgesFromHere != [ ] then [ "" ] else [ ])
+        ++ lib.optional (bridgesFromHere != [ ]) ""
         ++ map bridgeLine bridgesFromHere
-        ++ (if policyLines != [ ] then [ "" ] else [ ])
+        ++ lib.optional (policyLines != [ ]) ""
         ++ policyLines
-        ++ (if outgoing != [ ] then [ "" ] else [ ])
+        ++ lib.optional (outgoing != [ ]) ""
         ++ map transitionLine outgoing;
     in
     if entityKinds == [ ] then
@@ -354,7 +351,7 @@ let
       renderMermaid {
         inherit theme mermaidConfig;
         diagramKind = "graph LR";
-      } (map nodeDecl ordered ++ (if edgeLines != [ ] then [ "" ] ++ edgeLines else [ ]));
+      } (map nodeDecl ordered ++ lib.optionals (edgeLines != [ ]) ([ "" ] ++ edgeLines));
 
   toScopeEdgesMermaid = toScopeEdgesMermaidWith { };
 

--- a/nix/lib/diag/util.nix
+++ b/nix/lib/diag/util.nix
@@ -347,18 +347,13 @@ let
             else
               null;
         in
-        if dstKind != null && (n.entityKind or null) != null then
-          [
-            {
-              src = n.entityKind;
-              dst = dstKind;
-              aspect = n.label;
-              kind = "bridge";
-              node = n;
-            }
-          ]
-        else
-          [ ]
+        lib.optional (dstKind != null && (n.entityKind or null) != null) {
+          src = n.entityKind;
+          dst = dstKind;
+          aspect = n.label;
+          kind = "bridge";
+          node = n;
+        }
       ) nodes;
     in
     provideWrappers ++ entityBridges;

--- a/nix/lib/namespace.nix
+++ b/nix/lib/namespace.nix
@@ -26,13 +26,9 @@ let
 
   aliasModule = lib.mkAliasOptionModule [ name ] [ "den" "ful" name ];
 
-  outputModule =
-    if isOutput then
-      {
-        config.flake.denful.${name} = config.den.ful.${name};
-      }
-    else
-      { };
+  outputModule = lib.optionalAttrs isOutput {
+    config.flake.denful.${name} = config.den.ful.${name};
+  };
 
   # Merge external source classes into den.classes.
   # Local namespace classes are collected by aspect-schema.nix.


### PR DESCRIPTION
## Summary

Replaces 21 bare `if/then/else` sites across 13 files with their idiomatic `lib.optional`, `lib.optionals`, and `lib.optionalAttrs` equivalents.

This PR eliminates a persistent source of review noise — every PR touching these files triggers the same nit from a certain vigilant reviewer. We figured it was cheaper to fix all 21 sites at once than to mass-produce "will fix in follow-up" comments for the rest of eternity.

## Changes

- 10 × `if cond then [ x ] else [ ]` → `lib.optional`
- 5 × `if cond then [ ... ] else [ ]` → `lib.optionals`
- 6 × `if cond then { ... } else { }` → `lib.optionalAttrs`
- Added `lib` to the parameter set of `bind.nix`, `unfree.nix`, and `insecure.nix` where it wasn't previously in scope

Net: **-42 lines**. Zero semantic changes. 771/771 tests pass.

## Test plan

- [x] `just ci` — 771/771 green
- [x] `just fmt` — no diff
- [x] drupol mass-nit surface area reduced to zero (until we write more `if`s)