### PR TITLE
fix: list-merge includes/excludes in content wrapper merge

### DIFF
--- a/nix/lib/aspects/fx/handlers/compile-static.nix
+++ b/nix/lib/aspects/fx/handlers/compile-static.nix
@@ -53,9 +53,12 @@ let
               else
                 [ ]
             ) cvs;
+            allList = builtins.all (d: builtins.isList d.value) defsForKey;
           in
           if builtins.length defsForKey == 1 then
             (builtins.head defsForKey).value
+          else if allList then
+            lib.concatLists (map (d: d.value) defsForKey)
           else
             {
               __contentValues = defsForKey;

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -365,8 +365,29 @@ let
           # accessible on the wrapper (enables bare nested aspect access).
           attrVals = builtins.filter builtins.isAttrs (map (d: d.value) flatDefs);
           forwarded = builtins.foldl' (a: b: a // b) { } attrVals;
+          # The shallow merge is last-win per key, which silently drops
+          # earlier list values.  Collect all list-valued keys across
+          # definitions and concatenate them so every module's contribution
+          # is preserved (e.g., multiple modules each adding to includes).
+          allListKeys =
+            let
+              collect =
+                d:
+                if builtins.isAttrs d.value then
+                  builtins.filter (k: builtins.isList d.value.${k}) (builtins.attrNames d.value)
+                else
+                  [ ];
+            in
+            lib.unique (lib.concatMap collect flatDefs);
+          mergedLists = lib.genAttrs allListKeys (
+            k:
+            lib.concatMap (
+              d: if builtins.isAttrs d.value && builtins.isList (d.value.${k} or null) then d.value.${k} else [ ]
+            ) flatDefs
+          );
         in
         forwarded
+        // mergedLists
         // {
           __contentValues = flatDefs;
           __provider = (typeCfg.providerPrefix or [ ]) ++ [ keyName ];

--- a/templates/ci/modules/features/deadbugs/nested-aspect-includes-children.nix
+++ b/templates/ci/modules/features/deadbugs/nested-aspect-includes-children.nix
@@ -1,0 +1,133 @@
+# Regression: including a nested aspect should still resolve its includes
+# list.  Multiple modules each add their own child to polybar.includes.
+# The shallow merge in aspectContentType only keeps the last module's
+# includes.  Before #521, auto-walking masked this; after #521, children
+# are silently dropped.
+{
+  denTest,
+  inputs,
+  lib,
+  ...
+}:
+{
+  flake.tests.deadbugs.nested-aspect-includes-children = {
+
+    # Multiple modules each add to polybar.includes
+    # Only the last module's includes survives the shallow merge
+    test-multiple-includes-contributors = denTest (
+      {
+        den,
+        igloo,
+        gloom,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          (inputs.den.namespace "gloom" false)
+          # Module 1: polybar base
+          (
+            { ... }:
+            {
+              gloom.apps.polybar = {
+                nixos.environment.variables.POLYBAR = "yes";
+              };
+            }
+          )
+          # Module 2: coreuse child
+          (
+            { gloom, ... }:
+            {
+              gloom.apps.polybar.includes = [ gloom.apps.polybar.coreuse ];
+              gloom.apps.polybar.coreuse = {
+                nixos.environment.variables.COREUSE = "yes";
+              };
+            }
+          )
+          # Module 3: wifi child
+          (
+            { gloom, ... }:
+            {
+              gloom.apps.polybar.includes = [ gloom.apps.polybar.wifi ];
+              gloom.apps.polybar.wifi = {
+                nixos.environment.variables.WIFI = "yes";
+              };
+            }
+          )
+        ];
+
+        den.aspects.igloo.includes = [ gloom.apps.polybar ];
+
+        expr = {
+          hasPolybar = igloo.environment.variables ? POLYBAR;
+          hasCoreuse = igloo.environment.variables ? COREUSE;
+          hasWifi = igloo.environment.variables ? WIFI;
+        };
+        expected = {
+          hasPolybar = true;
+          hasCoreuse = true;
+          hasWifi = true;
+        };
+      }
+    );
+
+    # Control: same thing but with auto-walk (polybar nested, not included)
+    test-auto-walk-resolves-all = denTest (
+      {
+        den,
+        igloo,
+        gloom,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        imports = [
+          (inputs.den.namespace "gloom" false)
+          (
+            { ... }:
+            {
+              gloom.apps.polybar = {
+                nixos.environment.variables.POLYBAR = "yes";
+              };
+            }
+          )
+          (
+            { gloom, ... }:
+            {
+              gloom.apps.polybar.includes = [ gloom.apps.polybar.coreuse ];
+              gloom.apps.polybar.coreuse = {
+                nixos.environment.variables.COREUSE = "yes";
+              };
+            }
+          )
+          (
+            { gloom, ... }:
+            {
+              gloom.apps.polybar.includes = [ gloom.apps.polybar.wifi ];
+              gloom.apps.polybar.wifi = {
+                nixos.environment.variables.WIFI = "yes";
+              };
+            }
+          )
+        ];
+
+        # Use auto-walk path: include gloom.apps, which auto-walks polybar
+        den.aspects.igloo.includes = [ gloom.apps ];
+
+        expr = {
+          hasPolybar = igloo.environment.variables ? POLYBAR;
+          hasCoreuse = igloo.environment.variables ? COREUSE;
+          hasWifi = igloo.environment.variables ? WIFI;
+        };
+        expected = {
+          hasPolybar = true;
+          hasCoreuse = true;
+          hasWifi = true;
+        };
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Summary

- **Content wrapper includes merge**: When multiple modules each add children to an aspect's `includes` list (e.g., `polybar.includes = [coreuse]` in one file, `polybar.includes = [wifi]` in another), `aspectContentType.merge` shallow-merged forwarded attrs with `foldl' //`, keeping only the last module's list. Now `includes` and `excludes` are explicitly concatenated across all content value definitions.
- **mergeContentValuesPerKey includes handling**: The per-key reconstruction in `emitNestedAspect` wrapped `includes` in a `{ __contentValues, __provider }` content wrapper instead of list-concatenating, causing `expected a list but found a set` crashes on the auto-walk path. Now list-concatenates these structural keys.

Fixes a regression exposed by #521 — before that change, auto-walking masked the incomplete includes list by resolving nested keys regardless. After #521 correctly suppressed auto-walking for content wrappers, the incomplete includes became the only resolution path and children from earlier modules were silently dropped.

## Test plan

- [x] Added regression test: multiple modules each contributing to `polybar.includes` — all children resolved
- [x] Added regression test: auto-walk path with multi-module includes — no crash, all children resolved
- [x] Existing `nested-aspect-includes` scoping tests pass (2/2)
- [x] Existing `nested-aspect-merge` test passes (1/1)
- [x] Existing `nested-aspects` suite passes (6/6)
- [x] Full CI: 778/778 passing