### PR TITLE
fix: policy.when with hasAspect no longer cycles, policy.for accepts effect descriptors

### DIFF
--- a/nix/lib/aspects/fx/aspect/provide.nix
+++ b/nix/lib/aspects/fx/aspect/provide.nix
@@ -11,8 +11,7 @@ let
   inherit (den.lib.aspects.fx) identity;
   inherit (den.lib.aspects.fx.contentUtil) applyProvide;
   inherit (den.lib.aspects) isParametricWrapper;
-  inherit (den.lib.schemaUtil) schemaEntityKinds;
-  schemaEntityKindsSet = lib.genAttrs schemaEntityKinds (_: true);
+  inherit (den.lib.schemaUtil) schemaEntityKinds schemaEntityKindsSet;
 
   mkCrossPolicy =
     aspectName: nodeIdentity: provides: key:

--- a/nix/lib/aspects/fx/handlers/compile-conditional.nix
+++ b/nix/lib/aspects/fx/handlers/compile-conditional.nix
@@ -1,7 +1,9 @@
 # Effect handler: compile-conditional
 # Evaluates guard against path-set, emits includes or tombstones.
-# No gating — conditionals have their own guard mechanism.
+# Guards that fail are deferred for re-evaluation when the pathSet grows;
+# drain-conditionals resolves them at entity boundary.
 {
+  lib,
   den,
   ...
 }:
@@ -9,6 +11,8 @@ let
   inherit (den.lib) fx;
   inherit (den.lib.aspects.fx) identity;
   inherit (den.lib.aspects.fx.aspect) emitIncludes;
+  inherit (den.lib.schemaUtil) schemaEntityKindsSet;
+  inherit (import ./state-util.nix) scopedAppend;
 
   tombstoneAll =
     aspects:
@@ -22,6 +26,57 @@ let
         fx.bind (fx.send "resolve-complete" tombstone) (_: fx.pure (results ++ [ tombstone ]))
       )
     ) (fx.pure [ ]) aspects;
+
+  # In-flight pathSet is not class-partitioned, so forClass approximates
+  # as forAnyClass (may produce false positives across classes, never false
+  # negatives). Accurate enough for guards — the pathSet reflects all
+  # classes walked so far in the current resolution.
+  mkPipelineHasAspect = pathSet: {
+    __functor = _: ref: pathSet ? ${identity.key ref};
+    forClass = _: ref: pathSet ? ${identity.key ref};
+    forAnyClass = ref: pathSet ? ${identity.key ref};
+  };
+
+  # Build guard context with entity-shaped stubs so predicates written as
+  # ({ host, ... }: host.hasAspect ref) work without touching config.resolved.
+  # Uses scope handler keys to identify entity kinds without evaluating the
+  # handlers (which would force entity config and cycle).
+  mkGuardCtx =
+    pathSet: scopeHandlers:
+    let
+      pipelineHasAspect = mkPipelineHasAspect pathSet;
+      handlerKeys = builtins.attrNames scopeHandlers;
+      entityKeys = builtins.filter (k: schemaEntityKindsSet ? ${k}) handlerKeys;
+      entityStubs = lib.genAttrs entityKeys (_: {
+        hasAspect = pipelineHasAspect;
+      });
+    in
+    {
+      hasAspect = ref: pathSet ? ${identity.key ref};
+    }
+    // entityStubs;
+
+  # Defer a conditional for re-evaluation at entity boundary.
+  deferConditional =
+    condNode:
+    let
+      stub = {
+        name = condNode.name or "<when>";
+        meta =
+          (builtins.removeAttrs (condNode.meta or { }) [
+            "guard"
+            "aspects"
+          ])
+          // {
+            deferred = true;
+            guardDeferred = true;
+          };
+        includes = [ ];
+      };
+    in
+    fx.bind (fx.send "defer-conditional" condNode) (
+      _: fx.bind (fx.send "resolve-complete" stub) (_: fx.pure [ ])
+    );
 in
 {
   compileConditionalHandler = {
@@ -34,9 +89,7 @@ in
         resume = fx.bind (fx.send "get-path-set" null) (
           pathSet:
           let
-            guardCtx = {
-              hasAspect = ref: pathSet ? ${identity.key ref};
-            };
+            guardCtx = mkGuardCtx pathSet (condNode.__scopeHandlers or { });
             pass = condNode.meta.guard guardCtx;
           in
           if pass then
@@ -45,9 +98,71 @@ in
               __parentCtxId = condNode.__ctxId or null;
             } condNode.meta.aspects
           else
-            tombstoneAll condNode.meta.aspects
+            deferConditional condNode
         );
         inherit state;
       };
