### PR TITLE
feat: auto-label allow-ci for collaborators and add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/nix/     @vic @sini
+/modules/ @vic @sini

--- a/.github/workflows/auto-allow-ci.yml
+++ b/.github/workflows/auto-allow-ci.yml
@@ -1,0 +1,22 @@
+name: auto-allow-ci
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check author permission
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          perm=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission --jq '.permission')
+          if [[ "$perm" == "admin" || "$perm" == "write" ]]; then
+            echo "allowed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Add allow-ci label
+        if: steps.check.outputs.allowed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh issue edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label allow-ci


### PR DESCRIPTION
## Summary
- Adds `auto-allow-ci` workflow using `pull_request_target` that checks if the PR author has write/admin collaborator access and automatically adds the `allow-ci` label
- Adds `CODEOWNERS` to auto-request reviews from @vic and @sini for changes to `nix/` and `modules/`

## Test plan
- [ ] Open a test PR from a collaborator account — verify `allow-ci` label is added automatically
- [ ] Open a test PR from a non-collaborator — verify no label is added
- [ ] Modify a file in `nix/` or `modules/` — verify review is requested from vic and sini