### PR TITLE
feat: CLAUDE.md project guide and den-debugging skill

### DIFF
--- a/.claude/skills/den-debugging.md
+++ b/.claude/skills/den-debugging.md
@@ -73,20 +73,32 @@ Tests live in `templates/ci/modules/features/`. Bug regression tests go in `dead
 
 - **`denTest` args**: `den` (the den module), `igloo` (nixosConfigurations.igloo.config), `tuxHm` (igloo.home-manager.users.tux) are the main ones.
 - **Multi-file definitions**: Use `imports` with inline modules to simulate multiple files defining the same path — you can't have duplicate keys in a single nix file.
+- **Namespace setup**: Users with namespaces (e.g., `den.namespace "gloom"`) must be tested using `imports = [ (inputs.den.namespace "ns" false) ]` in denTest.  Access the namespace via the module arg (`{ ns, ... }:`), not `den.aspects`.
 - **Attribute existence checks**: Use `? attrName` to test presence without crashing on missing attrs.
 - **Stage new files**: Run `git add <file>` before nix can evaluate new test files.
 
 ### Run the test
 
 ```bash
-# Single test suite
-nix develop -c nix-unit --override-input den . --flake ./templates/ci#.tests.deadbugs.my-bug-name
+# Single test with trace (preferred — use just ci with dotted path)
+nix develop -c just ci deadbugs.my-bug-name.test-specific-case
 
-# With full trace on failure
-nix develop -c nix-unit --override-input den . --flake ./templates/ci#.tests.deadbugs.my-bug-name --show-trace
+# Whole suite
+nix develop -c just ci deadbugs.my-bug-name
+
+# Suite with full nix-unit output
+nix develop -c just ci-deep deadbugs.my-bug-name
 ```
 
 Confirm the test fails with the expected symptom before proceeding.
+
+### Working with user configs
+
+When a user reports a bug from their own den config, **don't try to build their flake directly** — it will have unresolvable inputs, hardware-specific modules, and secrets. Instead:
+
+1. Read the user's modules to extract the **pattern** — how they define aspects, which module args they use, how includes are structured.
+2. Write a regression test in den's CI suite that mirrors that pattern.
+3. For npins users: they can't use `--override-input`, and `follows.nix` local overrides (e.g., `builtins.pathExists ./den-local`) don't work in flake evaluation context because the store copy strips symlinks. Don't waste time making their flake build — the regression test is what matters.
 
 ## Phase 4: Implement the Fix
 
@@ -134,6 +146,8 @@ Don't revert everything. Isolate which specific change broke which test:
 1. Once you identify the problematic change, understand _why_ it breaks the other case before trying a different approach
 
 ### When the root cause isn't obvious
+
+When a bug involves content wrappers, check whether the forwarded (shallow-merged) attributes match the `__contentValues`.  `aspectContentType.merge` uses `foldl' //` to build forwarded attrs — this is last-win per key.  Structural list keys (`includes`, `excludes`) are explicitly concatenated, but other overlapping keys from different modules will silently overwrite.  The pipeline uses `__contentValues` for class emission but forwarded attrs for structural keys and direct attribute access.
 
 Look for structural markers that distinguish the working path from the broken path. In den's pipeline, common differentiators:
 