+  };
+
+  # Store a deferred conditional in scoped state.
+  deferConditionalHandler = {
+    "defer-conditional" =
+      { param, state }:
+      {
+        resume = null;
+        state = scopedAppend state "scopedDeferredConditionals" state.currentScope param;
+      };
+  };
+
+  # Re-evaluate deferred conditionals against the final pathSet.
+  # Called at entity boundary after the full tree walk completes.
+  drainConditionalsHandler = {
+    "drain-conditionals" =
+      { param, state }:
+      let
+        scope = state.currentScope;
+        allScoped = (state.scopedDeferredConditionals or (_: { })) null;
+        scopeDeferred = allScoped.${scope} or [ ];
+      in
+      if scopeDeferred == [ ] then
+        {
+          resume = fx.pure [ ];
+          inherit state;
+        }
+      else
+        {
+          resume = fx.bind (fx.send "get-path-set" null) (
+            pathSet:
+            let
+              go =
+                idx: acc:
+                if idx >= builtins.length scopeDeferred then
+                  acc
+                else
+                  let
+                    condNode = builtins.elemAt scopeDeferred idx;
+                    guardCtx = mkGuardCtx pathSet (condNode.__scopeHandlers or { });
+                    pass = condNode.meta.guard guardCtx;
+                  in
+                  go (idx + 1) (
+                    fx.bind acc (
+                      prev:
+                      if pass then
+                        fx.bind (emitIncludes {
+                          __parentScopeHandlers = condNode.__scopeHandlers or null;
+                          __parentCtxId = condNode.__ctxId or null;
+                        } condNode.meta.aspects) (results: fx.pure (prev ++ results))
+                      else
+                        fx.bind (tombstoneAll condNode.meta.aspects) (tombstones: fx.pure (prev ++ tombstones))
+                    )
+                  );
+            in
+            go 0 (fx.pure [ ])
+          );
+          # Clear deferred conditionals for this scope.
+          state = state // {
+            scopedDeferredConditionals = _: allScoped // { ${scope} = [ ]; };
+          };
+        };
   };
 }

--- a/nix/lib/aspects/fx/handlers/resolve-children.nix
+++ b/nix/lib/aspects/fx/handlers/resolve-children.nix
@@ -63,12 +63,20 @@ in
       {
         resume = fx.bind (chainWrap chainIdentity isMeaningful (resolveChildSequence aspect)) (
           allChildren:
-          let
-            resolved = aspect // {
-              includes = allChildren;
-            };
-          in
-          fx.bind (fx.send "resolve-complete" resolved) (_: fx.pure resolved)
+          # Re-evaluate deferred conditional guards now that the subtree
+          # has been walked and the pathSet is more complete.
+          fx.bind (fx.effects.hasHandler "drain-conditionals") (
+            hasDrain:
+            fx.bind (if hasDrain then fx.send "drain-conditionals" null else fx.pure [ ]) (
+              conditionalResults:
+              let
+                resolved = aspect // {
+                  includes = allChildren ++ conditionalResults;
+                };
+              in
+              fx.bind (fx.send "resolve-complete" resolved) (_: fx.pure resolved)
+            )
+          )
         );
         inherit state;
       };

--- a/nix/lib/aspects/fx/handlers/state-util.nix
+++ b/nix/lib/aspects/fx/handlers/state-util.nix
@@ -8,7 +8,7 @@
       ${field} =
         _:
         let
-          all = state.${field} null;
+          all = (state.${field} or (_: { })) null;
         in
         all // { ${scope} = (all.${scope} or [ ]) ++ [ item ]; };
     };
@@ -21,7 +21,7 @@
       ${field} =
         _:
         let
-          all = state.${field} null;
+          all = (state.${field} or (_: { })) null;
         in
         all // { ${scope} = (all.${scope} or [ ]) ++ items; };
     };
@@ -34,7 +34,7 @@
       ${field} =
         _:
         let
