### PR TITLE
feat: fleet-demo user registry, diagram rendering, and theme fixes

### DIFF
--- a/checkmate/modules/formatter.nix
+++ b/checkmate/modules/formatter.nix
@@ -1,5 +1,6 @@
 {
   perSystem.treefmt.settings.global.excludes = [
+    ".claude/**"
     ".github/*TEMPLATE*/*"
     "docs/*"
     "Justfile"
@@ -7,6 +8,10 @@
     "*.txt"
     "*.svg"
     "ci.bash"
+    "templates/fleet-demo/diagrams/*"
+    "templates/fleet-demo/README.md"
+    "templates/diagram-demo/diagrams/*"
+    "templates/diagram-demo/README.md"
   ];
   perSystem.treefmt.programs.deadnix.enable = false;
   perSystem.treefmt.programs.nixf-diagnose.enable = false;

--- a/nix/lib/diag/fleet-views.nix
+++ b/nix/lib/diag/fleet-views.nix
@@ -18,6 +18,17 @@ let
 
   sanitize = makeIdSanitizer "h";
 
+  # Index into theme.accentPool by position. The pool is a list of 8 accent
+  # colors from the base16 palette; indexing respects the user's chosen scheme.
+  accent =
+    theme: i:
+    let
+      pool = theme.accentPool;
+      len = builtins.length pool;
+    in
+    assert len > 0;
+    builtins.elemAt pool (lib.mod i len);
+
   # Extract host name from a scope ID like "environment=prod,fleet=fleet,host=lb-prod"
   hostNameFromScope =
     scopeId:
@@ -175,26 +186,47 @@ let
       flows = buildPipeFlows fleetCapture;
 
       # Unique pipe names for color assignment.
+      # Spread pipe colors across the accent pool using coprime stepping
+      # (step 3 over 8 slots) so adjacent pipes get visually distinct hues
+      # rather than neighboring palette entries.
       pipeNames = lib.unique (map (e: e.pipe) flows.flowEdges);
-      pipeColors = [
-        theme.accent0 or "#f38ba8"
-        theme.accent1 or "#fab387"
-        theme.accent2 or "#f9e2af"
-        theme.accent3 or "#a6e3a1"
-        theme.accent4 or "#94e2d5"
-        theme.accent5 or "#89b4fa"
-        theme.accent6 or "#cba6f7"
-        theme.accent7 or "#f2cdcd"
-      ];
       pipeColorOf =
         pipeName:
         let
           idx = lib.lists.findFirstIndex (p: p == pipeName) 0 pipeNames;
         in
-        builtins.elemAt pipeColors (lib.mod idx (builtins.length pipeColors));
+        accent theme (idx * 3);
 
-      # All unique host names for node declarations.
-      allHostNames = lib.unique (lib.concatMap (env: map (h: h.name) env.hosts) flows.environments);
+      # All hosts flattened with their role (producer, consumer, both).
+      allHosts = lib.concatMap (env: env.hosts) flows.environments;
+      allHostNames = lib.unique (map (h: h.name) allHosts);
+
+      # Classify host role for node shape and color.
+      hostRole =
+        h:
+        let
+          isProducer = h.produces != [ ];
+          isCollector = h.collects != [ ];
+        in
+        if isProducer && isCollector then
+          "both"
+        else if isCollector then
+          "consumer"
+        else
+          "producer";
+
+      # Node shapes: producers are boxes, consumers are rounded, both are stadium.
+      hostShape =
+        h:
+        let
+          role = hostRole h;
+        in
+        if role == "consumer" then
+          "([\"${h.name}\"])"
+        else if role == "both" then
+          "([\"${h.name}\"])"
+        else
+          "[\"${h.name}\"]";
 
       # Environment subgraphs.
       envSubgraph =
@@ -214,8 +246,11 @@ let
                 else
                   h.produces;
               annotation = if aspectPipes != [ ] then " (${lib.concatStringsSep ", " aspectPipes})" else "";
+              shape = hostShape h;
             in
-            "    ${sanitize h.name}([\"${h.name}${annotation}\"])"
+            "    ${sanitize h.name}${
+                  if annotation != "" then lib.replaceStrings [ h.name ] [ "${h.name}${annotation}" ] shape else shape
+                }"
           ) env.hosts;
         in
         "  subgraph ${sanitize "env_${env.name}"}[\"${env.name}\"]\n"
@@ -227,6 +262,7 @@ let
         pipeName:
         let
           edges = builtins.filter (e: e.pipe == pipeName) flows.flowEdges;
+          color = pipeColorOf pipeName;
           edgeDecl = e: "  ${sanitize e.from} -->|${e.pipe}| ${sanitize e.to}";
         in
         map edgeDecl edges;
@@ -235,7 +271,6 @@ let
       linkStyles =
         let
           allEdgeLines = lib.concatMap edgesForPipe pipeNames;
-          edgeIndices = lib.genList (i: i) (builtins.length allEdgeLines);
         in
         lib.imap0 (
           i: _:
@@ -254,10 +289,22 @@ let
                     go (remaining - builtins.elemAt edgeCounts pIdx) (pIdx + 1);
               in
               go i 0;
-            color = builtins.elemAt pipeColors (lib.mod pipeIdx (builtins.length pipeColors));
+            color = pipeColorOf (builtins.elemAt pipeNames pipeIdx);
           in
           "  linkStyle ${toString i} stroke:${color},stroke-width:2px"
         ) allEdgeLines;
+
+      # Per-host node styles: consistent entity-kind coloring matching
+      # scope topology and policy resolution views. Pipe colors are on
+      # edges only — node color shows what the entity IS, edge color
+      # shows what data FLOWS.
+      hostColor = accent theme 3; # same index as kindColors.host in other views
+      hostNodeStyles = lib.concatMap (
+        env:
+        map (
+          h: "  style ${sanitize h.name} fill:${hostColor},stroke:${hostColor},color:${theme.rootText}"
+        ) env.hosts
+      ) flows.environments;
     in
     if flows.flowEdges == [ ] then
       renderMermaid {
@@ -276,15 +323,11 @@ let
           ++ lib.concatMap edgesForPipe pipeNames
           ++ [ "" ]
           ++ linkStyles
-          ++ [
-            ""
-            "  classDef default fill:${theme.nodeBg or "#313244"},stroke:${theme.nodeBorder or "#a6adc8"},color:${theme.nodeText or "#cdd6f4"}"
-          ]
+          ++ [ "" ]
+          ++ hostNodeStyles
           ++ map (
             env:
-            "  style ${sanitize "env_${env.name}"} fill:${theme.clusterBg or "#313244"},stroke:${
-                theme.clusterBorder or "#6c7086"
-              },stroke-width:2px"
+            "  style ${sanitize "env_${env.name}"} fill:transparent,stroke:${theme.clusterBorder},stroke-width:1px"
           ) flows.environments
         );
 
@@ -352,18 +395,18 @@ let
 
       # Color nodes by entity kind.
       kindColors = {
-        fleet = theme.accent5 or "#89b4fa";
-        environment = theme.accent6 or "#cba6f7";
-        host = theme.accent3 or "#a6e3a1";
-        user = theme.accent1 or "#fab387";
-        "flake-system" = theme.accent4 or "#94e2d5";
+        fleet = accent theme 5;
+        environment = accent theme 6;
+        host = accent theme 3;
+        user = accent theme 1;
+        "flake-system" = accent theme 4;
       };
       nodeStyle =
         scopeId:
         let
           kind = scopeEntityKind.${scopeId} or null;
-          color = kindColors.${kind} or (theme.nodeBg or "#313244");
-          text = theme.rootText or "#1e1e2e";
+          color = kindColors.${kind} or theme.nodeBg;
+          text = theme.rootText;
         in
         "  style ${sanitize scopeId} fill:${color},stroke:${color},color:${text}";
     in
@@ -455,18 +498,8 @@ let
         aspectName:
         let
           idx = lib.lists.findFirstIndex (a: a == aspectName) 0 allAspects;
-          colors = [
-            (theme.accent0 or "#f38ba8")
-            (theme.accent1 or "#fab387")
-            (theme.accent2 or "#f9e2af")
-            (theme.accent3 or "#a6e3a1")
-            (theme.accent4 or "#94e2d5")
-            (theme.accent5 or "#89b4fa")
-            (theme.accent6 or "#cba6f7")
-            (theme.accent7 or "#f2cdcd")
-          ];
         in
-        builtins.elemAt colors (lib.mod idx (builtins.length colors));
+        accent theme idx;
 
       nodeStyles = lib.concatMap (
         h:
@@ -474,7 +507,7 @@ let
           a:
           let
             color = aspectColor a;
-            text = theme.rootText or "#1e1e2e";
+            text = theme.rootText;
           in
           "  style ${sanitize "${h.name}_${a}"} fill:${color},stroke:${color},color:${text}"
         ) (builtins.filter (a: builtins.elem a h.aspects) allAspects)
@@ -482,9 +515,7 @@ let
 
       hostStyles = map (
         h:
-        "  style ${sanitize "host_${h.name}"} fill:${theme.clusterBg or "#313244"},stroke:${
-            theme.clusterBorder or "#6c7086"
-          },stroke-width:2px"
+        "  style ${sanitize "host_${h.name}"} fill:${theme.clusterBg},stroke:${theme.clusterBorder},stroke-width:2px"
       ) hostAspects;
 
       # Link same aspects across hosts with dotted edges for visual grouping.
@@ -586,18 +617,18 @@ let
 
       # Color by entity kind.
       kindColors = {
-        fleet = theme.accent5 or "#89b4fa";
-        environment = theme.accent6 or "#cba6f7";
-        host = theme.accent3 or "#a6e3a1";
-        user = theme.accent1 or "#fab387";
-        "flake-system" = theme.accent4 or "#94e2d5";
+        fleet = accent theme 5;
+        environment = accent theme 6;
+        host = accent theme 3;
+        user = accent theme 1;
+        "flake-system" = accent theme 4;
       };
       nodeStyle =
         scopeId:
         let
           kind = scopeEntityKind.${scopeId} or null;
-          color = kindColors.${kind} or (theme.nodeBg or "#313244");
-          text = theme.rootText or "#1e1e2e";
+          color = kindColors.${kind} or theme.nodeBg;
+          text = theme.rootText;
         in
         "  style ${sanitize scopeId} fill:${color},stroke:${color},color:${text}";
     in
@@ -802,15 +833,13 @@ let
         env:
         map (
           h:
-          "  style ${sanitize "host_${h.name}"} fill:${theme.nodeBg or "#313244"},stroke:${theme.nodeBorder or "#a6adc8"},stroke-width:1px"
+          "  style ${sanitize "host_${h.name}"} fill:${theme.nodeBg},stroke:${theme.nodeBorder},stroke-width:1px"
         ) env.hosts
       ) flows.environments;
 
       envStyles = map (
         env:
-        "  style ${sanitize "env_${env.name}"} fill:${theme.clusterBg or "#313244"},stroke:${
-            theme.clusterBorder or "#6c7086"
-          },stroke-width:2px"
+        "  style ${sanitize "env_${env.name}"} fill:${theme.clusterBg},stroke:${theme.clusterBorder},stroke-width:2px"
       ) flows.environments;
     in
     renderMermaid

--- a/nix/lib/diag/namespace.nix
+++ b/nix/lib/diag/namespace.nix
@@ -47,6 +47,7 @@ let
           hasFunctorInclude = lib.any (i: !builtins.isAttrs i) incs;
           hasConstraint = (value.meta.handleWith or null) != null;
           hasProvides = (value.provides or { }) != { };
+          hasIncludes = incs != [ ];
           providerChain = value.meta.provider or [ ];
         in
         graphLib.emptyNode
@@ -64,6 +65,12 @@ let
           style = if hasConstraint then "adapter" else "default";
           providerPath = providerChain;
           hasClass = true;
+          # Structural role for consistent coloring: host aspects that
+          # include others vs shared leaf aspects that are included.
+          entityKind = if hasIncludes then "host" else "shared";
+          # colorKey makes all nodes of the same role hash to the same
+          # accent color (no per-name perturbation from nodeColorFor).
+          colorKey = if hasIncludes then "host" else "shared";
         };
 
       mkEdges =

--- a/nix/lib/diag/render-util.nix
+++ b/nix/lib/diag/render-util.nix
@@ -110,7 +110,11 @@ let
       isTerminal = node.style == "terminal";
       isPolicy = node.style == "policy";
       isDefault = !(isExcluded || isReplaced || isAdapter || isTerminal || isPolicy);