--- a/.claude/skills/den-debugging.md
+++ b/.claude/skills/den-debugging.md
@@ -1,0 +1,168 @@
+---
+name: den-debugging
+description: Systematic debugging workflow for den/nix issues. Use when encountering bug reports, test failures, regressions, or unexpected behavior in den's aspect pipeline, type system, or fx handlers. Also use when a user shares an error or describes broken behavior in their den config. Trigger on phrases like "bug report", "regression", "broken", "doesn't work", "used to work", "last-win", "not merging", "not included", "wrong behavior".
+---
+
+# Den Debugging Workflow
+
+A structured approach to reproducing, isolating, and fixing bugs in den. The core loop is: **understand the report, read the code path, write a failing test, confirm the failure, fix, confirm the fix, check for regressions.**
+
+This workflow exists because den's fx pipeline has layered abstractions (content wrappers, type merges, effect handlers, key classification) where bugs often manifest far from their root cause. Writing a test first anchors your understanding before you touch implementation code.
+
+## Phase 1: Understand the Bug Report
+
+Before reading any code, extract the concrete claims from the report:
+
+1. **What the user did** — the nix expressions they wrote, the API surface they used
+2. **What they expected** — the behavior they consider correct
+3. **What actually happened** — the observed result (error, wrong value, missing config)
+4. **What works** — any workaround or alternative path that succeeds (this narrows the search)
+
+If the report contrasts two API paths (e.g., old syntax works but new syntax doesn't), that contrast is your most valuable clue — it tells you exactly where the code paths diverge.
+
+## Phase 2: Trace the Code Path
+
+Read the relevant source files to understand the mechanism. Don't guess — follow the actual code path from the user's nix expression to the pipeline output.
+
+**Common entry points by symptom:**
+
+| Symptom | Start reading at |
+|---------|-----------------|
+| Values not merging / last-win | `nix/lib/aspects/types.nix` — `aspectContentType.merge`, `providerType.merge` |
+| Wrong keys classified | `nix/lib/aspects/fx/key-classification.nix` — `classifyKeys`, `hasRecognizedSubKeys` |
+| Nested aspects not resolving | `nix/lib/aspects/fx/handlers/compile-static.nix` — `emitNestedAspect` |
+| Includes pulling wrong things | `nix/lib/aspects/fx/aspect/children.nix` — `emitIncludes`, `processInclude` |
+| Parametric not binding | `nix/lib/aspects/fx/handlers/bind.nix` |
+| Class modules missing | `nix/lib/aspects/fx/handlers/emit-classes.nix`, `nix/lib/aspects/fx/content-util.nix` |
+| Scope/context issues | `nix/lib/aspects/fx/handlers/compile-static.nix` — scope handler propagation |
+| Entity resolution | `nix/lib/resolve-entity.nix` |
+| Forward/routing | `nix/lib/aspects/fx/handlers/compile-forward.nix` |
+| Gate/dedup | `nix/lib/aspects/fx/handlers/gate-tag.nix` |
+
+Use the Explore agent for broad searches when you're unsure which files are involved. Use direct Grep/Read for targeted lookups when you know the function name.
+
+## Phase 3: Write a Failing Test
+
+Write a minimal test that reproduces the bug **before** attempting any fix. This is non-negotiable — it prevents you from "fixing" something that was never broken, and it catches regressions immediately.
+
+### Test location and structure
+
+Tests live in `templates/ci/modules/features/`. Bug regression tests go in `deadbugs/` and follow the naming convention `issue-NNN-short-description.nix` when there's a GitHub issue, or `descriptive-name.nix` otherwise.
+
+### Test template
+
+```nix
+# Brief description of the bug being tested.
+{
+  denTest,
+  lib,
+  ...
+}:
+{
+  flake.tests.deadbugs.my-bug-name = {
+
+    test-descriptive-name = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # Set up the minimal den config that triggers the bug
+        den.aspects.igloo.something = { ... };
+
+        # Assert on the evaluated NixOS config
+        expr = {
+          someCheck = igloo.some.config.path == "expected";
+        };
+        expected = {
+          someCheck = true;
+        };
+      }
+    );
+
+  };
+}
+```
+
+### Key patterns
+
+- **`denTest` args**: `den` (the den module), `igloo` (nixosConfigurations.igloo.config), `tuxHm` (igloo.home-manager.users.tux) are the main ones.
+- **Multi-file definitions**: Use `imports` with inline modules to simulate multiple files defining the same path — you can't have duplicate keys in a single nix file.
+- **Attribute existence checks**: Use `? attrName` to test presence without crashing on missing attrs.
+- **Stage new files**: Run `git add <file>` before nix can evaluate new test files.
+
+### Run the test
+
+```bash
+# Single test suite
+nix develop -c nix-unit --override-input den . --flake ./templates/ci#.tests.deadbugs.my-bug-name
+
+# With full trace on failure
+nix develop -c nix-unit --override-input den . --flake ./templates/ci#.tests.deadbugs.my-bug-name --show-trace
+```
+
+Confirm the test fails with the expected symptom before proceeding.
+
+## Phase 4: Implement the Fix
+
+Now that you have a failing test anchoring the expected behavior:
+
+1. **Make the minimal change** that addresses the root cause. Resist the urge to refactor surrounding code.
+2. **Run your regression test** to confirm it passes.
+3. **Run the existing related tests** to check you haven't broken anything:
+   ```bash
+   # Run a related test suite
+   nix develop -c nix-unit --override-input den . --flake ./templates/ci#.tests.<related-suite>
+   ```
+4. **If existing tests break**, isolate which part of your change caused it. A useful technique: revert parts of the fix independently and rerun to identify the problematic change.
+
+## Phase 5: Validate
+
+Run the full CI suite before considering the fix complete:
+
+```bash
+# Full suite (limit to 4 workers during agent sessions)
+nix develop -c just ci
+
+# Specific suite with traces
+nix develop -c just ci suite.test
+```
+
+The summary line at the end shows pass/fail counts. All tests must pass.
+
+### Format before committing
+
+```bash
+nix develop -c just fmt
+```
+
+CI will reject unformatted code.
+
+## Debugging Techniques
+
+### When a fix causes regressions
+
+Don't revert everything. Isolate which specific change broke which test:
+
+1. Keep the test files, revert only implementation changes
+2. Re-apply changes one at a time, running the broken test after each
+3. Once you identify the problematic change, understand *why* it breaks the other case before trying a different approach
+
+### When the root cause isn't obvious
+
+Look for structural markers that distinguish the working path from the broken path. In den's pipeline, common differentiators:
+
+- `__contentValues` — present on content wrappers from `aspectContentType`, absent on sub-aspects from `emitNestedAspect` and full aspects from `aspectSubmodule`
+- `__provider` — tracks the definition path through nested aspects
+- `__providesForwarded` — keys forwarded from `provides` onto the aspect
+- `__fn` / `__args` — parametric wrappers
+- `__scopeHandlers` — context propagation
+
+### When you need to understand data flow
+
+Add `builtins.trace` calls temporarily to see what values flow through the pipeline:
+
+```nix
+innerValue = builtins.trace "innerValue keys: ${builtins.toJSON (builtins.attrNames innerValue)}" innerValue;
+```
+
+Remove traces before committing.

--- a/.claude/skills/den-debugging.md
+++ b/.claude/skills/den-debugging.md
@@ -1,7 +1,6 @@
 ---
-name: den-debugging
-description: Systematic debugging workflow for den/nix issues. Use when encountering bug reports, test failures, regressions, or unexpected behavior in den's aspect pipeline, type system, or fx handlers. Also use when a user shares an error or describes broken behavior in their den config. Trigger on phrases like "bug report", "regression", "broken", "doesn't work", "used to work", "last-win", "not merging", "not included", "wrong behavior".
----
+
+## name: den-debugging description: Systematic debugging workflow for den/nix issues. Use when encountering bug reports, test failures, regressions, or unexpected behavior in den's aspect pipeline, type system, or fx handlers. Also use when a user shares an error or describes broken behavior in their den config. Trigger on phrases like "bug report", "regression", "broken", "doesn't work", "used to work", "last-win", "not merging", "not included", "wrong behavior".
 
 # Den Debugging Workflow
 
@@ -13,10 +12,10 @@ This workflow exists because den's fx pipeline has layered abstractions (content
 
 Before reading any code, extract the concrete claims from the report:
 
-1. **What the user did** — the nix expressions they wrote, the API surface they used
-2. **What they expected** — the behavior they consider correct
-3. **What actually happened** — the observed result (error, wrong value, missing config)
-4. **What works** — any workaround or alternative path that succeeds (this narrows the search)
+- **What the user did** — the nix expressions they wrote, the API surface they used
+- **What they expected** — the behavior they consider correct
+- **What actually happened** — the observed result (error, wrong value, missing config)
+- **What works** — any workaround or alternative path that succeeds (this narrows the search)
 
 If the report contrasts two API paths (e.g., old syntax works but new syntax doesn't), that contrast is your most valuable clue — it tells you exactly where the code paths diverge.
 
@@ -24,20 +23,7 @@ If the report contrasts two API paths (e.g., old syntax works but new syntax doe
 
 Read the relevant source files to understand the mechanism. Don't guess — follow the actual code path from the user's nix expression to the pipeline output.
 
-**Common entry points by symptom:**
-
-| Symptom | Start reading at |
-|---------|-----------------|
-| Values not merging / last-win | `nix/lib/aspects/types.nix` — `aspectContentType.merge`, `providerType.merge` |
-| Wrong keys classified | `nix/lib/aspects/fx/key-classification.nix` — `classifyKeys`, `hasRecognizedSubKeys` |
-| Nested aspects not resolving | `nix/lib/aspects/fx/handlers/compile-static.nix` — `emitNestedAspect` |
-| Includes pulling wrong things | `nix/lib/aspects/fx/aspect/children.nix` — `emitIncludes`, `processInclude` |
-| Parametric not binding | `nix/lib/aspects/fx/handlers/bind.nix` |
-| Class modules missing | `nix/lib/aspects/fx/handlers/emit-classes.nix`, `nix/lib/aspects/fx/content-util.nix` |
-| Scope/context issues | `nix/lib/aspects/fx/handlers/compile-static.nix` — scope handler propagation |
-| Entity resolution | `nix/lib/resolve-entity.nix` |
-| Forward/routing | `nix/lib/aspects/fx/handlers/compile-forward.nix` |
-| Gate/dedup | `nix/lib/aspects/fx/handlers/gate-tag.nix` |
+Refer to the entry point table in `CLAUDE.md`'s "Debugging and tracing" section for a mapping of symptoms to source files and specific tracing points in the pipeline handlers.
 
 Use the Explore agent for broad searches when you're unsure which files are involved. Use direct Grep/Read for targeted lookups when you know the function name.
 
@@ -107,13 +93,13 @@ Confirm the test fails with the expected symptom before proceeding.
 Now that you have a failing test anchoring the expected behavior:
 
 1. **Make the minimal change** that addresses the root cause. Resist the urge to refactor surrounding code.
-2. **Run your regression test** to confirm it passes.
-3. **Run the existing related tests** to check you haven't broken anything:
+1. **Run your regression test** to confirm it passes.
+1. **Run the existing related tests** to check you haven't broken anything:
    ```bash
    # Run a related test suite
    nix develop -c nix-unit --override-input den . --flake ./templates/ci#.tests.<related-suite>
    ```
-4. **If existing tests break**, isolate which part of your change caused it. A useful technique: revert parts of the fix independently and rerun to identify the problematic change.
+1. **If existing tests break**, isolate which part of your change caused it. A useful technique: revert parts of the fix independently and rerun to identify the problematic change.
 
 ## Phase 5: Validate
 
@@ -144,8 +130,8 @@ CI will reject unformatted code.
 Don't revert everything. Isolate which specific change broke which test:
 
 1. Keep the test files, revert only implementation changes
-2. Re-apply changes one at a time, running the broken test after each
-3. Once you identify the problematic change, understand *why* it breaks the other case before trying a different approach
+1. Re-apply changes one at a time, running the broken test after each
+1. Once you identify the problematic change, understand _why_ it breaks the other case before trying a different approach
 
 ### When the root cause isn't obvious
 
@@ -165,4 +151,21 @@ Add `builtins.trace` calls temporarily to see what values flow through the pipel
 innerValue = builtins.trace "innerValue keys: ${builtins.toJSON (builtins.attrNames innerValue)}" innerValue;
 ```
 
-Remove traces before committing.
+Remove traces before committing. See `CLAUDE.md`'s "Debugging and tracing" section for the most useful tracing points in the pipeline handlers.
+
+### Structured tracing in tests
+
+The `denTest` harness provides a `trace` helper that resolves an aspect tree and returns its structure. Use it to inspect what the pipeline produces without modifying pipeline code:
+
+```nix
+test-trace-example = denTest (
+  { den, trace, ... }:
+  let t = trace "myAspect" den.aspects.myAspect;
+  in {
+    expr = builtins.length t.imports > 0;
+    expected = true;
+  }
+);
+```
+
+This is useful in Phase 3 when you want to verify what the pipeline emits for a given aspect configuration.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,160 @@
+# Den
+
+Den is a Nix flake framework for declarative multi-entity system configuration. It sits on top of NixOS, nix-darwin, and home-manager, providing a pipeline-driven layer for organizing configuration into reusable, composable units called **aspects**.
+
+## Repository layout
+
+```
+flake.nix / default.nix    — entry points (both delegate to nix/)
+nix/                       — all library and flake-module code
+  default.nix              — true root: exports flakeModule, lib, templates, etc.
+  flakeModule.nix           — flake-parts module, imports all of ../modules/
+  denTest.nix              — test harness (denTest helper, fixtures: igloo, tuxHm, etc.)
+  lib/
+    aspects/               — aspect engine: types, resolve, fx pipeline
+      fx/                  — effect handlers, key classification, content utils
+        handlers/          — compile-static, compile-parametric, emit-classes, bind, gate, etc.
+        aspect/            — children, normalize, provide
+        policy/            — policy dispatch and effects
+    entities/              — host.nix, home.nix entity kind definitions
+    diag/                  — diagram generation (c4, mermaid, dot, fleet views)
+  nixModule/               — den.aspects, den.policies, den.lib option declarations
+modules/                   — NixOS-module-style option declarations and batteries
+  options.nix              — den.hosts, den.homes, den.schema, den.classes, den.quirks
+  aspects/batteries/       — built-in batteries (define-user, home-manager, hostname, etc.)
+  policies/                — core and flake-level policy declarations
+templates/                 — example flakes + CI test suite
+  ci/                      — 133+ test files in modules/features/, deadbugs/ for regressions
+  minimal/, default/, example/, noflake/, microvm/, nvf-standalone/
+```
+
+## Core concepts
+
+- **Entities** — structural units: `host`, `user`, `home`. Declared via `den.hosts`, `den.homes`. Each has an `.aspect` entry point resolved through the pipeline.
+- **Aspects** — the main content unit, declared under `den.aspects.<name>`. Attrsets whose keys are classified as class keys, nested keys, or pipe keys.
+- **Classes** — output buckets (`nixos`, `darwin`, `homeManager`). Aspect keys matching registered classes emit modules into that class. Registered via `den.classes`.
+- **Provides / `_`** — sub-aspect namespace on every aspect. Used for selectable includes, self-provide, and cross-entity delivery. `_` is an alias for `provides`.
+- **Policies** — context-driven functions that emit typed effects (routes, includes, provides). Fire when their argument signature is satisfied by scope context.
+- **Pipes / Quirks** — registered via `den.quirks`. Pipe keys in aspects register pipe effects assembled post-pipeline.
+- **Scope** — context-derived identity (`"host=igloo,user=tux"`) isolating emissions per entity level. Scope tree emerges from policy-driven context expansion.
+
+## FX pipeline
+
+The pipeline is an algebraic effects trampoline. Every state change is an effect; pure data transforms stay as functions.
+
+Key stages: `resolve` → `compile` (shape router) → `gate` (dedup + constraints) → `compile-static` / `compile-parametric` / `compile-forward` / `compile-conditional` → `classify` → `emit-classes` → `emitNestedAspect` → `resolve-children` → policy iteration → drain deferred.
+
+Four aspect shapes, detected by the compiler router:
+
+- **Static** — no special fields → `compile-static`
+- **Parametric** — has `__args` → `compile-parametric` (binds scope args, re-resolves)
+- **Forward** — has `meta.__forward` → `compile-forward`
+- **Conditional** — has `meta.guard` → `compile-conditional`
+
+## Development commands
+
+```bash
+# formatting (required before commits, CI rejects unformatted code)
+nix develop -c just fmt
+
+# run full CI suite
+nix develop -c just ci
+
+# run full CI suite with full nix-unit output (slow)
+nix develop -c just ci-deep
+
+# run a specific test suite
+nix develop -c just ci nested-aspects
+
+# run a specific test with traces
+nix develop -c just ci nested-aspects.test-direct-nesting-basic
+
+# run tests directly via nix-unit (more control)
+nix-unit --override-input den . --flake ./templates/ci#.tests.<suite>
+
+# check a template
+nix flake check --override-input den . ./templates/<template>
+
+# interactive repl with den loaded
+just repl
+```
+
+## Testing
+
+Tests live in `templates/ci/modules/features/`. Bug regressions go in `deadbugs/`.
+
+Test files export `flake.tests.<suite>.<test-name>` using the `denTest` helper:
+
+```nix
+{ denTest, ... }:
+{
+  flake.tests.my-suite = {
+    test-something = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.aspects.igloo.nixos.networking.hostName = "test";
+
+        expr = igloo.networking.hostName;
+        expected = "test";
+      }
+    );
+  };
+}
+```
+
+Key `denTest` args: `den`, `igloo` (nixosConfigurations.igloo.config), `tuxHm` (igloo.home-manager.users.tux), `ns` (when a namespace is imported).
+
+New test files must be `git add`'d before nix can evaluate them. Use `--override-input den .` to test against the local checkout.
+
+## Git conventions
+
+- Format before committing: `nix develop -c just fmt`
+- Stage files explicitly by name, never `git add -A` or `git add .`
+- Stage new `.nix` files before running nix eval/test (nix needs them tracked)
+
+## Code style
+
+- Idiomatic Nix: use `inherit` for hyphenated identifiers in scope, not quoted assignment
+- Idiomatic Nix: use `lib.optional` `lib.optionals` `lib.optionalAttrs` for basic conditionals
+- Idiomatic Nix: avoid `with` — prefer `inherit` to bring names into scope. `with` obscures where bindings come from and breaks tooling.
+- Error messages: prefix with `den:` for traceability (e.g., `throw "den: multiple __functor definitions at ..."`)
+- Internal markers: double-underscore prefixed attrs (`__contentValues`, `__provider`, `__fn`) are pipeline internals. Don't add new ones without understanding the classification and structural key filtering in `key-classification.nix`.
+- Commenting: comments should describe why not what, code should be self documenting as to what
+- Minimal changes: fix the bug, don't refactor surroundings
+- Diagnose before reverting: the fix is usually one targeted change
+- After 3+ workarounds in the same area, redesign the component instead of patching further
+
+## Claude Code skills
+
+- **den-debugging** (`.claude/skills/den-debugging.md`) — structured workflow for reproducing, isolating, and fixing bugs. Guides through: understand report → trace code path → write failing test → fix → validate. Includes an entry point table mapping symptoms to source files.
+
+## Debugging and tracing
+
+For pipeline debugging, use `builtins.trace` temporarily to inspect values flowing through handlers:
+
+```nix
+innerValue = builtins.trace "keys: ${builtins.toJSON (builtins.attrNames innerValue)}" innerValue;
+```
+
+Remove all `builtins.trace` calls before committing — the pipeline code intentionally has none.
+
+For structured pipeline tracing in tests, use the `trace` helper from `denTest`:
+
+```nix
+test-trace-example = denTest (
+  { den, trace, ... }:
+  let t = trace "myAspect" den.aspects.myAspect;
+  in { expr = t.imports; expected = ...; }
+);
+```
+
+Use `--show-trace` with `nix-unit` for full Nix evaluation stack traces on errors.
+
+**Useful tracing points in the pipeline:**
+
+- **Gate dedup** (`handlers/gate.nix`) — trace `dedupKey` and `isDuplicate` to see why an aspect is being skipped. The dedup key is `"${scopeId}/${identityKey}"`.
+- **Emit-class collector** (`handlers/class-collector.nix`) — trace `loc` (`"${param.class}@${baseIdentity}"`) and `alreadyEmitted` to see what class modules are collected and whether dedup is suppressing entries.
+- **Classification** (`handlers/classify.nix`) — trace the `classified` result to see how keys are partitioned into `classKeys`, `nestedKeys`, and `pipeKeys`.
+- **Emit-classes** (`handlers/emit-classes.nix`) — trace `modules` from `unwrapContentValuesList aspect.${k}` to see what's actually being emitted for a class key.
+- **Compile-static nested walk** (`handlers/compile-static.nix`) — trace `nestedToWalk` to see which nested keys are auto-walked vs suppressed.


### PR DESCRIPTION
## Why

As den's pipeline grows in complexity, contributors (both human and AI-assisted) need clear orientation to work effectively. New contributors face a steep ramp-up: layered abstractions like content wrappers, effect handlers, and key classification mean bugs often manifest far from their root cause. Without guidance, debugging sessions wander through dozens of files before finding the right entry point.

This PR provides two complementary resources:

## What

### CLAUDE.md — project guide

A single-file orientation for the den codebase covering:
- Repository layout and what each directory contains
- Core concepts (entities, aspects, classes, provides, policies, pipes, scopes)
- The FX pipeline stages and four aspect shapes
- Development commands, testing patterns, and the `denTest` harness
- Code style conventions (idiomatic Nix, error messages, internal markers)
- Debugging and tracing guidance with specific handler insertion points for dedup, emit, classification, and nested key walking

### den-debugging skill (`.claude/skills/den-debugging.md`)

A structured debugging workflow for Claude Code users, distilled from actual bug-fixing sessions. Guides through five phases: understand report, trace code path, write failing test, fix, validate. References CLAUDE.md for entry point tables and tracing points rather than duplicating them.

Evaluated against 3 test prompts (multi-file merge bug, vague parametric report, test failure). With-skill runs used 19% fewer tokens on average and achieved 100% assertion pass rate vs 92% without. Note: the 92% is still with my (sini) local agent memory -- a standalone claude session would likely not perform that high.