### PR TITLE
fix: nested aspect key merge and includes scoping

### DIFF
--- a/nix/lib/aspects/fx/handlers/compile-static.nix
+++ b/nix/lib/aspects/fx/handlers/compile-static.nix
@@ -24,10 +24,55 @@ let
     "__parametricResolvedArgs"
   ];
 
+  # Merge multiple attrset content values per sub-key so class keys
+  # collect all definitions instead of last-win overwrite.
+  mergeContentValuesPerKey =
+    rawValue:
+    let
+      cvs = rawValue.__contentValues;
+      vals = map (d: d.value) cvs;
+      attrVals = builtins.filter builtins.isAttrs vals;
+    in
+    if builtins.length attrVals <= 1 then
+      unwrapContentValuesRaw rawValue
+    else
+      let
+        allKeys = lib.unique (lib.concatMap builtins.attrNames attrVals);
+        collectKey =
+          key:
+          let
+            defsForKey = lib.concatMap (
+              cv:
+              if builtins.isAttrs cv.value && cv.value ? ${key} then
+                [
+                  {
+                    inherit (cv) file;
+                    value = cv.value.${key};
+                  }
+                ]
+              else
+                [ ]
+            ) cvs;
+          in
+          if builtins.length defsForKey == 1 then
+            (builtins.head defsForKey).value
+          else
+            {
+              __contentValues = defsForKey;
+              __provider = (rawValue.__provider or [ ]) ++ [ key ];
+            };
+      in
+      lib.genAttrs allKeys collectKey;
+
   emitNestedAspect =
     aspect: ctx: k:
     let
-      innerValue = unwrapContentValuesRaw aspect.${k};
+      rawValue = aspect.${k};
+      innerValue =
+        if builtins.isAttrs rawValue && rawValue ? __contentValues then
+          mergeContentValuesPerKey rawValue
+        else
+          rawValue;
       subAspect =
         (if builtins.isAttrs innerValue then innerValue else { })
         // {

--- a/nix/lib/aspects/fx/handlers/compile-static.nix
+++ b/nix/lib/aspects/fx/handlers/compile-static.nix
@@ -118,6 +118,16 @@ in
                   })
                   (
                     classified:
+                    let
+                      # Content wrappers from aspectContentType (included via
+                      # den.aspects.X.Y in an includes list) carry __contentValues
+                      # at the top level.  Their nested sub-keys are independent
+                      # sub-aspects that should be included explicitly, not
+                      # auto-walked.  Sub-aspects from emitNestedAspect and full
+                      # aspects from aspectSubmodule do NOT have __contentValues
+                      # at the top level, so their nested keys auto-walk normally.
+                      nestedToWalk = lib.optionals (!(tagged ? __contentValues)) classified.nestedKeys;
+                    in
                     fx.bind
                       (fx.seq (
                         [
@@ -129,7 +139,7 @@ in
                           })
                           (registerConstraints tagged)
                         ]
-                        ++ map (emitNestedAspect tagged (param.ctx or { })) classified.nestedKeys
+                        ++ map (emitNestedAspect tagged (param.ctx or { })) nestedToWalk
                       ))
                       (
                         _:

--- a/templates/ci/modules/features/deadbugs/nested-aspect-includes.nix
+++ b/templates/ci/modules/features/deadbugs/nested-aspect-includes.nix
@@ -1,0 +1,74 @@
+# Regression: including a nested aspect should NOT auto-include its
+# sub-aspects.  den.aspects.apps.dev-tools.foo should only be included
+# when explicitly referenced, not when only <apps/dev-tools> is included.
+# https://github.com/denful/den/issues/XXX
+{
+  denTest,
+  lib,
+  ...
+}:
+{
+  flake.tests.deadbugs.nested-aspect-includes = {
+
+    # Including dev-tools should NOT pull in dev-tools.foo
+    test-nested-sub-aspect-not-auto-included = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.apps.dev-tools = {
+          nixos.environment.variables.DEV_TOOLS = "yes";
+        };
+
+        den.aspects.apps.dev-tools.foo = {
+          nixos.environment.variables.DEV_TOOLS_FOO = "yes";
+        };
+
+        # Include only dev-tools, not foo
+        den.aspects.igloo.includes = [ den.aspects.apps.dev-tools ];
+
+        expr = {
+          hasDevTools = igloo.environment.variables.DEV_TOOLS == "yes";
+          # foo should NOT be included
+          hasFoo = igloo.environment.variables ? DEV_TOOLS_FOO;
+        };
+        expected = {
+          hasDevTools = true;
+          hasFoo = false;
+        };
+      }
+    );
+
+    # Explicitly including the sub-aspect should work
+    test-nested-sub-aspect-explicit-include = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.apps.dev-tools = {
+          nixos.environment.variables.DEV_TOOLS = "yes";
+        };
+
+        den.aspects.apps.dev-tools.foo = {
+          nixos.environment.variables.DEV_TOOLS_FOO = "yes";
+        };
+
+        # Include both explicitly
+        den.aspects.igloo.includes = [
+          den.aspects.apps.dev-tools
+          den.aspects.apps.dev-tools.foo
+        ];
+
+        expr = {
+          hasDevTools = igloo.environment.variables.DEV_TOOLS == "yes";
+          hasFoo = igloo.environment.variables.DEV_TOOLS_FOO == "yes";
+        };
+        expected = {
+          hasDevTools = true;
+          hasFoo = true;
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/deadbugs/nested-aspect-merge.nix
+++ b/templates/ci/modules/features/deadbugs/nested-aspect-merge.nix
@@ -1,0 +1,37 @@
+# Regression: nested aspect keys with multiple definitions should merge
+# (collect all class modules), not last-win overwrite.
+{
+  denTest,
+  lib,
+  ...
+}:
+{
+  flake.tests.deadbugs.nested-aspect-merge = {
+
+    # Two modules defining den.aspects.system.base.nixos should both contribute.
+    # Before the fix, only the last definition survived (last-win via //).
+    test-multi-def-nested-class-key = denTest (
+      { den, igloo, ... }:
+      {
+        imports = [
+          # Module A
+          { den.aspects.igloo.base.nixos.environment.variables.FROM_A = "yes"; }
+          # Module B
+          { den.aspects.igloo.base.nixos.environment.variables.FROM_B = "yes"; }
+        ];
+
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        expr = {
+          hasA = igloo.environment.variables ? FROM_A;
+          hasB = igloo.environment.variables ? FROM_B;
+        };
+        expected = {
+          hasA = true;
+          hasB = true;
+        };
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Summary

- **Multi-definition merge**: When multiple modules define the same nested aspect key, class sub-keys are now properly collected instead of last-win overwrite. `emitNestedAspect` reconstructs per-sub-key `__contentValues` so all definitions contribute.
- **Includes scoping**: Explicitly including a nested aspect via `den.aspects.X.Y` no longer auto-walks its nested sub-keys. Sub-aspects at deeper levels must be included explicitly. Direct nesting and organizational grouping continue to auto-walk as before.

## Test plan

- [x] Added regression test for multi-definition nested class key merge
- [x] Added regression tests for includes scoping (auto-include prevented, explicit include works)
- [x] All 6 existing `nested-aspects` tests pass
- [x] Full CI: 776/776 passing