-      accent = nodeColorFor theme (node.entityKind or null) node.label;
+      # colorKey overrides the name used for per-node hashing. When set,
+      # all nodes with the same entityKind AND colorKey get the same color
+      # (no per-name perturbation). Used by namespace graphs where color
+      # means structural role, not individual identity.
+      accent = nodeColorFor theme (node.entityKind or null) (node.colorKey or node.label);
     in
     {
       inherit

--- a/nix/lib/diag/text.nix
+++ b/nix/lib/diag/text.nix
@@ -63,13 +63,16 @@ let
       policyNames = lib.unique (map (e: e.name) policyEntries);
 
       # Pipe data.
-      classKeys = [
+      # Keys that are NOT user-declared pipes — class keys plus framework-
+      # internal structural keys that appear in scopedClassImports.
+      nonPipeKeys = [
         "nixos"
         "homeManager"
         "user"
         "darwin"
+        "excludes"
       ];
-      isPipeKey = k: !builtins.elem k classKeys;
+      isPipeKey = k: !builtins.elem k nonPipeKeys;
 
       pipesByHost = map (
         hScope:

--- a/nix/lib/diag/themes.nix
+++ b/nix/lib/diag/themes.nix
@@ -53,39 +53,89 @@ let
   # `accentPool` is the list of 8 hues the per-node color hash selects
   # from. Keeping to base16's accent slots means every diagram's nodes
   # stay faithful to the chosen scheme.
-  themeFromPalette = palette: {
-    inherit palette;
-    background = palette.base00;
-    foreground = palette.base05;
-    mutedForeground = palette.base04;
-    nodeBg = palette.base01;
-    nodeBorder = palette.base04;
-    nodeText = palette.base05;
-    clusterBg = palette.base01;
-    clusterBorder = palette.base03;
-    edgeColor = palette.base04;
-    edgeText = palette.base05;
-    labelBg = palette.base00;
-    rootFill = palette.base0D;
-    rootStroke = palette.base0D;
-    rootText = palette.base00;
-    excludedFill = palette.base08;
-    excludedStroke = palette.base08;
-    excludedText = palette.base00;
-    replacedFill = palette.base09;
-    replacedStroke = palette.base09;
-    replacedText = palette.base00;
-    accentPool = [
-      palette.base08
-      palette.base09
-      palette.base0A
-      palette.base0B
-      palette.base0C
-      palette.base0D
-      palette.base0E
-      palette.base0F
-    ];
-  };
+  # Detect whether a palette is "light" (light base00 background) by
+  # comparing the first hex digit of base00 vs base05. In base16:
+  #   - Dark schemes: base00 is dark (low hex), base05 is light (high hex)
+  #   - Light schemes: base00 is light (high hex), base05 is dark (low hex)
+  isLightPalette =
+    palette:
+    let
+      bg = builtins.substring 1 1 palette.base00; # first hex digit after #
+      fg = builtins.substring 1 1 palette.base05;
+    in
+    (hexToInt bg) > (hexToInt fg);
+
+  # Hex digit lookup (reused from colors.nix pattern)
+  hexToInt =
+    c:
+    {
+      "0" = 0;
+      "1" = 1;
+      "2" = 2;
+      "3" = 3;
+      "4" = 4;
+      "5" = 5;
+      "6" = 6;
+      "7" = 7;
+      "8" = 8;
+      "9" = 9;
+      "a" = 10;
+      "b" = 11;
+      "c" = 12;
+      "d" = 13;
+      "e" = 14;
+      "f" = 15;
+      "A" = 10;
+      "B" = 11;
+      "C" = 12;
+      "D" = 13;
+      "E" = 14;
+      "F" = 15;
+    }
+    .${c} or 0;
+
+  themeFromPalette =
+    palette:
+    let
+      light = isLightPalette palette;
+      # Text on accent fills: need maximum contrast against vivid mid-tones.
+      # Dark themes: base00 (dark background) on bright fills.
+      # Light themes: base07 (dark foreground end) on bright fills.
+      contrastText = if light then palette.base07 else palette.base00;
+    in
+    {
+      inherit palette;
+      background = palette.base00;
+      foreground = palette.base05;
+      mutedForeground = palette.base04;
+      nodeBg = palette.base01;
+      nodeBorder = palette.base04;
+      nodeText = palette.base05;
+      clusterBg = palette.base01;
+      clusterBorder = palette.base03;
+      edgeColor = palette.base04;
+      edgeText = palette.base05;
+      labelBg = palette.base00;
+      rootFill = palette.base0D;
+      rootStroke = palette.base0D;
+      rootText = contrastText;
+      excludedFill = palette.base08;
+      excludedStroke = palette.base08;
+      excludedText = contrastText;
+      replacedFill = palette.base09;
+      replacedStroke = palette.base09;
+      replacedText = contrastText;
+      accentPool = [
+        palette.base08
+        palette.base09
+        palette.base0A
+        palette.base0B
+        palette.base0C
+        palette.base0D
+        palette.base0E
+        palette.base0F
+      ];
+    };
 
   # One-shot helper: scheme name → theme record.
   themeFromBase16 =

--- a/templates/fleet-demo/README.md
+++ b/templates/fleet-demo/README.md
@@ -1,0 +1,559 @@
+# Fleet Demo
+
+A multi-host NixOS fleet managed by den,
+demonstrating environment-based topology, cross-host data sharing, and
+policy-driven user access from a centralized registry.
+
+## What This Builds
+
+Four NixOS hosts across two environments:
+
+| Host | Environment | Role |
+|------|-------------|------|
+| `lb-prod` | prod | HAProxy load balancer — collects backend addresses from peers |
+| `web-prod-1` | prod | Nginx web server — emits backend address for load balancing |
+| `web-prod-2` | prod | Nginx web server — emits backend address for load balancing |
+| `web-staging` | staging | Nginx web server — staging environment |
+
+Each host gets a complete `nixosConfiguration` with networking, service
+config, and user accounts — all derived from the same set of aspects and
+policies.
+
+## Custom Entity Types
+
+Den has built-in entity kinds (host, user), but this demo defines two
+additional entity types entirely in user space — no framework changes
+required.
+
+### Environments
+
+`environments.nix` defines a custom `environment` entity type by setting
+`den.schema.environment.isEntity = true` and creating a typed option
+`fleet.environments` whose submodule imports `den.schema.environment`.
+Each environment carries a `domain-name` and is registered as an instance:
+
+```nix
+fleet.environments = {
+  prod    = { domain-name = "example.com"; };
+  staging = { domain-name = "staging.example.com"; };
+};
+```
+
+The host schema is extended with `environment` and `addr` options via
+`den.schema.host.imports`, so every host declares which environment it
+belongs to.
+
+### Users as Entities
+
+`users.nix` promotes users to real entities (`den.schema.user.isEntity = true`)
+and extends the user schema with `email`, `groups`, and `ssh-keys` options.
+The registry type imports `den.schema.user` so each entry is a proper user
+entity with `userName`, `classes`, and `aspect` — not a plain attrset.
+
+## Policy-Driven Scope Tree
+
+Den's default policies walk `den.hosts` and create host scopes directly
+under `flake-system`. This demo replaces that with a custom scope tree:
+
+```
+flake → fleet → environment → host → user
+```
+
+This is built by a chain of policies in `policies/fleet.nix`, each firing
+at a specific scope level and resolving child entities:
+
+| Policy | Fires at | Resolves | Mechanism |
+|--------|----------|----------|-----------|
+| `to-fleet` | flake | fleet | `resolve.to "fleet"` — creates a single fleet entity |
+| `fleet-to-envs` | fleet | environments | `resolve.to "environment"` — one per `fleet.environments` entry |
+| `env-to-hosts` | environment | hosts | `resolve.to "host"` — filters `den.hosts` by matching `host.environment` |
+| `env-users` | host | users | `resolve.to "user"` — filters `den.users.registry` by environment group grant |
+| `host-users` | host | users | `resolve.to "user"` — filters `den.users.registry` by host-specific group grant |
+
+Each `resolve.to` call creates a named child scope. The entity's context
+bindings (`host`, `user`, `environment`, etc.) are available to all aspects
+and policies that fire within that scope.
+
+### Disabling Default Policies
+
+Den's core provides built-in policies for common patterns. This demo
+disables two of them to take full control of the scope tree:
+
+- **`den.policies.to-os-outputs`** and **`den.policies.to-hm-outputs`** are
+  excluded from `den.schema.flake-system` — the fleet policies handle host
+  instantiation explicitly via `den.lib.policy.instantiate`, so the default
+  per-system output walk is unnecessary.
+
+- **`den.policies.host-to-users`** is excluded from `den.schema.host` — this
+  core policy walks `host.users` (inline user definitions) and resolves them
+  via `resolve.shared`. Since this demo resolves users from the external
+  registry via `resolve.to "user"`, the default policy would be a no-op but
+  is excluded for clarity.
+
+## User Registry and Group-Based Access
+
+Users are defined once in `den.users.registry` with identity metadata:
+
+```nix
+den.users.registry = {
+  alice = {
+    email = "alice@example.com";
+    groups = [ "admin" ];
+    ssh-keys = [ "ssh-ed25519 AAAAC3... alice@workstation" ];
+  };
+  bob = {
+    email = "bob@example.com";
+    groups = [ "deploy" ];
+    ssh-keys = [ "ssh-ed25519 AAAAC3... bob@laptop" ];
+  };
+};
+```
+
+Access is controlled by `fleet.user-access`, which maps group names to
+environments or specific hosts:
+
+```nix
+fleet.user-access.by-environment = {
+  prod    = { groups = [ "admin" ]; };
+  staging = { groups = [ "admin" "deploy" ]; };
+};
+```
+
+The `env-users` policy fires at each host scope, looks up the access
+grant for `host.environment`, and filters the registry for users whose
+`groups` intersect the granted set. Each match becomes a `resolve.to "user"`
+call, creating a user scope on that host.
+
+| User | Groups | Prod (grants admin) | Staging (grants admin + deploy) |
+|------|--------|---------------------|-------------------------------|
+| alice | admin | yes | yes |
+| bob | deploy | no | yes |
+
+The `host-users` policy provides the same mechanism scoped to individual
+hosts via `fleet.user-access.by-host`, allowing per-host overrides on top
+of environment-level grants.
+
+The `ssh-keys` battery fires in every user scope and sets
+`users.users.${user.userName}.openssh.authorizedKeys.keys` from
+`user.ssh-keys`. Because user scopes only exist on hosts where access
+was granted, keys are provisioned exactly where they should be — nowhere
+else.
+
+## Pipes and Cross-Host Data Sharing
+
+Pipes allow sibling hosts within the same environment to share data
+declaratively. They are built on den's quirk system.
+
+### Declaring Pipes
+
+`policies/pipes.nix` declares two quirks as pipes:
+
+```nix
+den.quirks.http-backends = {
+  description = "HTTP backend addresses for load balancer aggregation";
+};
+den.quirks.host-addrs = {
+  description = "Host address entries for /etc/hosts generation";
+};
+```
+
+Each host includes `pipe.collect` policies that gather these quirks
+from all peers in the same environment:
+
+```nix
+den.policies.collect-backends = { host, ... }: [
+  (pipe.from "http-backends" [ (pipe.collect ({ host, ... }: true)) ])
+];
+```
+
+### Emitting and Consuming
+
+Aspects participate in pipes by defining a key matching the quirk name.
+
+**Emitting** — the `nginx` aspect emits an `http-backends` entry:
+
+```nix
+den.aspects.nginx = {
+  nixos = { ... }: { services.nginx.enable = true; /* ... */ };
+  http-backends = { host, ... }: { inherit (host) addr; port = host.httpPort; };
+};
+```
+
+**Consuming** — the `haproxy` aspect receives the collected list:
+
+```nix
+den.aspects.haproxy = {
+  nixos = { http-backends, lib, ... }:
+    let
+      backendLines = lib.imap1 (i: b:
+        "  server backend${toString i} ${b.addr}:${toString b.port} check"
+      ) http-backends;
+    in { /* haproxy config using backendLines */ };
+};
+```
+
+The `http-backends` argument in the haproxy NixOS module is automatically
+populated by `pipe.collect` with entries from all sibling hosts that emit
+the `http-backends` quirk. Adding a new web server host to `prod` automatically
+adds it to haproxy's backend list — no manual wiring.
+
+The same pattern is used for `host-addrs`: every host emits its IP/hostname
+pair, and the `hostfile` aspect collects them to generate `/etc/hosts`.
+
+## Module Layout
+
+```
+modules/
+  den.nix                     — host definitions, defaults, systems
+  environments.nix            — environment entity type + instances (prod, staging)
+  users.nix                   — user registry, schema extension, access mappings
+  policies/
+    fleet.nix                 — scope tree: flake → fleet → env → host → user
+    pipes.nix                 — pipe declarations + collection policies
+  aspects/
+    features/
+      haproxy.nix             — HAProxy config from collected http-backends
+      nginx.nix               — Nginx server + http-backends emission
+      hostfile.nix            — /etc/hosts from collected host-addrs
+    hosts/
+      lb-prod.nix             — includes haproxy + hostfile
+      web-prod-{1,2}.nix      — includes nginx + hostfile
+      web-staging.nix         — includes nginx + hostfile
+    users/
+      ssh-keys.nix            — SSH key provisioning battery
+```
+
+## Usage
+
+Build a host configuration:
+
+```bash
+nix build .#nixosConfigurations.lb-prod.config.system.build.toplevel
+```
+
+Regenerate diagrams:
+
+```bash
+nix run .#write-diagrams
+```
+
+---
+
+# Diagrams
+
+The following visualizations are generated from the fleet's actual
+aspect-resolution pipeline. They show the same topology from different
+angles.
+
+## Legend
+
+| Concept | Description |
+|---------|-------------|
+| **Scope** | A context (node in the scope tree) where aspects and policies evaluate. Scopes inherit parent bindings. |
+| **Policy** | A function that fires at a scope and produces effects: resolving child entities, providing config, or collecting data. |
+| **Aspect** | A reusable unit of configuration. Aspects emit class modules (NixOS, Home Manager) and quirk data. |
+| **Pipe / Quirk** | A data channel between sibling scopes. One aspect emits a quirk, siblings collect it via `pipe.collect`. |
+| **Entity** | A named scope with identity: fleet, environment, host, or user. Created by `resolve.to`. |
+| **Registry** | A typed attrset of entity definitions. `fleet.environments` and `den.users.registry` are registries. |
+| **Battery** | A reusable include that generates per-entity aspect identities (e.g., `define-user`, `ssh-keys`). |
+
+## Scope Topology
+
+The scope tree shows how den organizes entities hierarchically.
+Each node is a scope — a context in which aspects and policies are
+evaluated. Child scopes inherit their parent's context bindings.
+
+In this fleet, the tree is: flake → fleet → environment → host → user.
+Environment and host scopes are created by policies that walk the
+`fleet.environments` and `den.hosts` registries. User scopes are
+created by access policies that match registry users by group membership.
+
+```mermaid
+graph TD
+  environment_prod_fleet_fleet[["environment: prod"]]
+  environment_prod_fleet_fleet_host_lb_prod["host: lb-prod"]
+  environment_prod_fleet_fleet_host_lb_prod_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_1["host: web-prod-1"]
+  environment_prod_fleet_fleet_host_web_prod_1_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_2["host: web-prod-2"]
+  environment_prod_fleet_fleet_host_web_prod_2_user_alice(["user: alice"])
+  environment_staging_fleet_fleet[["environment: staging"]]
+  environment_staging_fleet_fleet_host_web_staging["host: web-staging"]
+  environment_staging_fleet_fleet_host_web_staging_user_alice(["user: alice"])
+  environment_staging_fleet_fleet_host_web_staging_user_bob(["user: bob"])
+  fleet_fleet(["fleet: fleet"])
+  system_x86_64_linux["flake-system: system=x86_64-linux"]
+
+  fleet_fleet --> environment_prod_fleet_fleet
+  environment_prod_fleet_fleet --> environment_prod_fleet_fleet_host_lb_prod
+  environment_prod_fleet_fleet_host_lb_prod --> environment_prod_fleet_fleet_host_lb_prod_user_alice
+  environment_prod_fleet_fleet --> environment_prod_fleet_fleet_host_web_prod_1
+  environment_prod_fleet_fleet_host_web_prod_1 --> environment_prod_fleet_fleet_host_web_prod_1_user_alice
+  environment_prod_fleet_fleet --> environment_prod_fleet_fleet_host_web_prod_2
+  environment_prod_fleet_fleet_host_web_prod_2 --> environment_prod_fleet_fleet_host_web_prod_2_user_alice
+  fleet_fleet --> environment_staging_fleet_fleet
+  environment_staging_fleet_fleet --> environment_staging_fleet_fleet_host_web_staging
+  environment_staging_fleet_fleet_host_web_staging --> environment_staging_fleet_fleet_host_web_staging_user_alice
+  environment_staging_fleet_fleet_host_web_staging --> environment_staging_fleet_fleet_host_web_staging_user_bob
+
+  style environment_prod_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_bob fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style fleet_fleet fill:#218bff,stroke:#218bff,color:#1f2328
+  style system_x86_64_linux fill:#339D9B,stroke:#339D9B,color:#1f2328
+```
+
+## Policy Resolution
+
+Policies are functions that run at each scope and produce effects:
+resolving child entities, providing configuration, or collecting data.
+This diagram shows which policies fire at each scope level and what
+they produce.
+
+The arrows show the resolution chain — how `to-fleet` creates the
+fleet scope, `fleet-to-envs` fans out environments, `env-to-hosts`
+walks hosts, and `env-users`/`host-users` resolve registry users
+onto their granted hosts.
+
+```mermaid
+graph TD
+  environment_prod_fleet_fleet{{"environment: prod"}}
+  environment_prod_fleet_fleet_host_lb_prod["host: lb-prod"]
+  environment_prod_fleet_fleet_host_lb_prod_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_1["host: web-prod-1"]
+  environment_prod_fleet_fleet_host_web_prod_1_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_2["host: web-prod-2"]
+  environment_prod_fleet_fleet_host_web_prod_2_user_alice(["user: alice"])
+  environment_staging_fleet_fleet{{"environment: staging"}}
+  environment_staging_fleet_fleet_host_web_staging["host: web-staging"]
+  environment_staging_fleet_fleet_host_web_staging_user_alice(["user: alice"])
+  environment_staging_fleet_fleet_host_web_staging_user_bob(["user: bob"])
+  fleet_fleet(["fleet: fleet"])
+  system_x86_64_linux["flake-system: system=x86_64-linux"]
+
+  fleet_fleet -->|fleet-to-envs| environment_prod_fleet_fleet
+  environment_prod_fleet_fleet -->|env-to-hosts| environment_prod_fleet_fleet_host_lb_prod
+  environment_prod_fleet_fleet_host_lb_prod -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_prod_fleet_fleet_host_lb_prod_user_alice
+  environment_prod_fleet_fleet -->|env-to-hosts| environment_prod_fleet_fleet_host_web_prod_1
+  environment_prod_fleet_fleet_host_web_prod_1 -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_prod_fleet_fleet_host_web_prod_1_user_alice
+  environment_prod_fleet_fleet -->|env-to-hosts| environment_prod_fleet_fleet_host_web_prod_2
+  environment_prod_fleet_fleet_host_web_prod_2 -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_prod_fleet_fleet_host_web_prod_2_user_alice
+  fleet_fleet -->|fleet-to-envs| environment_staging_fleet_fleet
+  environment_staging_fleet_fleet -->|env-to-hosts| environment_staging_fleet_fleet_host_web_staging
+  environment_staging_fleet_fleet_host_web_staging -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_staging_fleet_fleet_host_web_staging_user_alice
+  environment_staging_fleet_fleet_host_web_staging -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_staging_fleet_fleet_host_web_staging_user_bob
+
+  style environment_prod_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_bob fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style fleet_fleet fill:#218bff,stroke:#218bff,color:#1f2328
+  style system_x86_64_linux fill:#339D9B,stroke:#339D9B,color:#1f2328
+```
+
+## Pipe Flow
+
+Pipes (quirks declared with `pipe.collect`) allow sibling hosts to
+share data. Each host that includes an aspect emitting a quirk
+contributes to a collected dataset available to peers in the same
+environment.
+
+This diagram shows two pipes in the fleet:
+- **http-backends** — nginx aspects emit backend addresses, collected
+  by the haproxy aspect on `lb-prod` to generate load balancer config.
+- **host-addrs** — every host emits its address, collected by the
+  hostfile aspect to generate `/etc/hosts` entries.
+
+```mermaid
+graph LR
+  subgraph env_prod["prod"]
+    lb_prod(["lb-prod (hostfile→host-addrs)"])
+    web_prod_1(["web-prod-1 (nginx→http-backends, hostfile→host-addrs)"])
+    web_prod_2(["web-prod-2 (nginx→http-backends, hostfile→host-addrs)"])
+  end
+  subgraph env_staging["staging"]
+    web_staging(["web-staging (nginx→http-backends, hostfile→host-addrs)"])
+  end
+
+  web_prod_1 -->|http-backends| lb_prod
+  web_prod_2 -->|http-backends| lb_prod
+  web_prod_1 -->|host-addrs| lb_prod
+  web_prod_2 -->|host-addrs| lb_prod
+  lb_prod -->|host-addrs| web_prod_1
+  web_prod_2 -->|host-addrs| web_prod_1
+  lb_prod -->|host-addrs| web_prod_2
+  web_prod_1 -->|host-addrs| web_prod_2
+
+  linkStyle 0 stroke:#fa4549,stroke-width:2px
+  linkStyle 1 stroke:#fa4549,stroke-width:2px
+  linkStyle 2 stroke:#2da44e,stroke-width:2px
+  linkStyle 3 stroke:#2da44e,stroke-width:2px
+  linkStyle 4 stroke:#2da44e,stroke-width:2px
+  linkStyle 5 stroke:#2da44e,stroke-width:2px
+  linkStyle 6 stroke:#2da44e,stroke-width:2px
+  linkStyle 7 stroke:#2da44e,stroke-width:2px
+
+  style lb_prod fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style web_prod_1 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style web_prod_2 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style web_staging fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style env_prod fill:transparent,stroke:#8c959f,stroke-width:1px
+  style env_staging fill:transparent,stroke:#8c959f,stroke-width:1px
+```
+
+## Pipe Sequence
+
+A sequence diagram showing the emit → collect flow for each pipe.
+Each host that participates in a pipe is shown as a lifeline, with
+arrows indicating data flow direction.
+
+> **Note:** The ordering of emitters in this diagram is arbitrary —
+> `pipe.collect` gathers all peer emissions as an unordered list.
+> The sequence is for visualization only; there is no guaranteed
+> evaluation order between sibling hosts.
+
+```mermaid
+sequenceDiagram
+    box prod
+    participant lb_prod as lb-prod
+    participant web_prod_1 as web-prod-1
+    participant web_prod_2 as web-prod-2
+    end
+    box staging
+    participant web_staging as web-staging
+    end
+
+    Note over lb_prod: hostfile → host-addrs
+    Note over web_prod_1: hostfile → host-addrs
+    Note over web_prod_2: hostfile → host-addrs
+    Note over web_staging: hostfile → host-addrs
+    web_prod_1 -->> lb_prod: host-addrs
+    web_prod_2 -->> lb_prod: host-addrs
+    lb_prod -->> web_prod_1: host-addrs
+    web_prod_2 -->> web_prod_1: host-addrs
+    lb_prod -->> web_prod_2: host-addrs
+    web_prod_1 -->> web_prod_2: host-addrs
+
+    Note over web_prod_1: nginx → http-backends
+    Note over web_prod_2: nginx → http-backends
+    Note over web_staging: nginx → http-backends
+    web_prod_1 -->> lb_prod: http-backends
+    web_prod_2 -->> lb_prod: http-backends
+```
+
+## Aspect Namespace
+
+The global registry of all declared aspects and their hierarchy.
+Each node is an aspect — a reusable unit of configuration that can
+be included by hosts or users. Edges show the `includes` relationship:
+`lb-prod` includes `haproxy` and `hostfile`, web servers include
+`nginx` and `hostfile`.
+
+```mermaid
+graph TD
+  aspects([aspects]):::root
+  haproxy["haproxy · shared"]:::haproxy_c
+  hostfile["hostfile · shared"]:::hostfile_c
+  lb_prod["lb-prod · host"]:::lb_prod_c
+  nginx["nginx · shared"]:::nginx_c
+  web_prod_1["web-prod-1 · host"]:::web_prod_1_c
+  web_prod_2["web-prod-2 · host"]:::web_prod_2_c
+  web_staging["web-staging · host"]:::web_staging_c
+
+  aspects --> lb_prod
+  aspects --> web_prod_1
+  aspects --> web_prod_2
+  aspects --> web_staging
+  lb_prod --> haproxy
+  lb_prod --> hostfile
+  web_prod_1 --> nginx
+  web_prod_1 --> hostfile
+  web_prod_2 --> nginx
+  web_prod_2 --> hostfile
+  web_staging --> nginx
+  web_staging --> hostfile
+
+  classDef root fill:#218bff,stroke:#218bff,color:#1f2328,font-weight:bold
+  classDef haproxy_c fill:#e16f24,stroke:#e16f24,color:#1f2328,stroke-width:2px
+  classDef hostfile_c fill:#e16f24,stroke:#e16f24,color:#1f2328,stroke-width:2px
+  classDef lb_prod_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+  classDef nginx_c fill:#e16f24,stroke:#e16f24,color:#1f2328,stroke-width:2px
+  classDef web_prod_1_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+  classDef web_prod_2_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+  classDef web_staging_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+```
+
+## Fleet Summary
+
+A tabular overview of the fleet's resolved topology: environment
+membership, aspect distribution per host, pipe producer/collector
+relationships, and which policies fired during resolution. This is
+the same data the diagrams above visualize, presented as text tables
+for quick reference or machine consumption.
+
+# Fleet Summary
+
+## Topology
+
+- **2** environments, **4** hosts, **5** users
+- Scope chain: flake → flake-system → fleet → user → host → environment
+- Trace entries: 245
+
+## Environments
+
+| Environment | Hosts | Host Count | Users |
+| ------------- | ------- | ------------ | ------- |
+| prod | lb-prod, web-prod-1, web-prod-2 | 3 | 3 |
+| staging | web-staging | 1 | 2 |
+
+## Aspects by Host
+
+| Host | Aspect Count | Aspects |
+| ------ | -------------- | --------- |
+| lb-prod | 5 | haproxy, hostfile, insecure-predicate/os, lb-prod, unfree-predicate/os |
+| web-prod-1 | 5 | hostfile, insecure-predicate/os, nginx, unfree-predicate/os, web-prod-1 |
+| web-prod-2 | 5 | hostfile, insecure-predicate/os, nginx, unfree-predicate/os, web-prod-2 |
+| web-staging | 5 | hostfile, insecure-predicate/os, nginx, unfree-predicate/os, web-staging |
+
+## Pipes
+
+| Pipe | Scope Boundary | Producers | Collectors |
+| ------ | ---------------- | ----------- | ------------ |
+| host-addrs | environment: prod | lb-prod, web-prod-1, web-prod-2 | lb-prod, web-prod-1, web-prod-2 |
+| host-addrs | environment: staging | web-staging | web-staging |
+| http-backends | environment: prod | web-prod-1, web-prod-2 | lb-prod |
+| http-backends | environment: staging | web-staging | web-staging |
+
+## Policies
+
+| Policy | Fires at |
+| -------- | ---------- |
+| to-fleet | flake |
+| to-systems | flake |
+| fleet-to-envs | fleet |
+| env-to-hosts | environment |
+| collect-backends | host |
+| collect-host-addrs | host |
+| env-users | host |
+| os-to-host | host |
+| user-to-host | user |
+| to-apps | flake-system |
+| to-checks | flake-system |
+| to-devShells | flake-system |
+| to-legacyPackages | flake-system |
+| to-packages | flake-system |

--- a/templates/fleet-demo/diagrams/fleet/fleet-ir.json
+++ b/templates/fleet-demo/diagrams/fleet/fleet-ir.json
@@ -1,0 +1,7787 @@
+{
+  "direction": "LR",
+  "edges": [
+    {
+      "crossHost": false,
+      "from": "scope_fleet_fleet",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_prod_fleet_fleet"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_prod_fleet_fleet_host_lb_prod"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet_host_lb_prod",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_prod_fleet_fleet_host_lb_prod_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_1"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_1_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_2"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_2_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_fleet_fleet",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_staging_fleet_fleet"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_staging_fleet_fleet",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_staging_fleet_fleet_host_web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_staging_fleet_fleet_host_web_staging",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_staging_fleet_fleet_host_web_staging_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_staging_fleet_fleet_host_web_staging",
+      "host": null,
+      "label": null,
+      "style": "normal",
+      "to": "scope_environment_staging_fleet_fleet_host_web_staging_user_bob"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet_host_lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__lb_prod"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__web_prod_1"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__web_prod_2"
+    },
+    {
+      "crossHost": false,
+      "from": "scope_environment_staging_fleet_fleet_host_web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__default_host_lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__define_user"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__default_host_lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__hostname"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__default_host_lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__insecure_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__default_host_lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__ssh_keys"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__default_host_lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__unfree_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__den__batteries__define_user",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__define_user__alice_lb_prod"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__den__batteries__define_user",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__host__resolve_define_user__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__den__batteries__hostname",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__hostname__os"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__den__batteries__ssh_keys",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__host__resolve_ssh_keys__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__den__batteries__ssh_keys",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__den__batteries__ssh_keys__alice_lb_prod"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__host",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__default_host_lb_prod"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__host",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__host__resolve_host_"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__host",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__lb_prod"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__insecure_predicate",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__host__resolve_insecure_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__insecure_predicate",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__insecure_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__insecure_predicate",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__insecure_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__haproxy"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__lb_prod",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__hostfile"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__unfree_predicate",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__host__resolve_unfree_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__unfree_predicate",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__unfree_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__unfree_predicate",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__unfree_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__user",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod___self_user_"
+    },
+    {
+      "crossHost": false,
+      "from": "lb_prod__user",
+      "host": "lb-prod",
+      "label": null,
+      "style": "normal",
+      "to": "lb_prod__default_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__default_host_web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__define_user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__default_host_web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__hostname"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__default_host_web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__insecure_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__default_host_web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__ssh_keys"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__default_host_web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__unfree_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__den__batteries__define_user",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__define_user__alice_web_prod_1"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__den__batteries__define_user",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__host__resolve_define_user__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__den__batteries__hostname",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__hostname__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__den__batteries__ssh_keys",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__host__resolve_ssh_keys__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__den__batteries__ssh_keys",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__den__batteries__ssh_keys__alice_web_prod_1"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__host",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__default_host_web_prod_1"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__host",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__host__resolve_host_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__host",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__web_prod_1"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__insecure_predicate",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__host__resolve_insecure_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__insecure_predicate",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__insecure_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__insecure_predicate",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__insecure_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__unfree_predicate",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__host__resolve_unfree_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__unfree_predicate",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__unfree_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__unfree_predicate",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__unfree_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__user",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1___self_user_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__user",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__default_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__hostfile"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_1__web_prod_1",
+      "host": "web-prod-1",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_1__nginx"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__default_host_web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__define_user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__default_host_web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__hostname"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__default_host_web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__insecure_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__default_host_web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__ssh_keys"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__default_host_web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__unfree_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__den__batteries__define_user",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__define_user__alice_web_prod_2"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__den__batteries__define_user",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__host__resolve_define_user__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__den__batteries__hostname",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__hostname__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__den__batteries__ssh_keys",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__host__resolve_ssh_keys__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__den__batteries__ssh_keys",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__den__batteries__ssh_keys__alice_web_prod_2"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__host",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__default_host_web_prod_2"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__host",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__host__resolve_host_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__host",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__web_prod_2"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__insecure_predicate",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__host__resolve_insecure_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__insecure_predicate",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__insecure_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__insecure_predicate",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__insecure_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__unfree_predicate",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__host__resolve_unfree_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__unfree_predicate",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__unfree_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__unfree_predicate",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__unfree_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__user",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2___self_user_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__user",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__default_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__hostfile"
+    },
+    {
+      "crossHost": false,
+      "from": "web_prod_2__web_prod_2",
+      "host": "web-prod-2",
+      "label": null,
+      "style": "normal",
+      "to": "web_prod_2__nginx"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__default_host_web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__define_user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__default_host_web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__hostname"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__default_host_web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__insecure_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__default_host_web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__ssh_keys"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__default_host_web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__unfree_predicate"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__den__batteries__define_user",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__define_user__alice_web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__den__batteries__define_user",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__define_user__bob_web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__den__batteries__define_user",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__host__resolve_define_user__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__den__batteries__hostname",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__hostname__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__den__batteries__ssh_keys",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__host__resolve_ssh_keys__den__batteries"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__den__batteries__ssh_keys",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__ssh_keys__alice_web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__den__batteries__ssh_keys",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__den__batteries__ssh_keys__bob_web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__host",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__default_host_web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__host",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__host__resolve_host_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__host",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__web_staging"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__insecure_predicate",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__host__resolve_insecure_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__insecure_predicate",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__insecure_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__insecure_predicate",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__insecure_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__unfree_predicate",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__host__resolve_unfree_predicate_"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__unfree_predicate",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__unfree_predicate__os"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__unfree_predicate",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__unfree_predicate__user"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__user_user_alice",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging___self_user__user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__user_user_bob",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging___self_user__user_bob"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__user_user_alice",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__default_user_alice"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__user_user_bob",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__default_user_bob"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__hostfile"
+    },
+    {
+      "crossHost": false,
+      "from": "web_staging__web_staging",
+      "host": "web-staging",
+      "label": null,
+      "style": "normal",
+      "to": "web_staging__nginx"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "host": null,
+      "label": "host-addrs",
+      "pipe": "host-addrs",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_lb_prod"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "host": null,
+      "label": "host-addrs",
+      "pipe": "host-addrs",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_lb_prod"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_lb_prod",
+      "host": null,
+      "label": "host-addrs",
+      "pipe": "host-addrs",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_1"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "host": null,
+      "label": "host-addrs",
+      "pipe": "host-addrs",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_1"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_lb_prod",
+      "host": null,
+      "label": "host-addrs",
+      "pipe": "host-addrs",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_2"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "host": null,
+      "label": "host-addrs",
+      "pipe": "host-addrs",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_web_prod_2"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "host": null,
+      "label": "http-backends",
+      "pipe": "http-backends",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_lb_prod"
+    },
+    {
+      "crossHost": true,
+      "from": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "host": null,
+      "label": "http-backends",
+      "pipe": "http-backends",
+      "style": "pipe",
+      "to": "scope_environment_prod_fleet_fleet_host_lb_prod"
+    }
+  ],
+  "entityInstances": [
+    {
+      "id": "scope_environment_prod_fleet_fleet",
+      "kind": "environment",
+      "label": "environment: prod",
+      "name": "prod",
+      "parent": "scope_fleet_fleet",
+      "scopeId": "environment=prod,fleet=fleet"
+    },
+    {
+      "id": "scope_environment_prod_fleet_fleet_host_lb_prod",
+      "kind": "host",
+      "label": "host: lb-prod",
+      "name": "lb-prod",
+      "parent": "scope_environment_prod_fleet_fleet",
+      "scopeId": "environment=prod,fleet=fleet,host=lb-prod"
+    },
+    {
+      "id": "scope_environment_prod_fleet_fleet_host_lb_prod_user_alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "scope_environment_prod_fleet_fleet_host_lb_prod",
+      "scopeId": "environment=prod,fleet=fleet,host=lb-prod,user=alice"
+    },
+    {
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "kind": "host",
+      "label": "host: web-prod-1",
+      "name": "web-prod-1",
+      "parent": "scope_environment_prod_fleet_fleet",
+      "scopeId": "environment=prod,fleet=fleet,host=web-prod-1"
+    },
+    {
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_1_user_alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "scopeId": "environment=prod,fleet=fleet,host=web-prod-1,user=alice"
+    },
+    {
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "kind": "host",
+      "label": "host: web-prod-2",
+      "name": "web-prod-2",
+      "parent": "scope_environment_prod_fleet_fleet",
+      "scopeId": "environment=prod,fleet=fleet,host=web-prod-2"
+    },
+    {
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_2_user_alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "scopeId": "environment=prod,fleet=fleet,host=web-prod-2,user=alice"
+    },
+    {
+      "id": "scope_environment_staging_fleet_fleet",
+      "kind": "environment",
+      "label": "environment: staging",
+      "name": "staging",
+      "parent": "scope_fleet_fleet",
+      "scopeId": "environment=staging,fleet=fleet"
+    },
+    {
+      "id": "scope_environment_staging_fleet_fleet_host_web_staging",
+      "kind": "host",
+      "label": "host: web-staging",
+      "name": "web-staging",
+      "parent": "scope_environment_staging_fleet_fleet",
+      "scopeId": "environment=staging,fleet=fleet,host=web-staging"
+    },
+    {
+      "id": "scope_environment_staging_fleet_fleet_host_web_staging_user_alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "scope_environment_staging_fleet_fleet_host_web_staging",
+      "scopeId": "environment=staging,fleet=fleet,host=web-staging,user=alice"
+    },
+    {
+      "id": "scope_environment_staging_fleet_fleet_host_web_staging_user_bob",
+      "kind": "user",
+      "label": "user: bob",
+      "name": "bob",
+      "parent": "scope_environment_staging_fleet_fleet_host_web_staging",
+      "scopeId": "environment=staging,fleet=fleet,host=web-staging,user=bob"
+    },
+    {
+      "id": "scope_fleet_fleet",
+      "kind": "fleet",
+      "label": "fleet: fleet",
+      "name": "fleet",
+      "parent": null,
+      "scopeId": "fleet=fleet"
+    },
+    {
+      "id": "scope_system_x86_64_linux",
+      "kind": "flake-system",
+      "label": "flake-system: system=x86_64-linux",
+      "name": "system=x86_64-linux",
+      "parent": null,
+      "scopeId": "system=x86_64-linux"
+    }
+  ],
+  "nodes": [
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "environment:prod",
+      "entityKind": "environment",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "environment: prod",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_prod_fleet_fleet",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "environment: prod",
+      "originalId": "environment=prod,fleet=fleet",
+      "pathKey": "environment=prod,fleet=fleet",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=prod,fleet=fleet",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host: lb-prod",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_prod_fleet_fleet_host_lb_prod",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "host: lb-prod",
+      "originalId": "environment=prod,fleet=fleet,host=lb-prod",
+      "pathKey": "environment=prod,fleet=fleet,host=lb-prod",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=prod,fleet=fleet,host=lb-prod",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user: alice",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_prod_fleet_fleet_host_lb_prod_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "user: alice",
+      "originalId": "environment=prod,fleet=fleet,host=lb-prod,user=alice",
+      "pathKey": "environment=prod,fleet=fleet,host=lb-prod,user=alice",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=prod,fleet=fleet,host=lb-prod,user=alice",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host: web-prod-1",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_1",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "host: web-prod-1",
+      "originalId": "environment=prod,fleet=fleet,host=web-prod-1",
+      "pathKey": "environment=prod,fleet=fleet,host=web-prod-1",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=prod,fleet=fleet,host=web-prod-1",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user: alice",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_1_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "user: alice",
+      "originalId": "environment=prod,fleet=fleet,host=web-prod-1,user=alice",
+      "pathKey": "environment=prod,fleet=fleet,host=web-prod-1,user=alice",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=prod,fleet=fleet,host=web-prod-1,user=alice",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host: web-prod-2",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_2",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "host: web-prod-2",
+      "originalId": "environment=prod,fleet=fleet,host=web-prod-2",
+      "pathKey": "environment=prod,fleet=fleet,host=web-prod-2",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=prod,fleet=fleet,host=web-prod-2",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user: alice",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_prod_fleet_fleet_host_web_prod_2_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "user: alice",
+      "originalId": "environment=prod,fleet=fleet,host=web-prod-2,user=alice",
+      "pathKey": "environment=prod,fleet=fleet,host=web-prod-2,user=alice",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=prod,fleet=fleet,host=web-prod-2,user=alice",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "environment:staging",
+      "entityKind": "environment",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "environment: staging",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_staging_fleet_fleet",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "environment: staging",
+      "originalId": "environment=staging,fleet=fleet",
+      "pathKey": "environment=staging,fleet=fleet",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=staging,fleet=fleet",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host: web-staging",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_staging_fleet_fleet_host_web_staging",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "host: web-staging",
+      "originalId": "environment=staging,fleet=fleet,host=web-staging",
+      "pathKey": "environment=staging,fleet=fleet,host=web-staging",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=staging,fleet=fleet,host=web-staging",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user: alice",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_staging_fleet_fleet_host_web_staging_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "user: alice",
+      "originalId": "environment=staging,fleet=fleet,host=web-staging,user=alice",
+      "pathKey": "environment=staging,fleet=fleet,host=web-staging,user=alice",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=staging,fleet=fleet,host=web-staging,user=alice",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:bob",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user: bob",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_environment_staging_fleet_fleet_host_web_staging_user_bob",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "user: bob",
+      "originalId": "environment=staging,fleet=fleet,host=web-staging,user=bob",
+      "pathKey": "environment=staging,fleet=fleet,host=web-staging,user=bob",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "environment=staging,fleet=fleet,host=web-staging,user=bob",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "fleet:fleet",
+      "entityKind": "fleet",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "fleet: fleet",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_fleet_fleet",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "fleet: fleet",
+      "originalId": "fleet=fleet",
+      "pathKey": "fleet=fleet",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "fleet=fleet",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "flake-system:system=x86_64-linux",
+      "entityKind": "flake-system",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "flake-system: system=x86_64-linux",
+      "hasClass": false,
+      "host": null,
+      "id": "scope_system_x86_64_linux",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "isScope": true,
+      "label": "flake-system: system=x86_64-linux",
+      "originalId": "system=x86_64-linux",
+      "pathKey": "system=x86_64-linux",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "system=x86_64-linux",
+      "shape": "rect",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "<self:user>",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod___self_user_",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "<self:user>",
+      "originalId": "_self_user_",
+      "pathKey": "<self:user>",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-backends",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__collect_backends",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-backends",
+      "originalId": "collect_backends",
+      "pathKey": "collect-backends",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-backends",
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-host-addrs",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__collect_host_addrs",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-host-addrs",
+      "originalId": "collect_host_addrs",
+      "pathKey": "collect-host-addrs",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-host-addrs",
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__default_host_lb_prod",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_host_lb_prod",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__default_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_user_alice",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/define-user",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__define_user",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user",
+      "originalId": "den__batteries__define_user",
+      "pathKey": "den/batteries/define-user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/define-user/alice@lb-prod",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__define_user__alice_lb_prod",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user/alice@lb-prod",
+      "originalId": "den__batteries__define_user__alice_lb_prod",
+      "pathKey": "den/batteries/define-user/alice@lb-prod",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "env-users",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__env_users",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "env-users",
+      "originalId": "env_users",
+      "pathKey": "env-users",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "env-users",
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "haproxy",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__haproxy",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "haproxy",
+      "originalId": "haproxy",
+      "pathKey": "haproxy",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__host",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host",
+      "originalId": "host",
+      "pathKey": "host",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(define-user):den/batteries",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__host__resolve_define_user__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(define-user):den/batteries",
+      "originalId": "den__batteries__host__resolve_define_user__den__batteries",
+      "pathKey": "den/batteries/host/resolve(define-user):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(host)",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__host__resolve_host_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(host)",
+      "originalId": "host__resolve_host_",
+      "pathKey": "host/resolve(host)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(insecure-predicate)",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__host__resolve_insecure_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(insecure-predicate)",
+      "originalId": "host__resolve_insecure_predicate_",
+      "pathKey": "host/resolve(insecure-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__host__resolve_ssh_keys__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(ssh-keys):den/batteries",
+      "originalId": "den__batteries__host__resolve_ssh_keys__den__batteries",
+      "pathKey": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(unfree-predicate)",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__host__resolve_unfree_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(unfree-predicate)",
+      "originalId": "host__resolve_unfree_predicate_",
+      "pathKey": "host/resolve(unfree-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "hostfile",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__hostfile",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "hostfile",
+      "originalId": "hostfile",
+      "pathKey": "hostfile",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": [
+          "host-addrs"
+        ]
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/hostname",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__hostname",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname",
+      "originalId": "den__batteries__hostname",
+      "pathKey": "den/batteries/hostname",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/hostname/os",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__hostname__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname/os",
+      "originalId": "den__batteries__hostname__os",
+      "pathKey": "den/batteries/hostname/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "insecure-predicate",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__insecure_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate",
+      "originalId": "insecure_predicate",
+      "pathKey": "insecure-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/os",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__insecure_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/os",
+      "originalId": "insecure_predicate__os",
+      "pathKey": "insecure-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/user",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__insecure_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/user",
+      "originalId": "insecure_predicate__user",
+      "pathKey": "insecure-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "lb-prod",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__lb_prod",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "lb-prod",
+      "originalId": "lb_prod",
+      "pathKey": "lb-prod",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__os_to_host_host_lb_prod",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_host_lb_prod",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__os_to_host_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_user_alice",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__ssh_keys",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys",
+      "originalId": "den__batteries__ssh_keys",
+      "pathKey": "den/batteries/ssh-keys",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys/alice@lb-prod",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__den__batteries__ssh_keys__alice_lb_prod",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys/alice@lb-prod",
+      "originalId": "den__batteries__ssh_keys__alice_lb_prod",
+      "pathKey": "den/batteries/ssh-keys/alice@lb-prod",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "unfree-predicate",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__unfree_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate",
+      "originalId": "unfree_predicate",
+      "pathKey": "unfree-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/os",
+      "hasClass": true,
+      "host": "lb-prod",
+      "id": "lb_prod__unfree_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/os",
+      "originalId": "unfree_predicate__os",
+      "pathKey": "unfree-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:lb-prod",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/user",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__unfree_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/user",
+      "originalId": "unfree_predicate__user",
+      "pathKey": "unfree-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:lb-prod",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__user",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "user",
+      "originalId": "user",
+      "pathKey": "user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "user-to-host",
+      "hasClass": false,
+      "host": "lb-prod",
+      "id": "lb_prod__user_to_host",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "user-to-host",
+      "originalId": "user_to_host",
+      "pathKey": "user-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "user-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "<self:user>",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1___self_user_",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "<self:user>",
+      "originalId": "_self_user_",
+      "pathKey": "<self:user>",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-backends",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__collect_backends",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-backends",
+      "originalId": "collect_backends",
+      "pathKey": "collect-backends",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-backends",
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-host-addrs",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__collect_host_addrs",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-host-addrs",
+      "originalId": "collect_host_addrs",
+      "pathKey": "collect-host-addrs",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-host-addrs",
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__default_host_web_prod_1",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_host_web_prod_1",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__default_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_user_alice",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/define-user",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__define_user",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user",
+      "originalId": "den__batteries__define_user",
+      "pathKey": "den/batteries/define-user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/define-user/alice@web-prod-1",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__define_user__alice_web_prod_1",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user/alice@web-prod-1",
+      "originalId": "den__batteries__define_user__alice_web_prod_1",
+      "pathKey": "den/batteries/define-user/alice@web-prod-1",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "env-users",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__env_users",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "env-users",
+      "originalId": "env_users",
+      "pathKey": "env-users",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "env-users",
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__host",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host",
+      "originalId": "host",
+      "pathKey": "host",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(define-user):den/batteries",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__host__resolve_define_user__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(define-user):den/batteries",
+      "originalId": "den__batteries__host__resolve_define_user__den__batteries",
+      "pathKey": "den/batteries/host/resolve(define-user):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(host)",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__host__resolve_host_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(host)",
+      "originalId": "host__resolve_host_",
+      "pathKey": "host/resolve(host)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(insecure-predicate)",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__host__resolve_insecure_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(insecure-predicate)",
+      "originalId": "host__resolve_insecure_predicate_",
+      "pathKey": "host/resolve(insecure-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__host__resolve_ssh_keys__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(ssh-keys):den/batteries",
+      "originalId": "den__batteries__host__resolve_ssh_keys__den__batteries",
+      "pathKey": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(unfree-predicate)",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__host__resolve_unfree_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(unfree-predicate)",
+      "originalId": "host__resolve_unfree_predicate_",
+      "pathKey": "host/resolve(unfree-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "hostfile",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__hostfile",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "hostfile",
+      "originalId": "hostfile",
+      "pathKey": "hostfile",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": [
+          "host-addrs"
+        ]
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/hostname",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__hostname",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname",
+      "originalId": "den__batteries__hostname",
+      "pathKey": "den/batteries/hostname",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/hostname/os",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__hostname__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname/os",
+      "originalId": "den__batteries__hostname__os",
+      "pathKey": "den/batteries/hostname/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "insecure-predicate",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__insecure_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate",
+      "originalId": "insecure_predicate",
+      "pathKey": "insecure-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/os",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__insecure_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/os",
+      "originalId": "insecure_predicate__os",
+      "pathKey": "insecure-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/user",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__insecure_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/user",
+      "originalId": "insecure_predicate__user",
+      "pathKey": "insecure-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "nginx",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__nginx",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "nginx",
+      "originalId": "nginx",
+      "pathKey": "nginx",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": [
+          "http-backends"
+        ]
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__os_to_host_host_web_prod_1",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_host_web_prod_1",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__os_to_host_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_user_alice",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__ssh_keys",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys",
+      "originalId": "den__batteries__ssh_keys",
+      "pathKey": "den/batteries/ssh-keys",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys/alice@web-prod-1",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__den__batteries__ssh_keys__alice_web_prod_1",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys/alice@web-prod-1",
+      "originalId": "den__batteries__ssh_keys__alice_web_prod_1",
+      "pathKey": "den/batteries/ssh-keys/alice@web-prod-1",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "unfree-predicate",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__unfree_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate",
+      "originalId": "unfree_predicate",
+      "pathKey": "unfree-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/os",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__unfree_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/os",
+      "originalId": "unfree_predicate__os",
+      "pathKey": "unfree-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/user",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__unfree_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/user",
+      "originalId": "unfree_predicate__user",
+      "pathKey": "unfree-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__user",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "user",
+      "originalId": "user",
+      "pathKey": "user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "user-to-host",
+      "hasClass": false,
+      "host": "web-prod-1",
+      "id": "web_prod_1__user_to_host",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "user-to-host",
+      "originalId": "user_to_host",
+      "pathKey": "user-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "user-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-1",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "web-prod-1",
+      "hasClass": true,
+      "host": "web-prod-1",
+      "id": "web_prod_1__web_prod_1",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "web-prod-1",
+      "originalId": "web_prod_1",
+      "pathKey": "web-prod-1",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-1",
+      "shape": "hexagon",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "<self:user>",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2___self_user_",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "<self:user>",
+      "originalId": "_self_user_",
+      "pathKey": "<self:user>",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-backends",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__collect_backends",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-backends",
+      "originalId": "collect_backends",
+      "pathKey": "collect-backends",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-backends",
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-host-addrs",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__collect_host_addrs",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-host-addrs",
+      "originalId": "collect_host_addrs",
+      "pathKey": "collect-host-addrs",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-host-addrs",
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__default_host_web_prod_2",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_host_web_prod_2",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__default_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_user_alice",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/define-user",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__define_user",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user",
+      "originalId": "den__batteries__define_user",
+      "pathKey": "den/batteries/define-user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/define-user/alice@web-prod-2",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__define_user__alice_web_prod_2",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user/alice@web-prod-2",
+      "originalId": "den__batteries__define_user__alice_web_prod_2",
+      "pathKey": "den/batteries/define-user/alice@web-prod-2",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "env-users",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__env_users",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "env-users",
+      "originalId": "env_users",
+      "pathKey": "env-users",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "env-users",
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__host",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host",
+      "originalId": "host",
+      "pathKey": "host",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(define-user):den/batteries",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__host__resolve_define_user__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(define-user):den/batteries",
+      "originalId": "den__batteries__host__resolve_define_user__den__batteries",
+      "pathKey": "den/batteries/host/resolve(define-user):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(host)",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__host__resolve_host_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(host)",
+      "originalId": "host__resolve_host_",
+      "pathKey": "host/resolve(host)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(insecure-predicate)",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__host__resolve_insecure_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(insecure-predicate)",
+      "originalId": "host__resolve_insecure_predicate_",
+      "pathKey": "host/resolve(insecure-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__host__resolve_ssh_keys__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(ssh-keys):den/batteries",
+      "originalId": "den__batteries__host__resolve_ssh_keys__den__batteries",
+      "pathKey": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(unfree-predicate)",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__host__resolve_unfree_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(unfree-predicate)",
+      "originalId": "host__resolve_unfree_predicate_",
+      "pathKey": "host/resolve(unfree-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "hostfile",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__hostfile",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "hostfile",
+      "originalId": "hostfile",
+      "pathKey": "hostfile",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": [
+          "host-addrs"
+        ]
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/hostname",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__hostname",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname",
+      "originalId": "den__batteries__hostname",
+      "pathKey": "den/batteries/hostname",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/hostname/os",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__hostname__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname/os",
+      "originalId": "den__batteries__hostname__os",
+      "pathKey": "den/batteries/hostname/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "insecure-predicate",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__insecure_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate",
+      "originalId": "insecure_predicate",
+      "pathKey": "insecure-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/os",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__insecure_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/os",
+      "originalId": "insecure_predicate__os",
+      "pathKey": "insecure-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/user",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__insecure_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/user",
+      "originalId": "insecure_predicate__user",
+      "pathKey": "insecure-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "nginx",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__nginx",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "nginx",
+      "originalId": "nginx",
+      "pathKey": "nginx",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": [
+          "http-backends"
+        ]
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__os_to_host_host_web_prod_2",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_host_web_prod_2",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__os_to_host_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_user_alice",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__ssh_keys",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys",
+      "originalId": "den__batteries__ssh_keys",
+      "pathKey": "den/batteries/ssh-keys",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys/alice@web-prod-2",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__den__batteries__ssh_keys__alice_web_prod_2",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys/alice@web-prod-2",
+      "originalId": "den__batteries__ssh_keys__alice_web_prod_2",
+      "pathKey": "den/batteries/ssh-keys/alice@web-prod-2",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "unfree-predicate",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__unfree_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate",
+      "originalId": "unfree_predicate",
+      "pathKey": "unfree-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/os",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__unfree_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/os",
+      "originalId": "unfree_predicate__os",
+      "pathKey": "unfree-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/user",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__unfree_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/user",
+      "originalId": "unfree_predicate__user",
+      "pathKey": "unfree-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__user",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "user",
+      "originalId": "user",
+      "pathKey": "user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "user-to-host",
+      "hasClass": false,
+      "host": "web-prod-2",
+      "id": "web_prod_2__user_to_host",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "user-to-host",
+      "originalId": "user_to_host",
+      "pathKey": "user-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "user-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-prod-2",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "web-prod-2",
+      "hasClass": true,
+      "host": "web-prod-2",
+      "id": "web_prod_2__web_prod_2",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "web-prod-2",
+      "originalId": "web_prod_2",
+      "pathKey": "web-prod-2",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-prod-2",
+      "shape": "hexagon",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "<self:user>",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging___self_user__user_alice",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "<self:user>",
+      "originalId": "_self_user__user_alice",
+      "pathKey": "<self:user>",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:bob",
+      "entityKind": "user",
+      "fnArgNames": [
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "<self:user>",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging___self_user__user_bob",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "<self:user>",
+      "originalId": "_self_user__user_bob",
+      "pathKey": "<self:user>",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:bob",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-backends",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__collect_backends",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-backends",
+      "originalId": "collect_backends",
+      "pathKey": "collect-backends",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-backends",
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "collect-host-addrs",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__collect_host_addrs",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "collect-host-addrs",
+      "originalId": "collect_host_addrs",
+      "pathKey": "collect-host-addrs",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "collect-host-addrs",
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__default_host_web_staging",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_host_web_staging",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__default_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_user_alice",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "user:bob",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "default",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__default_user_bob",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "default",
+      "originalId": "default_user_bob",
+      "pathKey": "default",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:bob",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/define-user",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__define_user",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user",
+      "originalId": "den__batteries__define_user",
+      "pathKey": "den/batteries/define-user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/define-user/alice@web-staging",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__define_user__alice_web_staging",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user/alice@web-staging",
+      "originalId": "den__batteries__define_user__alice_web_staging",
+      "pathKey": "den/batteries/define-user/alice@web-staging",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager+nixos",
+      "classes": [
+        "nixos",
+        "homeManager"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/define-user/bob@web-staging",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__define_user__bob_web_staging",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/define-user/bob@web-staging",
+      "originalId": "den__batteries__define_user__bob_web_staging",
+      "pathKey": "den/batteries/define-user/bob@web-staging",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "env-users",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__env_users",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "env-users",
+      "originalId": "env_users",
+      "pathKey": "env-users",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "env-users",
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__host",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host",
+      "originalId": "host",
+      "pathKey": "host",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(define-user):den/batteries",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__host__resolve_define_user__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(define-user):den/batteries",
+      "originalId": "den__batteries__host__resolve_define_user__den__batteries",
+      "pathKey": "den/batteries/host/resolve(define-user):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(host)",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__host__resolve_host_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(host)",
+      "originalId": "host__resolve_host_",
+      "pathKey": "host/resolve(host)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(insecure-predicate)",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__host__resolve_insecure_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(insecure-predicate)",
+      "originalId": "host__resolve_insecure_predicate_",
+      "pathKey": "host/resolve(insecure-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__host__resolve_ssh_keys__den__batteries",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/host/resolve(ssh-keys):den/batteries",
+      "originalId": "den__batteries__host__resolve_ssh_keys__den__batteries",
+      "pathKey": "den/batteries/host/resolve(ssh-keys):den/batteries",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "trapezoid",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "host/resolve(unfree-predicate)",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__host__resolve_unfree_predicate_",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "host/resolve(unfree-predicate)",
+      "originalId": "host__resolve_unfree_predicate_",
+      "pathKey": "host/resolve(unfree-predicate)",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "terminal",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "hostfile",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__hostfile",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "hostfile",
+      "originalId": "hostfile",
+      "pathKey": "hostfile",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": [
+          "host-addrs"
+        ]
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/hostname",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__hostname",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname",
+      "originalId": "den__batteries__hostname",
+      "pathKey": "den/batteries/hostname",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/hostname/os",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__hostname__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/hostname/os",
+      "originalId": "den__batteries__hostname__os",
+      "pathKey": "den/batteries/hostname/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "insecure-predicate",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__insecure_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate",
+      "originalId": "insecure_predicate",
+      "pathKey": "insecure-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/os",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__insecure_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/os",
+      "originalId": "insecure_predicate__os",
+      "pathKey": "insecure-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "insecure-predicate/user",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__insecure_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "insecure-predicate/user",
+      "originalId": "insecure_predicate__user",
+      "pathKey": "insecure-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "nginx",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__nginx",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "nginx",
+      "originalId": "nginx",
+      "pathKey": "nginx",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": [
+          "http-backends"
+        ]
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": "host",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__os_to_host_host_web_staging",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_host_web_staging",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__os_to_host_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_user_alice",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:bob",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "os-to-host",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__os_to_host_user_bob",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "os-to-host",
+      "originalId": "os_to_host_user_bob",
+      "pathKey": "os-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "os-to-host",
+      "providerPath": [],
+      "scope": "user:bob",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__ssh_keys",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys",
+      "originalId": "den__batteries__ssh_keys",
+      "pathKey": "den/batteries/ssh-keys",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "trapezoid",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys/alice@web-staging",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__ssh_keys__alice_web_staging",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys/alice@web-staging",
+      "originalId": "den__batteries__ssh_keys__alice_web_staging",
+      "pathKey": "den/batteries/ssh-keys/alice@web-staging",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "den/batteries/ssh-keys/bob@web-staging",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__den__batteries__ssh_keys__bob_web_staging",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": true,
+      "label": "batteries/ssh-keys/bob@web-staging",
+      "originalId": "den__batteries__ssh_keys__bob_web_staging",
+      "pathKey": "den/batteries/ssh-keys/bob@web-staging",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [
+        "den",
+        "batteries"
+      ],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "unfree-predicate",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__unfree_predicate",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate",
+      "originalId": "unfree_predicate",
+      "pathKey": "unfree-predicate",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/os",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__unfree_predicate__os",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/os",
+      "originalId": "unfree_predicate__os",
+      "pathKey": "unfree-predicate/os",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "homeManager",
+      "classes": [
+        "homeManager"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host",
+        "user"
+      ],
+      "from": null,
+      "fullLabel": "unfree-predicate/user",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__unfree_predicate__user",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "unfree-predicate/user",
+      "originalId": "unfree_predicate__user",
+      "pathKey": "unfree-predicate/user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "default",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__user_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "user",
+      "originalId": "user_user_alice",
+      "pathKey": "user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:bob",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": null,
+      "fullLabel": "user",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__user_user_bob",
+      "isParametric": false,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "user",
+      "originalId": "user_user_bob",
+      "pathKey": "user",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "user:bob",
+      "shape": "rect",
+      "style": "adapter",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:alice",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "user-to-host",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__user_to_host_user_alice",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "user-to-host",
+      "originalId": "user_to_host_user_alice",
+      "pathKey": "user-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "user-to-host",
+      "providerPath": [],
+      "scope": "user:alice",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "",
+      "classes": [],
+      "entityInstance": "user:bob",
+      "entityKind": "user",
+      "fnArgNames": [],
+      "from": "user",
+      "fullLabel": "user-to-host",
+      "hasClass": false,
+      "host": "web-staging",
+      "id": "web_staging__user_to_host_user_bob",
+      "isParametric": false,
+      "isPolicyDispatch": true,
+      "isProvider": false,
+      "label": "user-to-host",
+      "originalId": "user_to_host_user_bob",
+      "pathKey": "user-to-host",
+      "perClass": {},
+      "pipes": {
+        "produces": []
+      },
+      "policyName": "user-to-host",
+      "providerPath": [],
+      "scope": "user:bob",
+      "shape": "rect",
+      "style": "policy",
+      "to": null
+    },
+    {
+      "class": "nixos",
+      "classes": [
+        "nixos"
+      ],
+      "entityInstance": "host:web-staging",
+      "entityKind": "host",
+      "fnArgNames": [
+        "host"
+      ],
+      "from": null,
+      "fullLabel": "web-staging",
+      "hasClass": true,
+      "host": "web-staging",
+      "id": "web_staging__web_staging",
+      "isParametric": true,
+      "isPolicyDispatch": false,
+      "isProvider": false,
+      "label": "web-staging",
+      "originalId": "web_staging",
+      "pathKey": "web-staging",
+      "perClass": {
+        "homeManager": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        },
+        "nixos": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": true,
+          "replacedBy": null
+        },
+        "user": {
+          "excluded": false,
+          "excludedFrom": null,
+          "hasClass": false,
+          "replacedBy": null
+        }
+      },
+      "pipes": {
+        "produces": []
+      },
+      "policyName": null,
+      "providerPath": [],
+      "scope": "host:web-staging",
+      "shape": "hexagon",
+      "style": "adapter",
+      "to": null
+    }
+  ],
+  "pipes": {
+    "host-addrs": {
+      "consumers": [
+        {
+          "hasCollect": true,
+          "host": "lb-prod",
+          "scope": "environment=prod,fleet=fleet,host=lb-prod",
+          "stages": [
+            "collect"
+          ]
+        },
+        {
+          "hasCollect": true,
+          "host": "web-prod-1",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-1",
+          "stages": [
+            "collect"
+          ]
+        },
+        {
+          "hasCollect": true,
+          "host": "web-prod-2",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-2",
+          "stages": [
+            "collect"
+          ]
+        },
+        {
+          "hasCollect": true,
+          "host": "web-staging",
+          "scope": "environment=staging,fleet=fleet,host=web-staging",
+          "stages": [
+            "collect"
+          ]
+        }
+      ],
+      "flows": [
+        {
+          "from": "web-prod-1",
+          "pipeName": "host-addrs",
+          "to": "lb-prod"
+        },
+        {
+          "from": "web-prod-2",
+          "pipeName": "host-addrs",
+          "to": "lb-prod"
+        },
+        {
+          "from": "lb-prod",
+          "pipeName": "host-addrs",
+          "to": "web-prod-1"
+        },
+        {
+          "from": "web-prod-2",
+          "pipeName": "host-addrs",
+          "to": "web-prod-1"
+        },
+        {
+          "from": "lb-prod",
+          "pipeName": "host-addrs",
+          "to": "web-prod-2"
+        },
+        {
+          "from": "web-prod-1",
+          "pipeName": "host-addrs",
+          "to": "web-prod-2"
+        }
+      ],
+      "producers": [
+        {
+          "aspect": "hostfile",
+          "host": "lb-prod",
+          "scope": "environment=prod,fleet=fleet,host=lb-prod"
+        },
+        {
+          "aspect": "hostfile",
+          "host": "web-prod-1",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-1"
+        },
+        {
+          "aspect": "hostfile",
+          "host": "web-prod-2",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-2"
+        },
+        {
+          "aspect": "hostfile",
+          "host": "web-staging",
+          "scope": "environment=staging,fleet=fleet,host=web-staging"
+        }
+      ]
+    },
+    "http-backends": {
+      "consumers": [
+        {
+          "hasCollect": true,
+          "host": "lb-prod",
+          "scope": "environment=prod,fleet=fleet,host=lb-prod",
+          "stages": [
+            "collect"
+          ]
+        },
+        {
+          "hasCollect": true,
+          "host": "web-prod-1",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-1",
+          "stages": [
+            "collect"
+          ]
+        },
+        {
+          "hasCollect": true,
+          "host": "web-prod-2",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-2",
+          "stages": [
+            "collect"
+          ]
+        },
+        {
+          "hasCollect": true,
+          "host": "web-staging",
+          "scope": "environment=staging,fleet=fleet,host=web-staging",
+          "stages": [
+            "collect"
+          ]
+        }
+      ],
+      "flows": [
+        {
+          "from": "web-prod-1",
+          "pipeName": "http-backends",
+          "to": "lb-prod"
+        },
+        {
+          "from": "web-prod-2",
+          "pipeName": "http-backends",
+          "to": "lb-prod"
+        }
+      ],
+      "producers": [
+        {
+          "aspect": "nginx",
+          "host": "web-prod-1",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-1"
+        },
+        {
+          "aspect": "nginx",
+          "host": "web-prod-2",
+          "scope": "environment=prod,fleet=fleet,host=web-prod-2"
+        },
+        {
+          "aspect": "nginx",
+          "host": "web-staging",
+          "scope": "environment=staging,fleet=fleet,host=web-staging"
+        }
+      ]
+    }
+  },
+  "rootName": "fleet",
+  "scopes": [
+    {
+      "children": [
+        "environment=prod,fleet=fleet,host=lb-prod",
+        "environment=prod,fleet=fleet,host=web-prod-1",
+        "environment=prod,fleet=fleet,host=web-prod-2"
+      ],
+      "ctxKeys": [
+        "environment",
+        "fleet"
+      ],
+      "id": "environment=prod,fleet=fleet",
+      "kind": "environment",
+      "label": "environment: prod",
+      "name": "prod",
+      "parent": "fleet=fleet"
+    },
+    {
+      "children": [
+        "environment=prod,fleet=fleet,host=lb-prod,user=alice"
+      ],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host"
+      ],
+      "id": "environment=prod,fleet=fleet,host=lb-prod",
+      "kind": "host",
+      "label": "host: lb-prod",
+      "name": "lb-prod",
+      "parent": "environment=prod,fleet=fleet"
+    },
+    {
+      "children": [],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host",
+        "user"
+      ],
+      "id": "environment=prod,fleet=fleet,host=lb-prod,user=alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "environment=prod,fleet=fleet,host=lb-prod"
+    },
+    {
+      "children": [
+        "environment=prod,fleet=fleet,host=web-prod-1,user=alice"
+      ],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host"
+      ],
+      "id": "environment=prod,fleet=fleet,host=web-prod-1",
+      "kind": "host",
+      "label": "host: web-prod-1",
+      "name": "web-prod-1",
+      "parent": "environment=prod,fleet=fleet"
+    },
+    {
+      "children": [],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host",
+        "user"
+      ],
+      "id": "environment=prod,fleet=fleet,host=web-prod-1,user=alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "environment=prod,fleet=fleet,host=web-prod-1"
+    },
+    {
+      "children": [
+        "environment=prod,fleet=fleet,host=web-prod-2,user=alice"
+      ],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host"
+      ],
+      "id": "environment=prod,fleet=fleet,host=web-prod-2",
+      "kind": "host",
+      "label": "host: web-prod-2",
+      "name": "web-prod-2",
+      "parent": "environment=prod,fleet=fleet"
+    },
+    {
+      "children": [],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host",
+        "user"
+      ],
+      "id": "environment=prod,fleet=fleet,host=web-prod-2,user=alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "environment=prod,fleet=fleet,host=web-prod-2"
+    },
+    {
+      "children": [
+        "environment=staging,fleet=fleet,host=web-staging"
+      ],
+      "ctxKeys": [
+        "environment",
+        "fleet"
+      ],
+      "id": "environment=staging,fleet=fleet",
+      "kind": "environment",
+      "label": "environment: staging",
+      "name": "staging",
+      "parent": "fleet=fleet"
+    },
+    {
+      "children": [
+        "environment=staging,fleet=fleet,host=web-staging,user=alice",
+        "environment=staging,fleet=fleet,host=web-staging,user=bob"
+      ],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host"
+      ],
+      "id": "environment=staging,fleet=fleet,host=web-staging",
+      "kind": "host",
+      "label": "host: web-staging",
+      "name": "web-staging",
+      "parent": "environment=staging,fleet=fleet"
+    },
+    {
+      "children": [],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host",
+        "user"
+      ],
+      "id": "environment=staging,fleet=fleet,host=web-staging,user=alice",
+      "kind": "user",
+      "label": "user: alice",
+      "name": "alice",
+      "parent": "environment=staging,fleet=fleet,host=web-staging"
+    },
+    {
+      "children": [],
+      "ctxKeys": [
+        "environment",
+        "fleet",
+        "host",
+        "user"
+      ],
+      "id": "environment=staging,fleet=fleet,host=web-staging,user=bob",
+      "kind": "user",
+      "label": "user: bob",
+      "name": "bob",
+      "parent": "environment=staging,fleet=fleet,host=web-staging"
+    },
+    {
+      "children": [
+        "environment=prod,fleet=fleet",
+        "environment=staging,fleet=fleet"
+      ],
+      "ctxKeys": [
+        "fleet"
+      ],
+      "id": "fleet=fleet",
+      "kind": "fleet",
+      "label": "fleet: fleet",
+      "name": "fleet",
+      "parent": null
+    },
+    {
+      "children": [],
+      "ctxKeys": [
+        "system"
+      ],
+      "id": "system=x86_64-linux",
+      "kind": "flake-system",
+      "label": "flake-system: system=x86_64-linux",
+      "name": "system=x86_64-linux",
+      "parent": null
+    }
+  ]
+}