-          all = state.${field} null;
+          all = (state.${field} or (_: { })) null;
         in
         all // { ${scope} = (all.${scope} or { }) // attrs; };
     };

--- a/nix/lib/aspects/fx/pipeline.nix
+++ b/nix/lib/aspects/fx/pipeline.nix
@@ -65,6 +65,8 @@ let
     // handlers.compileHandler
     // handlers.compileForwardHandler
     // handlers.compileConditionalHandler
+    // handlers.deferConditionalHandler
+    // handlers.drainConditionalsHandler
     // handlers.compileParametricHandler
     // handlers.compileStaticHandler
     // handlers.bindHandler
@@ -139,6 +141,7 @@ let
     # Pre-merged flat view (avoid O(S) rebuild per installPolicies call).
     flatAspectPolicies = { };
     scopedDeferredIncludes = _: { };
+    scopedDeferredConditionals = _: { };
     scopedIncludesChain = _: { };
     scopedConstraintRegistry = _: { };
     scopedConstraintFilters = _: { };

--- a/nix/lib/aspects/fx/policy/classify.nix
+++ b/nix/lib/aspects/fx/policy/classify.nix
@@ -3,9 +3,9 @@
 {
   lib,
   schemaEntityKinds,
+  schemaEntityKindsSet,
 }:
 let
-  schemaEntityKindsSet = lib.genAttrs schemaEntityKinds (_: true);
 
   # Classify a resolve effect into schema vs enrichment (single-pass partition).
   classifyResolve =

--- a/nix/lib/aspects/fx/policy/default.nix
+++ b/nix/lib/aspects/fx/policy/default.nix
@@ -19,9 +19,9 @@ let
   inherit (den.lib.synthesizePolicies) resolveArgsSatisfied;
   inherit (den.lib.aspects.fx.pipeline) mkScopeId;
   inherit (den.lib.aspects.fx) identity;
-  inherit (den.lib.schemaUtil) schemaEntityKinds;
+  inherit (den.lib.schemaUtil) schemaEntityKinds schemaEntityKindsSet;
 
-  classify = import ./classify.nix { inherit lib schemaEntityKinds; };
+  classify = import ./classify.nix { inherit lib schemaEntityKinds schemaEntityKindsSet; };
   inherit (classify) classifyPolicyResult hasEffects extractTaggedEffects;
 
   dispatch = import ./dispatch.nix {
@@ -53,6 +53,7 @@ let
       constantHandler
       mkScopeId
       schemaEntityKinds
+      schemaEntityKindsSet
       classifyPolicyResult
       extractTaggedEffects
       dispatchAspect

--- a/nix/lib/aspects/fx/policy/schema.nix
+++ b/nix/lib/aspects/fx/policy/schema.nix
@@ -7,6 +7,7 @@
   constantHandler,
   mkScopeId,
   schemaEntityKinds,
+  schemaEntityKindsSet,
   classifyPolicyResult,
   extractTaggedEffects,
   dispatchAspect,
@@ -15,8 +16,6 @@
   mkSupplementalResolution,
 }:
 let
-  schemaEntityKindsSet = lib.genAttrs schemaEntityKinds (_: true);
-
   # Determine target entity kind from a schema effect.
   resolveTargetKind =
     entityKind: schemaEffect:

--- a/nix/lib/policy-effects.nix
+++ b/nix/lib/policy-effects.nix
@@ -1,6 +1,27 @@
 # Typed policy effect constructors.
 # Policies return lists of these; the pipeline dispatches on __policyEffect.
 { ... }:
+let
+  # Coerce a value into an inner policy record for use in `for` / `when`.
+  # Accepts: policies (__isPolicy), effect descriptors (__policyEffect),
+  # or raw functions (ctx -> [effects]).
+  toInnerPolicy =
+    p:
+    if p.__isPolicy or false then
+      p
+    else if p.__policyEffect or null != null then
+      {
+        __isPolicy = true;
+        name = "<effect:${p.__policyEffect}>";
+        fn = _: [ p ];
+      }
+    else
+      {
+        __isPolicy = true;
+        name = "<inline>";
+        fn = p;
+      };
+in
 {
   # Create a new context scope (fan-out). Each resolve creates a parallel
   # branch — a sibling context with new bindings merged into parent.
@@ -165,15 +186,7 @@
       wrap =
         p:
         let
-          inner =
-            if p.__isPolicy or false then
-              p
-            else
-              {
-                __isPolicy = true;
-                name = "<inline>";
-                fn = p;
-              };
+          inner = toInnerPolicy p;
         in
         {
           __isPolicy = true;
@@ -198,15 +211,7 @@
       wrap =
         p:
         let
-          inner =
-            if p.__isPolicy or false then
-              p
-            else
-              {
-                __isPolicy = true;
-                name = "<inline>";
-                fn = p;
-              };
+          inner = toInnerPolicy p;
         in
         {
           __isPolicy = true;

--- a/nix/lib/policy-effects.nix
+++ b/nix/lib/policy-effects.nix
@@ -4,7 +4,7 @@
 let
   # Coerce a value into an inner policy record for use in `for` / `when`.
   # Accepts: policies (__isPolicy), effect descriptors (__policyEffect),
-  # or raw functions (ctx -> [effects]).
+  # inline aspect attrsets, or raw functions (ctx -> [effects]).
   toInnerPolicy =
     p:
     if p.__isPolicy or false then
@@ -14,6 +14,17 @@ let
         __isPolicy = true;
         name = "<effect:${p.__policyEffect}>";
         fn = _: [ p ];
+      }
+    else if builtins.isAttrs p then
+      {
+        __isPolicy = true;
+        name = "<inline-aspect>";
+        fn = _: [
+          {
+            __policyEffect = "include";
+            value = p;
+          }
+        ];
       }
     else
       {
@@ -204,11 +215,36 @@ in
     if builtins.isList policiesOrSingle then map wrap policies else wrap policiesOrSingle;
 
   # Wrap a policy (or list of policies) to only fire when predicate is true.
+  # When wrapping inline aspects or effect descriptors, emits a conditional
+  # aspect (meta.guard) instead of a policy. This avoids the cycle where
+  # predicates that access entity.hasAspect trigger config.resolved during
+  # policy dispatch. The compile-conditional handler provides hasAspect from
+  # the in-flight pathSet, plus entity-shaped stubs for destructuring.
   when =
     predicate: policiesOrSingle:
     let
       policies = if builtins.isList policiesOrSingle then policiesOrSingle else [ policiesOrSingle ];
-      wrap =
+      # Wrap a non-policy value as a conditional aspect (compile-conditional path).
+      wrapAsConditional =
+        p:
+        let
+          effectType = p.__policyEffect or null;
+          aspects =
+            if effectType == "include" then
+              [ p.value ]
+            else if effectType != null then
+              throw "den: policy.when does not support ${effectType} effect descriptors — only include and inline aspects"
+            else
+              [ p ];
+        in
+        {
+          name = "<when>";
+          meta.guard = predicate;
+          meta.aspects = aspects;
+          includes = [ ];
+        };
+      # Wrap a policy value with predicate gating (dispatch path).
+      wrapAsPolicy =
         p:
         let
           inner = toInnerPolicy p;
@@ -218,6 +254,8 @@ in
           inherit (inner) name;
           fn = ctx: if predicate ctx then inner.fn ctx else [ ];
         };
+      wrap =
+        p: if p.__isPolicy or false || builtins.isFunction p then wrapAsPolicy p else wrapAsConditional p;
     in
     if builtins.isList policiesOrSingle then map wrap policies else wrap policiesOrSingle;
 

--- a/nix/lib/schema-util.nix
+++ b/nix/lib/schema-util.nix
@@ -18,7 +18,8 @@ let
   schemaArgKinds = builtins.filter (
     k: k != "conf" && k != "aspect" && !(lib.hasPrefix "_" k)
   ) schemaNames;
+  schemaEntityKindsSet = lib.genAttrs schemaEntityKinds (_: true);
 in
 {
-  inherit schemaEntityKinds schemaArgKinds;
+  inherit schemaEntityKinds schemaEntityKindsSet schemaArgKinds;
 }

--- a/templates/ci/modules/features/deadbugs/issue-525-hasaspect-in-policy-when.nix
+++ b/templates/ci/modules/features/deadbugs/issue-525-hasaspect-in-policy-when.nix
@@ -1,0 +1,134 @@
+{ denTest, ... }:
+{
+  flake.tests.issue-525-hasaspect-in-policy-when = {
+    # policy.when with host.hasAspect — the original bug report.
+    # Was infinite recursion because hasAspect read config.resolved.
+    # Fix: policy.when emits conditional aspect; compile-conditional provides
+    # entity-shaped stubs with pathSet-based hasAspect, defers on failure.
+    test-hasaspect-guard-fires = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.my-aspect.nixos.programs.git.enable = true;
+
+        den.aspects.igloo.includes = [ aspects.my-aspect ];
+
+        den.schema.host.includes = [
+          (policy.when ({ host, ... }: host.hasAspect aspects.my-aspect) {
+            nixos.networking.hostName = "guarded";
+          })
+        ];
+
+        expr = igloo.networking.hostName;
+        expected = "guarded";
+      }
+    );
+
+    # Negative case: guard should suppress when aspect is not present.
+    test-hasaspect-guard-suppresses = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.my-aspect.nixos.programs.git.enable = true;
+
+        # my-aspect is NOT included for igloo
+        den.schema.host.includes = [
+          (policy.when ({ host, ... }: host.hasAspect aspects.my-aspect) {
+            nixos.networking.hostName = "guarded";
+          })
+        ];
+
+        expr = igloo.networking.hostName;
+        expected = "nixos";
+      }
+    );
+
+    # Works from user aspect includes too.
+    test-hasaspect-from-user-scope = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.my-aspect.nixos.programs.git.enable = true;
+
+        den.aspects.igloo.includes = [ aspects.my-aspect ];
+
+        den.aspects.tux.includes = [
+          (policy.when ({ host, ... }: host.hasAspect aspects.my-aspect) {
+            nixos.networking.hostName = "from-user-guard";
+          })
+        ];
+
+        expr = igloo.networking.hostName;
+        expected = "from-user-guard";
+      }
+    );
+
+    # Walk-order independence: guard references an aspect included AFTER the
+    # conditional. On first pass the guard fails (my-aspect not yet in pathSet),
+    # but drain-conditionals re-evaluates with the final pathSet.
+    test-deferred-guard-fires-after-walk = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.my-aspect.nixos.programs.git.enable = true;
+
+        # Guard comes BEFORE the aspect it checks — tests deferral.
+        den.schema.host.includes = [
+          (policy.when ({ host, ... }: host.hasAspect aspects.my-aspect) {
+            nixos.networking.hostName = "deferred-guard";
+          })
+        ];
+
+        den.aspects.igloo.includes = [ aspects.my-aspect ];
+
+        expr = igloo.networking.hostName;
+        expected = "deferred-guard";
+      }
+    );
+
+    # forAnyClass variant works.
+    test-hasaspect-foranyclass = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.my-aspect.nixos.programs.git.enable = true;
+
+        den.aspects.igloo.includes = [ aspects.my-aspect ];
+
+        den.schema.host.includes = [
+          (policy.when ({ host, ... }: host.hasAspect.forAnyClass aspects.my-aspect) {
+            nixos.networking.hostName = "any-class-guard";
+          })
+        ];
+
+        expr = igloo.networking.hostName;
+        expected = "any-class-guard";
+      }
+    );
+  };
+}

