### PR TITLE
fix: user-scope detection for home-env batteries and diagram null guard

### DIFF
--- a/modules/aspects/batteries/hjem.nix
+++ b/modules/aspects/batteries/hjem.nix
@@ -9,7 +9,12 @@ let
   result = makeHomeEnv {
     className = "hjem";
     optionPath = "hjem";
-    getModule = { host, ... }: inputs.hjem."${host.class}Modules".default;
+    getModule =
+      { host, ... }:
+      if inputs ? hjem then
+        inputs.hjem."${host.class}Modules".default
+      else
+        throw "den: hjem battery requires inputs.hjem — add hjem to your flake inputs or set den.hosts.<system>.<name>.hjem.module explicitly";
     forwardPathFn =
       { user, ... }:
       [
@@ -23,6 +28,8 @@ in
 {
   den.schema.host.imports = [ result.hostConf ];
   den.schema.host.includes = [ result.battery ];
+
+  den.schema.user.includes = [ result.userDetect ];
 
   den.classes.hjem.description = "Hjem user environment";
 }

--- a/modules/aspects/batteries/home-manager.nix
+++ b/modules/aspects/batteries/home-manager.nix
@@ -47,5 +47,7 @@ in
     { includes = [ hmHostBridge ]; }
   ];
 
+  den.schema.user.includes = [ result.userDetect ];
+
   den.classes.homeManager.description = "Home Manager user environment";
 }

--- a/modules/aspects/batteries/maid.nix
+++ b/modules/aspects/batteries/maid.nix
@@ -10,7 +10,12 @@ let
     className = "maid";
     supportedOses = [ "nixos" ];
     optionPath = "nix-maid";
-    getModule = { host, ... }: inputs.nix-maid."${host.class}Modules".default;
+    getModule =
+      { host, ... }:
+      if inputs ? nix-maid then
+        inputs.nix-maid."${host.class}Modules".default
+      else
+        throw "den: maid battery requires inputs.nix-maid — add nix-maid to your flake inputs or set den.hosts.<system>.<name>.nix-maid.module explicitly";
     forwardPathFn =
       { user, ... }:
       [
@@ -25,6 +30,8 @@ in
 {
   den.schema.host.imports = [ result.hostConf ];
   den.schema.host.includes = [ result.battery ];
+
+  den.schema.user.includes = [ result.userDetect ];
 
   den.classes.maid.description = "nix-maid user environment";
 }

--- a/nix/lib/diag/text.nix
+++ b/nix/lib/diag/text.nix
@@ -7,6 +7,10 @@
 # All functions return plain strings (not derivations).
 { lib }:
 let
+  # entityInstance is explicitly null in some graph constructors;
+  # Nix `or` only catches missing attrs, not null values.
+  instOf = default: e: if e.entityInstance or null == null then default else e.entityInstance;
+
   # --- Table helpers ---
 
   # Render a markdown table from headers and rows.
@@ -182,7 +186,7 @@ let
       aspectsByHost = lib.foldl' (
         acc: e:
         let
-          inst = e.entityInstance or "";
+          inst = instOf "" e;
           parts = lib.splitString ":" inst;
           kind = builtins.head parts;
           name = if builtins.length parts > 1 then lib.concatStringsSep ":" (lib.tail parts) else "";
@@ -278,7 +282,7 @@ let
       instanceGroups = lib.foldl' (
         acc: n:
         let
-          inst = n.entityInstance or "unscoped";
+          inst = instOf "unscoped" n;
         in
         acc // { ${inst} = (acc.${inst} or [ ]) ++ [ n ]; }
       ) { } userAspects;
@@ -299,7 +303,7 @@ let
         (
           if n.isParametric or false then "yes (${lib.concatStringsSep ", " (n.fnArgNames or [ ])})" else "no"
         )
-        (n.entityInstance or "—")
+        (instOf "—" n)
       ]) (lib.sort (a: b: a.label < b.label) userAspects);
 
       # Class breakdown.

--- a/nix/lib/home-env.nix
+++ b/nix/lib/home-env.nix
@@ -94,6 +94,14 @@ let
           fromAspect = _: den.lib.resolveEntity "user" { inherit host user; };
         };
 
+      # Includes shared by both host-scope and user-scope detection.
+      classIncludes = [
+        (den.lib.policy.include hostModule)
+      ]
+      ++ lib.optional (den.aspects ? os-user-class-fwd) (
+        den.lib.policy.include den.aspects.os-user-class-fwd
+      );
+
       policyFn =
         { host, ... }:
         let
@@ -109,14 +117,25 @@ let
             resolves = map (
               pair: den.lib.policy.resolve.withIncludes [ userForward ] { user = pair.user; }
             ) pairs;
-            rootIncludes = [
-              (den.lib.policy.include hostModule)
-            ]
-            ++ lib.optional (den.aspects ? os-user-class-fwd) (
-              den.lib.policy.include den.aspects.os-user-class-fwd
-            );
           in
-          resolves ++ rootIncludes;
+          resolves ++ classIncludes;
+
+      # Complements the host-scope battery which only sees users
+      # declared on host.users, not registry or policy-resolved users.
+      userDetectFn =
+        { host, user, ... }:
+        let
+          isOsSupported = builtins.elem host.class supportedOses;
+          hasClass = lib.elem className user.classes;
+        in
+        lib.optionals (isOsSupported && hasClass) (
+          [
+            (den.lib.policy.include (userForward {
+              inherit host user;
+            }))
+          ]
+          ++ classIncludes
+        );
     in
     {
       battery = {
@@ -126,6 +145,18 @@ let
             __isPolicy = true;
             name = "host-to-${ctxName}-users";
             fn = policyFn;
+          }
+        ];
+      };
+
+      # User-scope policy for user schema includes.
+      userDetect = {
+        policies."${ctxName}-user-detect" = userDetectFn;
+        includes = [
+          {
+            __isPolicy = true;
+            name = "${ctxName}-user-detect";
+            fn = userDetectFn;
           }
         ];
       };


### PR DESCRIPTION
## Summary

- **User-scope detection for home-env batteries**: The host-scope battery policy relied on `host.users` to detect class membership, which fails when users come from external registries resolved via policies (e.g. fleet-demo). Added `userDetect` — a user-scope policy on `den.schema.user.includes` that fires at `{ host, user }` context regardless of how the user was resolved. Applied to all three batteries: homeManager, hjem, maid.

- **Guard hjem/maid against missing inputs**: `hjem.nix` and `maid.nix` unconditionally accessed `inputs.hjem`/`inputs.nix-maid` in `getModule`, crashing any flake without those inputs. Now throws an actionable error message instead.

- **Fix diagram null coercion**: `entityInstance` is explicitly set to `null` in graph entries, but `text.nix` used `or ""` which only catches missing attrs. Changed to proper null-aware checks matching the existing `instOf` pattern from `graph.nix`.

## Test plan

- [x] 786/786 CI tests pass
- [x] `nix eval --override-input den . ./templates/fleet-demo#den` evaluates cleanly
- [x] `nix flake check --override-input den . ./templates/minimal` passes