--- a/templates/fleet-demo/diagrams/fleet/namespace.md
+++ b/templates/fleet-demo/diagrams/fleet/namespace.md
@@ -1,0 +1,41 @@
+## Aspect Namespace
+
+The global registry of all declared aspects and their hierarchy.
+Each node is an aspect — a reusable unit of configuration that can
+be included by hosts or users. Edges show the `includes` relationship:
+`lb-prod` includes `haproxy` and `hostfile`, web servers include
+`nginx` and `hostfile`.
+
+```mermaid
+graph TD
+  aspects([aspects]):::root
+  haproxy["haproxy · shared"]:::haproxy_c
+  hostfile["hostfile · shared"]:::hostfile_c
+  lb_prod["lb-prod · host"]:::lb_prod_c
+  nginx["nginx · shared"]:::nginx_c
+  web_prod_1["web-prod-1 · host"]:::web_prod_1_c
+  web_prod_2["web-prod-2 · host"]:::web_prod_2_c
+  web_staging["web-staging · host"]:::web_staging_c
+
+  aspects --> lb_prod
+  aspects --> web_prod_1
+  aspects --> web_prod_2
+  aspects --> web_staging
+  lb_prod --> haproxy
+  lb_prod --> hostfile
+  web_prod_1 --> nginx
+  web_prod_1 --> hostfile
+  web_prod_2 --> nginx
+  web_prod_2 --> hostfile
+  web_staging --> nginx
+  web_staging --> hostfile
+
+  classDef root fill:#218bff,stroke:#218bff,color:#1f2328,font-weight:bold
+  classDef haproxy_c fill:#e16f24,stroke:#e16f24,color:#1f2328,stroke-width:2px
+  classDef hostfile_c fill:#e16f24,stroke:#e16f24,color:#1f2328,stroke-width:2px
+  classDef lb_prod_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+  classDef nginx_c fill:#e16f24,stroke:#e16f24,color:#1f2328,stroke-width:2px
+  classDef web_prod_1_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+  classDef web_prod_2_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+  classDef web_staging_c fill:#218bff,stroke:#218bff,color:#1f2328,stroke-width:2px
+```