--- a/templates/ci/modules/features/fx-compile-conditional.nix
+++ b/templates/ci/modules/features/fx-compile-conditional.nix
@@ -140,9 +140,14 @@
               inherit state;
             };
         };
-        comp = fx.send "compile-conditional" param;
+        comp = fx.bind (fx.send "compile-conditional" param) (_: fx.send "drain-conditionals" null);
         result = fx.handle {
-          handlers = handlers.compileConditionalHandler // identity.pathSetHandler // stubs;
+          handlers =
+            handlers.compileConditionalHandler
+            // handlers.deferConditionalHandler
+            // handlers.drainConditionalsHandler
+            // identity.pathSetHandler
+            // stubs;
           inherit state;
         } comp;
         tombstones = result.value;
@@ -187,9 +192,18 @@
               inherit state;
             };
         };
-        comp = fx.send "compile-conditional" param;
+        comp = fx.bind (fx.send "compile-conditional" param) (
+          _:
+          # Drain deferred conditionals to produce tombstones.
+          fx.send "drain-conditionals" null
+        );
         result = fx.handle {
-          handlers = handlers.compileConditionalHandler // identity.pathSetHandler // stubs;
+          handlers =
+            handlers.compileConditionalHandler
+            // handlers.deferConditionalHandler
+            // handlers.drainConditionalsHandler
+            // identity.pathSetHandler
+            // stubs;
           inherit state;
         } comp;
       in

