### PR TITLE
fix: auto-allow-ci permissions and trigger

### DIFF
--- a/.github/workflows/auto-allow-ci.yml
+++ b/.github/workflows/auto-allow-ci.yml
@@ -1,7 +1,9 @@
 name: auto-allow-ci
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
+permissions:
+  pull-requests: write
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/checkmate/modules/formatter.nix
+++ b/checkmate/modules/formatter.nix
@@ -2,6 +2,7 @@
   perSystem.treefmt.settings.global.excludes = [
     ".claude/**"
     ".github/*TEMPLATE*/*"
+    ".github/CODEOWNERS"
     "docs/*"
     "Justfile"
     "AGENT*.md"


### PR DESCRIPTION
## Summary
- Adds `pull-requests: write` permission so `GITHUB_TOKEN` can add labels
- Removes `synchronize` trigger so the workflow only runs on PR open/reopen, not on every push

Fixes the `Resource not accessible by integration` error from #531.