--- a/templates/fleet-demo/diagrams/fleet/pipe-flow.md
+++ b/templates/fleet-demo/diagrams/fleet/pipe-flow.md
@@ -1,0 +1,49 @@
+## Pipe Flow
+
+Pipes (quirks declared with `pipe.collect`) allow sibling hosts to
+share data. Each host that includes an aspect emitting a quirk
+contributes to a collected dataset available to peers in the same
+environment.
+
+This diagram shows two pipes in the fleet:
+- **http-backends** — nginx aspects emit backend addresses, collected
+  by the haproxy aspect on `lb-prod` to generate load balancer config.
+- **host-addrs** — every host emits its address, collected by the
+  hostfile aspect to generate `/etc/hosts` entries.
+
+```mermaid
+graph LR
+  subgraph env_prod["prod"]
+    lb_prod(["lb-prod (hostfile→host-addrs)"])
+    web_prod_1(["web-prod-1 (nginx→http-backends, hostfile→host-addrs)"])
+    web_prod_2(["web-prod-2 (nginx→http-backends, hostfile→host-addrs)"])
+  end
+  subgraph env_staging["staging"]
+    web_staging(["web-staging (nginx→http-backends, hostfile→host-addrs)"])
+  end
+
+  web_prod_1 -->|http-backends| lb_prod
+  web_prod_2 -->|http-backends| lb_prod
+  web_prod_1 -->|host-addrs| lb_prod
+  web_prod_2 -->|host-addrs| lb_prod
+  lb_prod -->|host-addrs| web_prod_1
+  web_prod_2 -->|host-addrs| web_prod_1
+  lb_prod -->|host-addrs| web_prod_2
+  web_prod_1 -->|host-addrs| web_prod_2
+
+  linkStyle 0 stroke:#fa4549,stroke-width:2px
+  linkStyle 1 stroke:#fa4549,stroke-width:2px
+  linkStyle 2 stroke:#2da44e,stroke-width:2px
+  linkStyle 3 stroke:#2da44e,stroke-width:2px
+  linkStyle 4 stroke:#2da44e,stroke-width:2px
+  linkStyle 5 stroke:#2da44e,stroke-width:2px
+  linkStyle 6 stroke:#2da44e,stroke-width:2px
+  linkStyle 7 stroke:#2da44e,stroke-width:2px
+
+  style lb_prod fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style web_prod_1 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style web_prod_2 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style web_staging fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style env_prod fill:transparent,stroke:#8c959f,stroke-width:1px
+  style env_staging fill:transparent,stroke:#8c959f,stroke-width:1px
+```