--- a/templates/ci/modules/features/fx-dispatch-policies.nix
+++ b/templates/ci/modules/features/fx-dispatch-policies.nix
@@ -127,10 +127,10 @@
         fx = den.lib.fx;
         handlers = den.lib.aspects.fx.handlers;
         inherit (den.lib.synthesizePolicies) resolveArgsSatisfied;
-        inherit (den.lib.schemaUtil) schemaEntityKinds;
+        inherit (den.lib.schemaUtil) schemaEntityKinds schemaEntityKindsSet;
 
         classify = import ../../../../nix/lib/aspects/fx/policy/classify.nix {
-          inherit lib schemaEntityKinds;
+          inherit lib schemaEntityKinds schemaEntityKindsSet;
         };
         dispatch = import ../../../../nix/lib/aspects/fx/policy/dispatch.nix {
           inherit lib resolveArgsSatisfied;

--- a/templates/ci/modules/features/narrow-effects.nix
+++ b/templates/ci/modules/features/narrow-effects.nix
@@ -25,6 +25,8 @@ let
     // handlers.compileStaticHandler
     // handlers.compileParametricHandler
     // handlers.compileConditionalHandler
+    // handlers.deferConditionalHandler
+    // handlers.drainConditionalsHandler
     // handlers.compileForwardHandler
     // handlers.bindHandler
     // handlers.deferHandler
@@ -145,9 +147,10 @@ in
       }
     );
 
-    # resolve-conditional: guard fails — tombstone in includes, no classes emitted.
+    # resolve-conditional: guard fails — deferred, then drained as tombstone
+    # at resolve-children boundary. No classes emitted.
     test-resolve-conditional-guard-fail = denTest (
-      { den, ... }:
+      { den, lib, ... }:
       let
         fx = den.lib.fx;
         child = {
@@ -171,15 +174,18 @@ in
           handlers = mkHandlers { inherit den; };
           state = defaultState;
         } comp;
-        tombstone = builtins.head (builtins.head result.value).includes;
+        children = (builtins.head result.value).includes;
+        tombstone = lib.findFirst (c: c.meta.excluded or false) null children;
       in
       {
         expr = {
           classCount = builtins.length (result.state.classes or [ ]);
-          tombstoneGuardFailed = tombstone.meta.guardFailed or false;
+          tombstoneFound = tombstone != null;
+          tombstoneGuardFailed = if tombstone != null then tombstone.meta.guardFailed or false else false;
         };
         expected = {
           classCount = 0;
+          tombstoneFound = true;
           tombstoneGuardFailed = true;
         };
       }

--- a/templates/ci/modules/features/policy-for-include.nix
+++ b/templates/ci/modules/features/policy-for-include.nix
@@ -75,5 +75,25 @@
         expected = "from-zed";
       }
     );
+
+    # policy.when wrapping an inline aspect attrset should work.
+    test-when-inline-aspect = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.schema.host.includes = [
+          (policy.when (_: true) {
+            nixos.networking.hostName = "from-inline";
+          })
+        ];
+
+        expr = igloo.networking.hostName;
+        expected = "from-inline";
+      }
+    );
   };
 }