--- a/templates/fleet-demo/diagrams/fleet/pipe-sequence.md
+++ b/templates/fleet-demo/diagrams/fleet/pipe-sequence.md
@@ -1,0 +1,39 @@
+## Pipe Sequence
+
+A sequence diagram showing the emit → collect flow for each pipe.
+Each host that participates in a pipe is shown as a lifeline, with
+arrows indicating data flow direction.
+
+> **Note:** The ordering of emitters in this diagram is arbitrary —
+> `pipe.collect` gathers all peer emissions as an unordered list.
+> The sequence is for visualization only; there is no guaranteed
+> evaluation order between sibling hosts.
+
+```mermaid
+sequenceDiagram
+    box prod
+    participant lb_prod as lb-prod
+    participant web_prod_1 as web-prod-1
+    participant web_prod_2 as web-prod-2
+    end
+    box staging
+    participant web_staging as web-staging
+    end
+
+    Note over lb_prod: hostfile → host-addrs
+    Note over web_prod_1: hostfile → host-addrs
+    Note over web_prod_2: hostfile → host-addrs
+    Note over web_staging: hostfile → host-addrs
+    web_prod_1 -->> lb_prod: host-addrs
+    web_prod_2 -->> lb_prod: host-addrs
+    lb_prod -->> web_prod_1: host-addrs
+    web_prod_2 -->> web_prod_1: host-addrs
+    lb_prod -->> web_prod_2: host-addrs
+    web_prod_1 -->> web_prod_2: host-addrs
+
+    Note over web_prod_1: nginx → http-backends
+    Note over web_prod_2: nginx → http-backends
+    Note over web_staging: nginx → http-backends
+    web_prod_1 -->> lb_prod: http-backends
+    web_prod_2 -->> lb_prod: http-backends
+```

--- a/templates/fleet-demo/diagrams/fleet/policy-resolution.md
+++ b/templates/fleet-demo/diagrams/fleet/policy-resolution.md
@@ -1,0 +1,54 @@
+## Policy Resolution
+
+Policies are functions that run at each scope and produce effects:
+resolving child entities, providing configuration, or collecting data.
+This diagram shows which policies fire at each scope level and what
+they produce.
+
+The arrows show the resolution chain — how `to-fleet` creates the
+fleet scope, `fleet-to-envs` fans out environments, `env-to-hosts`
+walks hosts, and `env-users`/`host-users` resolve registry users
+onto their granted hosts.
+
+```mermaid
+graph TD
+  environment_prod_fleet_fleet{{"environment: prod"}}
+  environment_prod_fleet_fleet_host_lb_prod["host: lb-prod"]
+  environment_prod_fleet_fleet_host_lb_prod_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_1["host: web-prod-1"]
+  environment_prod_fleet_fleet_host_web_prod_1_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_2["host: web-prod-2"]
+  environment_prod_fleet_fleet_host_web_prod_2_user_alice(["user: alice"])
+  environment_staging_fleet_fleet{{"environment: staging"}}
+  environment_staging_fleet_fleet_host_web_staging["host: web-staging"]
+  environment_staging_fleet_fleet_host_web_staging_user_alice(["user: alice"])
+  environment_staging_fleet_fleet_host_web_staging_user_bob(["user: bob"])
+  fleet_fleet(["fleet: fleet"])
+  system_x86_64_linux["flake-system: system=x86_64-linux"]
+
+  fleet_fleet -->|fleet-to-envs| environment_prod_fleet_fleet
+  environment_prod_fleet_fleet -->|env-to-hosts| environment_prod_fleet_fleet_host_lb_prod
+  environment_prod_fleet_fleet_host_lb_prod -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_prod_fleet_fleet_host_lb_prod_user_alice
+  environment_prod_fleet_fleet -->|env-to-hosts| environment_prod_fleet_fleet_host_web_prod_1
+  environment_prod_fleet_fleet_host_web_prod_1 -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_prod_fleet_fleet_host_web_prod_1_user_alice
+  environment_prod_fleet_fleet -->|env-to-hosts| environment_prod_fleet_fleet_host_web_prod_2
+  environment_prod_fleet_fleet_host_web_prod_2 -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_prod_fleet_fleet_host_web_prod_2_user_alice
+  fleet_fleet -->|fleet-to-envs| environment_staging_fleet_fleet
+  environment_staging_fleet_fleet -->|env-to-hosts| environment_staging_fleet_fleet_host_web_staging
+  environment_staging_fleet_fleet_host_web_staging -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_staging_fleet_fleet_host_web_staging_user_alice
+  environment_staging_fleet_fleet_host_web_staging -->|collect-backends, collect-host-addrs, env-users, os-to-host| environment_staging_fleet_fleet_host_web_staging_user_bob
+
+  style environment_prod_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_bob fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style fleet_fleet fill:#218bff,stroke:#218bff,color:#1f2328
+  style system_x86_64_linux fill:#339D9B,stroke:#339D9B,color:#1f2328
+```

--- a/templates/fleet-demo/diagrams/fleet/scope-topology.md
+++ b/templates/fleet-demo/diagrams/fleet/scope-topology.md
@@ -1,0 +1,53 @@
+## Scope Topology
+
+The scope tree shows how den organizes entities hierarchically.
+Each node is a scope — a context in which aspects and policies are
+evaluated. Child scopes inherit their parent's context bindings.
+
+In this fleet, the tree is: flake → fleet → environment → host → user.
+Environment and host scopes are created by policies that walk the
+`fleet.environments` and `den.hosts` registries. User scopes are
+created by access policies that match registry users by group membership.
+
+```mermaid
+graph TD
+  environment_prod_fleet_fleet[["environment: prod"]]
+  environment_prod_fleet_fleet_host_lb_prod["host: lb-prod"]
+  environment_prod_fleet_fleet_host_lb_prod_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_1["host: web-prod-1"]
+  environment_prod_fleet_fleet_host_web_prod_1_user_alice(["user: alice"])
+  environment_prod_fleet_fleet_host_web_prod_2["host: web-prod-2"]
+  environment_prod_fleet_fleet_host_web_prod_2_user_alice(["user: alice"])
+  environment_staging_fleet_fleet[["environment: staging"]]
+  environment_staging_fleet_fleet_host_web_staging["host: web-staging"]
+  environment_staging_fleet_fleet_host_web_staging_user_alice(["user: alice"])
+  environment_staging_fleet_fleet_host_web_staging_user_bob(["user: bob"])
+  fleet_fleet(["fleet: fleet"])
+  system_x86_64_linux["flake-system: system=x86_64-linux"]
+
+  fleet_fleet --> environment_prod_fleet_fleet
+  environment_prod_fleet_fleet --> environment_prod_fleet_fleet_host_lb_prod
+  environment_prod_fleet_fleet_host_lb_prod --> environment_prod_fleet_fleet_host_lb_prod_user_alice
+  environment_prod_fleet_fleet --> environment_prod_fleet_fleet_host_web_prod_1
+  environment_prod_fleet_fleet_host_web_prod_1 --> environment_prod_fleet_fleet_host_web_prod_1_user_alice
+  environment_prod_fleet_fleet --> environment_prod_fleet_fleet_host_web_prod_2
+  environment_prod_fleet_fleet_host_web_prod_2 --> environment_prod_fleet_fleet_host_web_prod_2_user_alice
+  fleet_fleet --> environment_staging_fleet_fleet
+  environment_staging_fleet_fleet --> environment_staging_fleet_fleet_host_web_staging
+  environment_staging_fleet_fleet_host_web_staging --> environment_staging_fleet_fleet_host_web_staging_user_alice
+  environment_staging_fleet_fleet_host_web_staging --> environment_staging_fleet_fleet_host_web_staging_user_bob
+
+  style environment_prod_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_lb_prod_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_1_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2 fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_prod_fleet_fleet_host_web_prod_2_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet fill:#a475f9,stroke:#a475f9,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging fill:#2da44e,stroke:#2da44e,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_alice fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style environment_staging_fleet_fleet_host_web_staging_user_bob fill:#e16f24,stroke:#e16f24,color:#1f2328
+  style fleet_fleet fill:#218bff,stroke:#218bff,color:#1f2328
+  style system_x86_64_linux fill:#339D9B,stroke:#339D9B,color:#1f2328
+```

--- a/templates/fleet-demo/diagrams/fleet/summary.md
+++ b/templates/fleet-demo/diagrams/fleet/summary.md
@@ -1,0 +1,59 @@
+## Fleet Summary
+
+A tabular overview of the fleet's resolved topology: environment
+membership, aspect distribution per host, pipe producer/collector
+relationships, and which policies fired during resolution. This is
+the same data the diagrams above visualize, presented as text tables
+for quick reference or machine consumption.
+
+# Fleet Summary
+
+## Topology
+
+- **2** environments, **4** hosts, **5** users
+- Scope chain: flake → flake-system → fleet → user → host → environment
+- Trace entries: 245
+
+## Environments
+
+| Environment | Hosts | Host Count | Users |
+| ------------- | ------- | ------------ | ------- |
+| prod | lb-prod, web-prod-1, web-prod-2 | 3 | 3 |
+| staging | web-staging | 1 | 2 |
+
+## Aspects by Host
+
+| Host | Aspect Count | Aspects |
+| ------ | -------------- | --------- |
+| lb-prod | 5 | haproxy, hostfile, insecure-predicate/os, lb-prod, unfree-predicate/os |
+| web-prod-1 | 5 | hostfile, insecure-predicate/os, nginx, unfree-predicate/os, web-prod-1 |
+| web-prod-2 | 5 | hostfile, insecure-predicate/os, nginx, unfree-predicate/os, web-prod-2 |
+| web-staging | 5 | hostfile, insecure-predicate/os, nginx, unfree-predicate/os, web-staging |
+
+## Pipes
+
+| Pipe | Scope Boundary | Producers | Collectors |
+| ------ | ---------------- | ----------- | ------------ |
+| host-addrs | environment: prod | lb-prod, web-prod-1, web-prod-2 | lb-prod, web-prod-1, web-prod-2 |
+| host-addrs | environment: staging | web-staging | web-staging |
+| http-backends | environment: prod | web-prod-1, web-prod-2 | lb-prod |
+| http-backends | environment: staging | web-staging | web-staging |
+
+## Policies
+
+| Policy | Fires at |
+| -------- | ---------- |
+| to-fleet | flake |
+| to-systems | flake |
+| fleet-to-envs | fleet |
+| env-to-hosts | environment |
+| collect-backends | host |
+| collect-host-addrs | host |
+| env-users | host |
+| os-to-host | host |
+| user-to-host | user |
+| to-apps | flake-system |
+| to-checks | flake-system |
+| to-devShells | flake-system |
+| to-legacyPackages | flake-system |
+| to-packages | flake-system |

--- a/templates/fleet-demo/modules/aspects/users/deploy.nix
+++ b/templates/fleet-demo/modules/aspects/users/deploy.nix
@@ -1,7 +1,0 @@
-# deploy: service account user present on all hosts.
-{ ... }:
-{
-  den.aspects.deploy = {
-    homeManager.home.stateVersion = "25.11";
-  };
-}

--- a/templates/fleet-demo/modules/aspects/users/ssh-keys.nix
+++ b/templates/fleet-demo/modules/aspects/users/ssh-keys.nix
@@ -3,13 +3,21 @@
 # Reads user.ssh-keys from the registry-sourced user entity and sets
 # openssh.authorizedKeys.keys on the corresponding OS user.
 # Only fires in user scope — keys land only on hosts where policies granted access.
+#
+# Structured as a battery (like define-user) so that each user gets a
+# unique aspect identity, preventing cross-user dedup in the pipeline.
 { ... }:
 {
   den.aspects.ssh-keys = {
-    nixos =
-      { user, ... }:
-      {
-        users.users.${user.userName}.openssh.authorizedKeys.keys = user.ssh-keys;
-      };
+    description = "Provision authorized SSH keys from user registry";
+    includes = [
+      (
+        { host, user }:
+        {
+          name = "ssh-keys/${user.userName}@${host.name}";
+          nixos.users.users.${user.userName}.openssh.authorizedKeys.keys = user.ssh-keys;
+        }
+      )
+    ];
   };
 }

--- a/templates/fleet-demo/modules/aspects/users/ssh-keys.nix
+++ b/templates/fleet-demo/modules/aspects/users/ssh-keys.nix
@@ -1,0 +1,15 @@
+# ssh-keys: provision authorized SSH keys for users.
+#
+# Reads user.ssh-keys from the registry-sourced user entity and sets
+# openssh.authorizedKeys.keys on the corresponding OS user.
+# Only fires in user scope — keys land only on hosts where policies granted access.
+{ ... }:
+{
+  den.aspects.ssh-keys = {
+    nixos =
+      { user, ... }:
+      {
+        users.users.${user.userName}.openssh.authorizedKeys.keys = user.ssh-keys;
+      };
+  };
+}

--- a/templates/fleet-demo/modules/den.nix
+++ b/templates/fleet-demo/modules/den.nix
@@ -1,16 +1,19 @@
-# Fleet topology: two environments, four hosts, haproxy + web backends.
+# Fleet topology: two environments, four hosts, policy-driven user access.
 #
 # Scope tree:
 #   flake
-#   +-- flake-system (x86_64-linux)
-#   |   +-- [packages, checks, devShells — kept]
 #   +-- fleet
 #       +-- environment:prod
 #       |   +-- host:lb-prod
+#       |   |   +-- user:alice  (via prod/admin)
 #       |   +-- host:web-prod-1
+#       |   |   +-- user:alice  (via prod/admin)
 #       |   +-- host:web-prod-2
+#       |       +-- user:alice  (via prod/admin)
 #       +-- environment:staging
 #           +-- host:web-staging
+#               +-- user:alice  (via staging/admin)
+#               +-- user:bob    (via staging/deploy)
 { lib, den, ... }:
 {
   den.schema.user.classes = lib.mkDefault [ "homeManager" ];
@@ -26,22 +29,18 @@
     lb-prod = {
       environment = "prod";
       addr = "10.0.1.1";
-      users.deploy = { };
     };
     web-prod-1 = {
       environment = "prod";
       addr = "10.0.1.10";
-      users.deploy = { };
     };
     web-prod-2 = {
       environment = "prod";
       addr = "10.0.1.11";
-      users.deploy = { };
     };
     web-staging = {
       environment = "staging";
       addr = "10.0.2.10";
-      users.deploy = { };
     };
   };
 
@@ -53,6 +52,7 @@
   den.default.includes = [
     den.batteries.define-user
     den.batteries.hostname
+    den.aspects.ssh-keys
   ];
 
   den.systems = [ "x86_64-linux" ];

--- a/templates/fleet-demo/modules/diagrams.nix
+++ b/templates/fleet-demo/modules/diagrams.nix
@@ -1,12 +1,9 @@
-# Aspect resolution diagrams for fleet-demo.
+# Fleet-level diagrams for fleet-demo.
 #
-# Renders views for hosts, users, and the fleet into organized
-# subdirectories under diagrams/:
-#
-#   diagrams/
-#     hosts/<host>/              — per-host views + DAG
-#     hosts/<host>/users/<user>/ — per-user views
-#     fleet/                     — fleet-wide views
+# Produces a README.md with an organic description of the demo template
+# followed by an inline gallery of fleet-wide mermaid diagrams: scope
+# topology, policy resolution, pipe flow, pipe sequence, and aspect
+# namespace. Individual view files are also written under diagrams/fleet/.
 {
   den,
   lib,
@@ -14,305 +11,483 @@
 }:
 let
   inherit (den.lib) diag;
-
   allHosts = lib.concatMap builtins.attrValues (builtins.attrValues den.hosts);