--- a/templates/ci/modules/features/policy-for-include.nix
+++ b/templates/ci/modules/features/policy-for-include.nix
@@ -1,0 +1,79 @@
+{ denTest, ... }:
+{
+  flake.tests.policy-for-include = {
+    # policy.for wrapping policy.include should work (was: "attempt to call
+    # something which is not a function but a set").
+    test-for-include-fires = denTest (
+      { den, config, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+        yalova = den.hosts.x86_64-linux.yalova;
+        yalovaConfig = config.flake.nixosConfigurations.yalova.config;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.yalova.users.tux = { };
+
+        den.schema.host.includes = [
+          (policy.for yalova (policy.include aspects.zed-editor))
+        ];
+
+        den.aspects.zed-editor = {
+          nixos.networking.hostName = "from-zed";
+        };
+
+        expr = yalovaConfig.networking.hostName;
+        expected = "from-zed";
+      }
+    );
+
+    # policy.for on a non-matching entity should suppress the include.
+    test-for-include-suppressed = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+        yalova = den.hosts.x86_64-linux.yalova;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.yalova.users.tux = { };
+
+        den.schema.host.includes = [
+          (policy.for yalova (policy.include aspects.zed-editor))
+        ];
+
+        den.aspects.zed-editor = {
+          nixos.services.foobar.enable = true;
+        };
+
+        expr = igloo.services.foobar.enable or false;
+        expected = false;
+      }
+    );
+
+    # policy.when wrapping policy.include should work.
+    test-when-include-fires = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den) aspects;
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.schema.host.includes = [
+          (policy.when (_: true) (policy.include aspects.zed-editor))
+        ];
+
+        den.aspects.zed-editor = {
+          nixos.networking.hostName = "from-zed";
+        };
+
+        expr = igloo.networking.hostName;
+        expected = "from-zed";
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- `policy.for` and `policy.when` now accept policy effect descriptors (e.g. `policy.include`) and inline aspect attrsets as arguments, not just raw functions or existing policies
- Fixes crash: `policy.for entity (policy.include aspects.foo)` → "attempt to call something which is not a function but a set"
- Fixes #525: `policy.when ({host,...}: host.hasAspect ref) { ... }` → infinite recursion
- Guards are walk-order independent: deferred on first failure, re-evaluated against final pathSet

## How it works

**`policy.for`/`policy.when` accept effect descriptors** — `toInnerPolicy` helper coerces effect descriptors and inline attrsets into callable policies. Four-branch dispatch: existing policy → passthrough, effect descriptor → constant function, inline attrset → include effect, raw function → direct use.

**`policy.when` with non-function values emits conditional aspects** — instead of registering a policy (which fires during dispatch, causing the `hasAspect` → `config.resolved` cycle), inline aspects and effect descriptors become conditional aspects with `meta.guard`. These route through `compile-conditional`, which evaluates guards against the in-flight pathSet — no dependency on `config.resolved`.

**Entity-shaped guard context** — `compile-conditional` enriches the guard context with entity stubs (`host = { hasAspect }`, `user = { hasAspect }`) derived from scope handler keys. This lets predicates written as `({ host, ... }: host.hasAspect ref)` work without touching entity config.

**Deferred guard evaluation** — when a guard fails (aspect not yet in pathSet), the conditional is deferred via `defer-conditional` and re-evaluated at `resolve-children` boundary when the pathSet is complete. Still-failing guards produce tombstones. This makes guards walk-order independent.

## Changes

- `nix/lib/policy-effects.nix` — `toInnerPolicy` helper, `policy.when` conditional path, throws on non-include effect descriptors
- `nix/lib/aspects/fx/handlers/compile-conditional.nix` — `mkGuardCtx`, `mkPipelineHasAspect`, `deferConditional`, `deferConditionalHandler`, `drainConditionalsHandler`
- `nix/lib/aspects/fx/handlers/resolve-children.nix` — drains conditionals after children resolve
- `nix/lib/aspects/fx/handlers/state-util.nix` — defensive `or` in all three scoped helpers
- `nix/lib/aspects/fx/pipeline.nix` — new state field, handler registrations
- `nix/lib/schema-util.nix` — extracted `schemaEntityKindsSet` (was duplicated in 4 files)
- 4 files updated to use shared `schemaEntityKindsSet`

## Test plan

- [x] `test-for-include-fires` — `policy.for entity (policy.include ...)` delivers content
- [x] `test-for-include-suppressed` — non-matching entity suppresses
- [x] `test-when-include-fires` — `policy.when pred (policy.include ...)` works
- [x] `test-when-inline-aspect` — `policy.when pred { nixos... }` works
- [x] `test-hasaspect-guard-fires` — `host.hasAspect` in guard fires correctly
- [x] `test-hasaspect-guard-suppresses` — guard suppresses when aspect absent
- [x] `test-hasaspect-from-user-scope` — works from user aspect includes
- [x] `test-deferred-guard-fires-after-walk` — walk-order independence via deferral
- [x] `test-hasaspect-foranyclass` — `forAnyClass` variant works
- [x] Full CI: 795/795 passing