-
-  themeScheme = "catppuccin-mocha";
-
 in
 {
   perSystem =
     { pkgs, ... }:
     let
-      theme = diag.themeFromBase16 {
-        inherit pkgs;
-        scheme = themeScheme;
-      };
-
-      # Patched mermaid-cli: swap bundled mermaid for 11.14.0.
-      mermaidCliPatched = pkgs.mermaid-cli.overrideAttrs (old: {
-        postInstall = (old.postInstall or "") + ''
-          mermaid_dir="$out/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/mermaid"
-          if [ ! -d "$mermaid_dir" ]; then
-            echo "mermaidCliPatched: expected $mermaid_dir to exist." >&2
-            exit 1
-          fi
-          rm -rf "$mermaid_dir"
-          mkdir -p "$mermaid_dir"
-          ${pkgs.gnutar}/bin/tar -xzf ${
-            pkgs.fetchurl {
-              url = "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz";
-              hash = "sha256-Y7oGZJ4X4Q/uAuVMfC7az+JQtLvds8JJfwDToypC5cc=";
-            }
-          } -C "$mermaid_dir" --strip-components=1
-        '';
-      });
-
-      rc = diag.renderContext {
-        inherit pkgs theme;
-        mermaidCli = mermaidCliPatched;
-        mermaidConfig = {
-          layout = "elk";
-          elk = {
-            mergeEdges = true;
-            nodePlacementStrategy = "BRANDES_KOEPF";
-          };
-          flowchart = {
-            wrappingWidth = 600;
-          };
-        };
-      };
-
+      rc = diag.renderContext { inherit pkgs; };
+      fleetCapture = diag.captureFleet { };
       fleetData = diag.fleet.of { flakeName = "fleet-demo"; };
 
-      renderUsers = true;
-
-      hostViewDefs = classes: rc.views.host ++ rc.views.classViews classes;
-      userViewDefs = classes: rc.views.user ++ rc.views.classViews classes;
-      fleetViewDefs = rc.views.fleet;
-
-      inherit (diag.export)
-        entityEntries
-        filterByRender
-        mkGallery
-        mkWriteScript
-        entriesToPackages
-        entriesToFiles
-        ;
-
-      graphClasses = entity: lib.unique (lib.concatMap (n: n.classes or [ ]) entity.nodes);
-
-      # --- Host entries ---
-
-      hostEntries = lib.concatMap (
-        host:
+      # Strip %%{init: ...}%% frontmatter from mermaid source.
+      # Produces clean diagrams that use the renderer's default theme
+      # (e.g., GitHub's built-in mermaid styling when viewed on github.com).
+      stripFrontmatter =
+        source:
         let
-          entity = diag.hostContext { inherit host; };
+          lines = lib.splitString "\n" source;
+          body = builtins.filter (l: !(lib.hasPrefix "%%{init:" l)) lines;
         in
-        entityEntries { inherit pkgs rc diag; } {
-          inherit entity;
-          name = host.name;
-          dir = "hosts/${host.name}";
-          viewDefs = hostViewDefs (graphClasses entity);
-        }
-      ) allHosts;
+        lib.concatStringsSep "\n" body;
 
-      # --- User entries ---
+      # --- Diagram sections ---
 
-      allUsers = lib.concatMap (
-        host:
-        lib.mapAttrsToList (userName: user: {
-          inherit host user userName;
-          name = "${host.name}-${userName}";
-        }) (host.users or { })
-      ) allHosts;
-
-      filteredUsers = filterByRender {
-        all = allUsers;
-        renderList = renderUsers;
-        getKey = u: u.userName;
-      };
-
-      userEntries = lib.concatMap (
-        u:
+      scopeTopologySection =
         let
-          entity = diag.userContext { inherit (u) host user; };
+          source = stripFrontmatter (rc.render.toScopeTopologyMermaid fleetCapture);
         in
-        entityEntries { inherit pkgs rc diag; } {
-          inherit entity;
-          name = u.userName;
-          dir = "hosts/${u.host.name}/users/${u.userName}";
-          viewDefs = userViewDefs (graphClasses entity);
-        }
-      ) filteredUsers;
+        ''
+          ## Scope Topology
 
-      # --- Fleet entries ---
+          The scope tree shows how den organizes entities hierarchically.
+          Each node is a scope — a context in which aspects and policies are
+          evaluated. Child scopes inherit their parent's context bindings.
 
-      fleetEntriesList = diag.export.fleetEntries { inherit pkgs; } {
-        inherit fleetData;
-        viewDefs = fleetViewDefs;
-      };
+          In this fleet, the tree is: flake → fleet → environment → host → user.
+          Environment and host scopes are created by policies that walk the
+          `fleet.environments` and `den.hosts` registries. User scopes are
+          created by access policies that match registry users by group membership.
 
-      # --- Pipe flow entries ---
+          ```mermaid
+          ${source}
+          ```
+        '';
 
-      mkFleetEntries = viewName: view: [
-        {
-          name = "fleet";
-          view = viewName;
-          dir = "fleet";
-          ext = "md";
-          tool = null;
-          drv = view.md;
-        }
-        {
-          name = "fleet";
-          view = viewName;
-          dir = "fleet";
-          ext = "svg";
-          tool = "mmd";
-          drv = view.svg;
-        }
-      ];
+      policyResolutionSection =
+        let
+          source = stripFrontmatter (rc.render.toPolicyResolutionMapMermaid fleetCapture);
+        in
+        ''
+          ## Policy Resolution
 
-      # Text summary entries (markdown only, no SVG).
-      mkTextEntry = name: dir: drv: {
-        inherit name dir drv;
-        view = "summary";
+          Policies are functions that run at each scope and produce effects:
+          resolving child entities, providing configuration, or collecting data.
+          This diagram shows which policies fire at each scope level and what
+          they produce.
+
+          The arrows show the resolution chain — how `to-fleet` creates the
+          fleet scope, `fleet-to-envs` fans out environments, `env-to-hosts`
+          walks hosts, and `env-users`/`host-users` resolve registry users
+          onto their granted hosts.
+
+          ```mermaid
+          ${source}
+          ```
+        '';
+
+      pipeFlowSection =
+        let
+          source = stripFrontmatter (rc.render.toPipeFlowMermaid fleetCapture);
+        in
+        ''
+          ## Pipe Flow
+
+          Pipes (quirks declared with `pipe.collect`) allow sibling hosts to
+          share data. Each host that includes an aspect emitting a quirk
+          contributes to a collected dataset available to peers in the same
+          environment.
+
+          This diagram shows two pipes in the fleet:
+          - **http-backends** — nginx aspects emit backend addresses, collected
+            by the haproxy aspect on `lb-prod` to generate load balancer config.
+          - **host-addrs** — every host emits its address, collected by the
+            hostfile aspect to generate `/etc/hosts` entries.
+
+          ```mermaid
+          ${source}
+          ```
+        '';
+
+      pipeSequenceSection =
+        let
+          source = stripFrontmatter (rc.render.toPipeSequenceMermaid fleetCapture);
+        in
+        ''
+          ## Pipe Sequence
+
+          A sequence diagram showing the emit → collect flow for each pipe.
+          Each host that participates in a pipe is shown as a lifeline, with
+          arrows indicating data flow direction.
+
+          > **Note:** The ordering of emitters in this diagram is arbitrary —
+          > `pipe.collect` gathers all peer emissions as an unordered list.
+          > The sequence is for visualization only; there is no guaranteed
+          > evaluation order between sibling hosts.
+
+          ```mermaid
+          ${source}
+          ```
+        '';
+
+      namespaceSection =
+        let
+          # Fleet-demo doesn't use WSL — filter out battery-injected aspects
+          # that aren't relevant to this template's topology.
+          namespaceGraph = diag.graph.ofNamespace {
+            filter = v: v.name != "wsl-host-aspect";
+          };
+          source = stripFrontmatter (rc.renderDense.toMermaid namespaceGraph);
+        in
+        ''
+          ## Aspect Namespace
+
+          The global registry of all declared aspects and their hierarchy.
+          Each node is an aspect — a reusable unit of configuration that can
+          be included by hosts or users. Edges show the `includes` relationship:
+          `lb-prod` includes `haproxy` and `hostfile`, web servers include
+          `nginx` and `hostfile`.
+
+          ```mermaid
+          ${source}
+          ```
+        '';
+
+      legendSection = ''
+        ## Legend
+
+        | Concept | Description |
+        |---------|-------------|
+        | **Scope** | A context (node in the scope tree) where aspects and policies evaluate. Scopes inherit parent bindings. |
+        | **Policy** | A function that fires at a scope and produces effects: resolving child entities, providing config, or collecting data. |
+        | **Aspect** | A reusable unit of configuration. Aspects emit class modules (NixOS, Home Manager) and quirk data. |
+        | **Pipe / Quirk** | A data channel between sibling scopes. One aspect emits a quirk, siblings collect it via `pipe.collect`. |
+        | **Entity** | A named scope with identity: fleet, environment, host, or user. Created by `resolve.to`. |
+        | **Registry** | A typed attrset of entity definitions. `fleet.environments` and `den.users.registry` are registries. |
+        | **Battery** | A reusable include that generates per-entity aspect identities (e.g., `define-user`, `ssh-keys`). |
+      '';
+
+      # --- Fleet summary (tabular text view) ---
+
+      fleetSummarySection =
+        let
+          summaryText = diag.text.fleetSummary fleetCapture;
+        in
+        ''
+          ## Fleet Summary
+
+          A tabular overview of the fleet's resolved topology: environment
+          membership, aspect distribution per host, pipe producer/collector
+          relationships, and which policies fired during resolution. This is
+          the same data the diagrams above visualize, presented as text tables
+          for quick reference or machine consumption.
+
+          ${summaryText}
+        '';
+
+      # --- Individual view files (diagrams/fleet/) ---
+
+      mkViewFile = name: content: {
+        name = "fleet";
+        view = name;
+        dir = "fleet";
         ext = "md";
         tool = null;
+        drv = pkgs.writeText "${name}.md" content;
       };
 
-      textEntries = [
-        (mkTextEntry "fleet" "fleet" fleetSummaryDrv)
-      ]
-      ++ map (
-        host: mkTextEntry host.name "hosts/${host.name}" hostSummaryDrvs."${host.name}-summary"
-      ) allHosts;
+      # --- IR (machine-readable) ---
 
-      fleetViewEntries =
-        mkFleetEntries "pipe-flow" pipeFlowView
-        ++ mkFleetEntries "scope-topology" scopeTopoView
-        ++ mkFleetEntries "aspect-matrix" aspectMatrixView
-        ++ mkFleetEntries "policy-resolution" policyMapView
-        ++ mkFleetEntries "pipe-sequence" pipeSeqView
-        ++ mkFleetEntries "fleet-dag" fleetDagView
-        ++ [
-          {
-            name = "fleet";
-            view = "fleet-ir";
-            dir = "fleet";
-            ext = "json";
-            tool = null;
-            drv = fleetIrDrv;
-          }
-        ];
-
-      # --- Assembly ---
-
-      everyEntry = hostEntries ++ userEntries ++ fleetEntriesList ++ fleetViewEntries ++ textEntries;
-      allPackages = entriesToPackages everyEntry;
-
-      # --- Galleries ---
-
-      hostGalleries = map (host: {
-        path = "diagrams/hosts/${host.name}.md";
-        drv = mkGallery pkgs {
-          name = host.name;
-          dir = "hosts/${host.name}";
-          title = "Gallery: ${host.name}";
-          entries = everyEntry;
-        };
-      }) allHosts;
-
-      fleetGallery = {
-        path = "diagrams/fleet.md";
-        drv = mkGallery pkgs {
-          name = "fleet";
-          dir = "fleet";
-          title = "Fleet Gallery";
-          entries = everyEntry;
-        };
-      };
-
-      galleries = hostGalleries ++ [ fleetGallery ];
-
-      # --- Fleet-level views from captureFleet ---
-      fleetCapture = diag.captureFleet { };
-
-      # Per-host graph IRs for fleet DAG composition.
       hostGraphs = lib.listToAttrs (
         map (host: {
           name = host.name;
           value = diag.hostContext { inherit host; };
         }) allHosts
       );
-
-      mkFleetView =
-        name: title: renderFn:
-        let
-          source = renderFn fleetCapture;
-          md = pkgs.writeText "${name}.md" "# ${title}\n\n![${title}](./${name}.mmd.svg)\n\n```mermaid\n${source}\n```\n";
-          svg = rc.mmdSourceToSvg name source;
-        in
-        {
-          inherit md svg;
-        };
-
-      # --- Text summaries ---
-      fleetSummaryText = diag.text.fleetSummary fleetCapture;
-      fleetSummaryDrv = pkgs.writeText "fleet-summary.md" fleetSummaryText;
-
-      hostSummaryDrvs = lib.listToAttrs (
-        map (
-          host:
-          let
-            entity = diag.hostContext { inherit host; };
-            text = diag.text.hostSummary {
-              graph = entity;
-              inherit host fleetCapture;
-            };
-          in
-          {
-            name = "${host.name}-summary";
-            value = pkgs.writeText "${host.name}-summary.md" text;
-          }
-        ) allHosts
-      );
-
-      pipeFlowView = mkFleetView "pipe-flow" "Pipe Flow" rc.render.toPipeFlowMermaid;
-      scopeTopoView = mkFleetView "scope-topology" "Scope Topology" rc.render.toScopeTopologyMermaid;
-      aspectMatrixView = mkFleetView "aspect-matrix" "Aspect Coverage" rc.render.toAspectMatrixMermaid;
-      policyMapView =
-        mkFleetView "policy-resolution" "Policy Resolution Map"
-          rc.render.toPolicyResolutionMapMermaid;
-      pipeSeqView = mkFleetView "pipe-sequence" "Pipe Sequence" rc.render.toPipeSequenceMermaid;
-      fleetDagSource = rc.render.toFleetDagMermaid { inherit fleetCapture hostGraphs; };
-      fleetIrJson = diag.fleetGraph.toJSON { inherit fleetCapture hostGraphs; };
       fleetIrDrv = pkgs.runCommand "fleet-ir.json" { nativeBuildInputs = [ pkgs.jq ]; } ''
-        echo ${lib.escapeShellArg fleetIrJson} | jq . > $out
+        echo ${
+          lib.escapeShellArg (diag.fleetGraph.toJSON { inherit fleetCapture hostGraphs; })
+        } | jq . > $out
       '';
-      fleetDagView = {
-        md = pkgs.writeText "fleet-dag.md" "# Fleet DAG\n\n![Fleet DAG](./fleet-dag.mmd.svg)\n\n```mermaid\n${fleetDagSource}\n```\n";
-        svg = rc.mmdSourceToSvg "fleet-dag" fleetDagSource;
-      };
 
-      readmeDrv = pkgs.writeText "README.md" ''
-        # Fleet Demo Diagrams
+      everyEntry = [
+        (mkViewFile "scope-topology" scopeTopologySection)
+        (mkViewFile "policy-resolution" policyResolutionSection)
+        (mkViewFile "pipe-flow" pipeFlowSection)
+        (mkViewFile "pipe-sequence" pipeSequenceSection)
+        (mkViewFile "namespace" namespaceSection)
+        (mkViewFile "summary" fleetSummarySection)
+        {
+          name = "fleet";
+          view = "fleet-ir";
+          dir = "fleet";
+          ext = "json";
+          tool = null;
+          drv = fleetIrDrv;
+        }
+      ];
 
-        Aspect-resolution visualization for fleet-demo.
+      # --- README with gallery appended ---
 
-        ## Topology
+      readmeDrv = pkgs.writeText "README.md" (
+        lib.concatStringsSep "\n" [
+          ''
+            # Fleet Demo
 
-        ```
-        flake → fleet → environment:prod → lb-prod, web-prod-1, web-prod-2
-                       → environment:staging → web-staging
-        ```
+            A multi-host NixOS fleet managed by den,
+            demonstrating environment-based topology, cross-host data sharing, and
+            policy-driven user access from a centralized registry.
 
-        ## Quirk/Pipe Flow
+            ## What This Builds
 
-        - `http-backends`: nginx aspects emit backend data, haproxy collects via pipe.collect
-        - `host-addrs`: every host emits addr, hostfile collects via pipe.collect
+            Four NixOS hosts across two environments:
 
-        ## Usage
+            | Host | Environment | Role |
+            |------|-------------|------|
+            | `lb-prod` | prod | HAProxy load balancer — collects backend addresses from peers |
+            | `web-prod-1` | prod | Nginx web server — emits backend address for load balancing |
+            | `web-prod-2` | prod | Nginx web server — emits backend address for load balancing |
+            | `web-staging` | staging | Nginx web server — staging environment |
 
-        ```bash
-        nix run --override-input den . .#write-diagrams
-        ```
-      '';
+            Each host gets a complete `nixosConfiguration` with networking, service
+            config, and user accounts — all derived from the same set of aspects and
+            policies.
+
+            ## Custom Entity Types
+
+            Den has built-in entity kinds (host, user), but this demo defines two
+            additional entity types entirely in user space — no framework changes
+            required.
+
+            ### Environments
+
+            `environments.nix` defines a custom `environment` entity type by setting
+            `den.schema.environment.isEntity = true` and creating a typed option
+            `fleet.environments` whose submodule imports `den.schema.environment`.
+            Each environment carries a `domain-name` and is registered as an instance:
+
+            ```nix
+            fleet.environments = {
+              prod    = { domain-name = "example.com"; };
+              staging = { domain-name = "staging.example.com"; };
+            };
+            ```
+
+            The host schema is extended with `environment` and `addr` options via
+            `den.schema.host.imports`, so every host declares which environment it
+            belongs to.
+
+            ### Users as Entities
+
+            `users.nix` promotes users to real entities (`den.schema.user.isEntity = true`)
+            and extends the user schema with `email`, `groups`, and `ssh-keys` options.
+            The registry type imports `den.schema.user` so each entry is a proper user
+            entity with `userName`, `classes`, and `aspect` — not a plain attrset.
+
+            ## Policy-Driven Scope Tree
+
+            Den's default policies walk `den.hosts` and create host scopes directly
+            under `flake-system`. This demo replaces that with a custom scope tree:
+
+            ```
+            flake → fleet → environment → host → user
+            ```
+
+            This is built by a chain of policies in `policies/fleet.nix`, each firing
+            at a specific scope level and resolving child entities:
+
+            | Policy | Fires at | Resolves | Mechanism |
+            |--------|----------|----------|-----------|
+            | `to-fleet` | flake | fleet | `resolve.to "fleet"` — creates a single fleet entity |
+            | `fleet-to-envs` | fleet | environments | `resolve.to "environment"` — one per `fleet.environments` entry |
+            | `env-to-hosts` | environment | hosts | `resolve.to "host"` — filters `den.hosts` by matching `host.environment` |
+            | `env-users` | host | users | `resolve.to "user"` — filters `den.users.registry` by environment group grant |
+            | `host-users` | host | users | `resolve.to "user"` — filters `den.users.registry` by host-specific group grant |
+
+            Each `resolve.to` call creates a named child scope. The entity's context
+            bindings (`host`, `user`, `environment`, etc.) are available to all aspects
+            and policies that fire within that scope.
+
+            ### Disabling Default Policies
+
+            Den's core provides built-in policies for common patterns. This demo
+            disables two of them to take full control of the scope tree:
+
+            - **`den.policies.to-os-outputs`** and **`den.policies.to-hm-outputs`** are
+              excluded from `den.schema.flake-system` — the fleet policies handle host
+              instantiation explicitly via `den.lib.policy.instantiate`, so the default
+              per-system output walk is unnecessary.
+
+            - **`den.policies.host-to-users`** is excluded from `den.schema.host` — this
+              core policy walks `host.users` (inline user definitions) and resolves them
+              via `resolve.shared`. Since this demo resolves users from the external
+              registry via `resolve.to "user"`, the default policy would be a no-op but
+              is excluded for clarity.
+
+            ## User Registry and Group-Based Access
+
+            Users are defined once in `den.users.registry` with identity metadata:
+
+            ```nix
+            den.users.registry = {
+              alice = {
+                email = "alice@example.com";
+                groups = [ "admin" ];
+                ssh-keys = [ "ssh-ed25519 AAAAC3... alice@workstation" ];
+              };
+              bob = {
+                email = "bob@example.com";
+                groups = [ "deploy" ];
+                ssh-keys = [ "ssh-ed25519 AAAAC3... bob@laptop" ];
+              };
+            };
+            ```
+
+            Access is controlled by `fleet.user-access`, which maps group names to
+            environments or specific hosts:
+
+            ```nix
+            fleet.user-access.by-environment = {
+              prod    = { groups = [ "admin" ]; };
+              staging = { groups = [ "admin" "deploy" ]; };
+            };
+            ```
+
+            The `env-users` policy fires at each host scope, looks up the access
+            grant for `host.environment`, and filters the registry for users whose
+            `groups` intersect the granted set. Each match becomes a `resolve.to "user"`
+            call, creating a user scope on that host.
+
+            | User | Groups | Prod (grants admin) | Staging (grants admin + deploy) |
+            |------|--------|---------------------|-------------------------------|
+            | alice | admin | yes | yes |
+            | bob | deploy | no | yes |
+
+            The `host-users` policy provides the same mechanism scoped to individual
+            hosts via `fleet.user-access.by-host`, allowing per-host overrides on top
+            of environment-level grants.
+
+            The `ssh-keys` aspect fires in every user scope and sets
+            `users.users.''${user.userName}.openssh.authorizedKeys.keys` from
+            `user.ssh-keys`. Because user scopes only exist on hosts where access
+            was granted, keys are provisioned exactly where they should be — nowhere
+            else.
+
+            ## Pipes and Cross-Host Data Sharing
+
+            Pipes allow sibling hosts within the same environment to share data
+            declaratively. They are built on den's quirk system.
+
+            ### Declaring Pipes
+
+            `policies/pipes.nix` declares two quirks as pipes:
+
+            ```nix
+            den.quirks.http-backends = {
+              description = "HTTP backend addresses for load balancer aggregation";
+            };
+            den.quirks.host-addrs = {
+              description = "Host address entries for /etc/hosts generation";
+            };
+            ```
+
+            Each host includes `pipe.collect` policies that gather these quirks
+            from all peers in the same environment:
+
+            ```nix
+            den.policies.collect-backends = { host, ... }: [
+              (pipe.from "http-backends" [ (pipe.collect ({ host, ... }: true)) ])
+            ];
+            ```
+
+            ### Emitting and Consuming
+
+            Aspects participate in pipes by defining a key matching the quirk name.
+
+            **Emitting** — the `nginx` aspect emits an `http-backends` entry:
+
+            ```nix
+            den.aspects.nginx = {
+              nixos = { ... }: { services.nginx.enable = true; /* ... */ };
+              http-backends = { host, ... }: { inherit (host) addr; port = host.httpPort; };
+            };
+            ```
+
+            **Consuming** — the `haproxy` aspect receives the collected list:
+
+            ```nix
+            den.aspects.haproxy = {
+              nixos = { http-backends, lib, ... }:
+                let
+                  backendLines = lib.imap1 (i: b:
+                    "  server backend''${toString i} ''${b.addr}:''${toString b.port} check"
+                  ) http-backends;
+                in { /* haproxy config using backendLines */ };
+            };
+            ```
+
+            The `http-backends` argument in the haproxy NixOS module is automatically
+            populated by `pipe.collect` with entries from all sibling hosts that emit
+            the `http-backends` quirk. Adding a new web server host to `prod` automatically
+            adds it to haproxy's backend list — no manual wiring.
+
+            The same pattern is used for `host-addrs`: every host emits its IP/hostname
+            pair, and the `hostfile` aspect collects them to generate `/etc/hosts`.
+
+            ## Module Layout
+
+            ```
+            modules/
+              den.nix                     — host definitions, defaults, systems
+              environments.nix            — environment entity type + instances (prod, staging)
+              users.nix                   — user registry, schema extension, access mappings
+              policies/
+                fleet.nix                 — scope tree: flake → fleet → env → host → user
+                pipes.nix                 — pipe declarations + collection policies
+              aspects/
+                features/
+                  haproxy.nix             — HAProxy config from collected http-backends
+                  nginx.nix               — Nginx server + http-backends emission
+                  hostfile.nix            — /etc/hosts from collected host-addrs
+                hosts/
+                  lb-prod.nix             — includes haproxy + hostfile
+                  web-prod-{1,2}.nix      — includes nginx + hostfile
+                  web-staging.nix         — includes nginx + hostfile
+                users/
+                  ssh-keys.nix            — SSH key provisioning aspect
+            ```
+
+            ## Usage
+
+            Build a host configuration:
+
+            ```bash
+            nix build .#nixosConfigurations.lb-prod.config.system.build.toplevel
+            ```
+
+            Regenerate diagrams:
+
+            ```bash
+            nix run .#write-diagrams
+            ```
+          ''
+          "---"
+          ""
+          "# Diagrams"
+          ""
+          "The following visualizations are generated from the fleet's actual"
+          "aspect-resolution pipeline. They show the same topology from different"
+          "angles."
+          ""
+          legendSection
+          scopeTopologySection
+          policyResolutionSection
+          pipeFlowSection
+          pipeSequenceSection
+          namespaceSection
+          fleetSummarySection
+        ]
+      );
     in
     {
-      packages =
-        allPackages
-        // hostSummaryDrvs
-        // {
-          fleet-summary = fleetSummaryDrv;
-        }
-        // {
-          write-diagrams = mkWriteScript pkgs {
-            entries = everyEntry;
-            inherit galleries readmeDrv;
-            destExpr = ''"$(${pkgs.git}/bin/git rev-parse --show-toplevel)/templates/fleet-demo"'';
-          };
+      packages = diag.export.entriesToPackages everyEntry // {
+        write-diagrams = diag.export.mkWriteScript pkgs {
+          entries = everyEntry;
+          galleries = [ ];
+          inherit readmeDrv;
+          destExpr = ''"$(${pkgs.git}/bin/git rev-parse --show-toplevel)/templates/fleet-demo"'';
         };
+      };
     };
 }

--- a/templates/fleet-demo/modules/policies/fleet.nix
+++ b/templates/fleet-demo/modules/policies/fleet.nix
@@ -15,9 +15,18 @@
 let
   inherit (den.lib.policy) resolve;
 
+  # Capture module-level config for use inside policies.
+  # Policy functions receive entity context (host, user, etc.), NOT module args.
+  # Destructuring `config` in the policy signature would fail resolveArgsSatisfied
+  # since `config` is not an entity binding in the resolve context.
+  registry = config.den.users.registry;
+  accessByEnv = config.fleet.user-access.by-environment;
+  accessByHost = config.fleet.user-access.by-host;
+  environments = config.fleet.environments;
+
   # Filter registry user names whose groups intersect the granted set.
   matchRegistryUsers =
-    grantedGroups: registry:
+    grantedGroups:
     lib.filter (name: builtins.any (g: lib.elem g grantedGroups) registry.${name}.groups) (
       builtins.attrNames registry
     );
@@ -40,7 +49,7 @@ in
       resolve.to "environment" {
         environment = env;
       }
-    ) config.fleet.environments;
+    ) environments;
 
   # environment -> hosts: walk hosts whose environment matches.
   # Guard: only fire at environment scope (not at host scopes which inherit environment).
@@ -62,21 +71,21 @@ in
 
   # host -> users (by environment): resolve registry users whose groups match.
   den.policies.env-users =
-    { host, config, ... }:
+    { host, ... }:
     let
-      grant = config.fleet.user-access.by-environment.${host.environment} or { groups = [ ]; };
-      matched = matchRegistryUsers grant.groups config.den.users.registry;
+      grant = accessByEnv.${host.environment} or { groups = [ ]; };
+      matched = matchRegistryUsers grant.groups;
     in
-    map (name: resolve.to "user" { user = config.den.users.registry.${name}; }) matched;
+    map (name: resolve.to "user" { user = registry.${name}; }) matched;
 
   # host -> users (by host): resolve registry users by host-specific group match.
   den.policies.host-users =
-    { host, config, ... }:
+    { host, ... }:
     let
-      grant = config.fleet.user-access.by-host.${host.name} or { groups = [ ]; };
-      matched = matchRegistryUsers grant.groups config.den.users.registry;
+      grant = accessByHost.${host.name} or { groups = [ ]; };
+      matched = matchRegistryUsers grant.groups;
     in
-    map (name: resolve.to "user" { user = config.den.users.registry.${name}; }) matched;
+    map (name: resolve.to "user" { user = registry.${name}; }) matched;
 
   den.schema.flake.includes = [ den.policies.to-fleet ];
   den.schema.fleet.includes = [ den.policies.fleet-to-envs ];

--- a/templates/fleet-demo/modules/policies/fleet.nix
+++ b/templates/fleet-demo/modules/policies/fleet.nix
@@ -1,10 +1,11 @@
-# Fleet topology policies.
+# Fleet topology and user-access policies.
 #
-# Wires the scope tree: flake -> fleet -> environment -> hosts.
+# Wires the scope tree: flake -> fleet -> environment -> hosts -> users.
 # Each environment groups its hosts as siblings for pipe.collect.
 #
 # Environment membership derived from den.schema.host.environment.
 # Environment entities read from fleet.environments registry.
+# User resolution driven by fleet.user-access group intersection.
 {
   lib,
   den,
@@ -13,6 +14,13 @@
 }:
 let
   inherit (den.lib.policy) resolve;
+
+  # Filter registry user names whose groups intersect the granted set.
+  matchRegistryUsers =
+    grantedGroups: registry:
+    lib.filter (name: builtins.any (g: lib.elem g grantedGroups) registry.${name}.groups) (
+      builtins.attrNames registry
+    );
 in
 {
   # flake -> fleet: single fleet entity.
@@ -52,7 +60,30 @@ in
       ) (builtins.attrNames (den.hosts.${system} or { }))
     ) (builtins.attrNames (den.hosts or { }));
 
+  # host -> users (by environment): resolve registry users whose groups match.
+  den.policies.env-users =
+    { host, config, ... }:
+    let
+      grant = config.fleet.user-access.by-environment.${host.environment} or { groups = [ ]; };
+      matched = matchRegistryUsers grant.groups config.den.users.registry;
+    in
+    map (name: resolve.to "user" { user = config.den.users.registry.${name}; }) matched;
+
+  # host -> users (by host): resolve registry users by host-specific group match.
+  den.policies.host-users =
+    { host, config, ... }:
+    let
+      grant = config.fleet.user-access.by-host.${host.name} or { groups = [ ]; };
+      matched = matchRegistryUsers grant.groups config.den.users.registry;
+    in
+    map (name: resolve.to "user" { user = config.den.users.registry.${name}; }) matched;
+
   den.schema.flake.includes = [ den.policies.to-fleet ];
   den.schema.fleet.includes = [ den.policies.fleet-to-envs ];
   den.schema.environment.includes = [ den.policies.env-to-hosts ];
+  den.schema.host.includes = [
+    den.policies.env-users
+    den.policies.host-users
+  ];
+  den.schema.host.excludes = [ den.policies.host-to-users ];
 }

--- a/templates/fleet-demo/modules/users.nix
+++ b/templates/fleet-demo/modules/users.nix
@@ -1,0 +1,119 @@
+# User registry and policy-driven access mappings.
+#
+# Demonstrates a standalone user registry with extended schema,
+# resolved onto hosts via fleet.user-access group policies.
+{
+  lib,
+  config,
+  den,
+  ...
+}:
+let
+  # Submodule for group-based access grants.
+  accessGrantType = lib.types.submodule {
+    options.groups = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = "Groups granted access";
+    };
+  };
+
+  # Extend user schema with registry fields.
+  extendUserSchema =
+    { ... }:
+    {
+      options.email = lib.mkOption {
+        type = lib.types.str;
+        default = "";
+        description = "User email address";
+      };
+      options.groups = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "Group memberships for access policy selection";
+      };
+      options.ssh-keys = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        description = "SSH public keys for authorized_keys";
+      };
+    };
+
+  # Registry entry type — imports den.schema.user so entries are proper user entities.
+  registryUserType = lib.types.submodule (
+    { name, config, ... }:
+    {
+      freeformType = lib.types.attrsOf lib.types.anything;
+      imports = [ den.schema.user ];
+      config._module.args.user = config;
+      options.name = lib.mkOption {
+        type = lib.types.str;
+        default = name;
+        description = "User name (from attrset key)";
+      };
+    }
+  );
+in
+{
+  # Registry: standalone, not under fleet.
+  options.den.users.registry = lib.mkOption {
+    type = lib.types.attrsOf registryUserType;
+    default = { };
+    description = "External user registry with extended schema";
+  };
+
+  # Access mappings: under fleet.
+  options.fleet.user-access = {
+    by-environment = lib.mkOption {
+      type = lib.types.attrsOf accessGrantType;
+      default = { };
+      description = "Grant user groups access to all hosts in an environment";
+    };
+    by-host = lib.mkOption {
+      type = lib.types.attrsOf accessGrantType;
+      default = { };
+      description = "Grant user groups access to a specific host";
+    };
+  };
+
+  config = {
+    # Promote users to real entities.
+    den.schema.user.isEntity = true;
+
+    # Extend user schema with registry fields.
+    den.schema.user.imports = [ extendUserSchema ];
+
+    # Demo users.
+    den.users.registry = {
+      alice = {
+        email = "alice@example.com";
+        groups = [ "admin" ];
+        ssh-keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyAlice alice@workstation" ];
+      };
+      bob = {
+        email = "bob@example.com";
+        groups = [ "deploy" ];
+        ssh-keys = [ "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBob bob@laptop" ];
+      };
+    };
+
+    # Expose registry as flake output for nix eval.
+    flake.den.users = config.den.users;
+
+    # Access mappings.
+    fleet.user-access = {
+      by-environment = {
+        staging = {
+          groups = [
+            "admin"
+            "deploy"
+          ];
+        };
+        prod = {
+          groups = [ "admin" ];
+        };
+      };
+      by-host = { };
+    };
+  };
+}

--- a/templates/fleet-demo/modules/users.nix
+++ b/templates/fleet-demo/modules/users.nix
@@ -39,17 +39,37 @@ let
       };
     };
 
-  # Registry entry type — imports den.schema.user so entries are proper user entities.
+  # Registry entry type — mirrors the standard user entity shape from
+  # nix/lib/entities/host.nix so that pipeline self-provide, define-user,
+  # and other batteries find the expected attributes (userName, aspect, classes).
   registryUserType = lib.types.submodule (
     { name, config, ... }:
     {
       freeformType = lib.types.attrsOf lib.types.anything;
       imports = [ den.schema.user ];
       config._module.args.user = config;
-      options.name = lib.mkOption {
-        type = lib.types.str;
-        default = name;
-        description = "User name (from attrset key)";
+      options = {
+        name = lib.mkOption {
+          type = lib.types.str;
+          default = name;
+          description = "User name (from attrset key)";
+        };
+        userName = lib.mkOption {
+          type = lib.types.str;
+          default = name;
+          description = "User account name";
+        };
+        classes = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ "user" ];
+          description = "Home management nix classes";
+        };
+        aspect = lib.mkOption {
+          type = lib.types.raw;
+          default = if den.aspects ? ${name} then den.aspects.${name} else { };
+          defaultText = "den.aspects.<name>";
+          description = "Aspect that configures this user";
+        };
       };
     }
   );


### PR DESCRIPTION
## Summary

- **Fleet demo**: wire ssh-keys battery, user registry, composite mermaid galleries, deep README covering policies/pipes/entities/groups
- **Diagram theme fix**: fleet-views.nix referenced `theme.accent0..7` (named attrs that don't exist) instead of indexing `theme.accentPool` — all accent colors fell through to hard-coded Catppuccin values regardless of chosen scheme
- **Light theme contrast**: auto-detect light vs dark palettes, select `base07` (dark) or `base00` (dark) for text on accent fills
- **Consistent coloring**: hosts are green across all fleet views (pipe-flow, scope-topology, policy-resolution); namespace colors by structural role (host vs shared) using `colorKey`; transparent pipe-flow subgraphs; coprime-stepped pipe edge colors

## Test plan

- [x] 778/778 CI tests passing
- [x] Regenerated fleet-demo diagrams with correct palette colors
- [x] Verified github-light default theme produces dark text on accent fills
- [x] Verified namespace diagram: uniform color per structural role
- [x] Verified pipe-flow: entity-kind host coloring, transparent env subgraphs