### PR TITLE
fix: route ensureEntry emitted function instead of attrset

### DIFF
--- a/nix/lib/aspects/fx/route/apply.nix
+++ b/nix/lib/aspects/fx/route/apply.nix
@@ -162,11 +162,9 @@ let
             && route.path or [ ] != [ ]
             && modulesWithAdapter == [ ]
           )
-          (_: {
-            config = lib.setAttrByPath route.path (_: {
-              imports = [ ];
-            });
-          });
+          {
+            config = lib.setAttrByPath route.path { };
+          };
       isAdapterRoute = route.adapterKey or null != null;
       adapterWrapped = lib.optional isAdapterRoute (mkAdapterFunctor route sourceModules);
       # Route with instantiate: collect modules, call instantiate function,

--- a/templates/ci/modules/features/deadbugs/route-ensure-entry-function.nix
+++ b/templates/ci/modules/features/deadbugs/route-ensure-entry-function.nix
@@ -1,0 +1,38 @@
+{ denTest, ... }:
+{
+  flake.tests.route-ensure-entry-function = {
+    # When a route with adaptArgs and path has no source modules, the
+    # ensureEntry placeholder must produce an attrset — not a function.
+    # Bug: ensureEntry used (_: { imports = []; }) which is a function value.
+    test-empty-route-not-function = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.classes.custom = { };
+
+        den.policies.route-custom = _: [
+          (policy.route {
+            fromClass = "custom";
+            intoClass = "nixos";
+            collectSubtree = true;
+            path = [ "services" ];
+            adaptArgs = _: { };
+          })
+        ];
+
+        den.schema.host.includes = [
+          den.policies.route-custom
+        ];
+
+        # No aspects emit into the custom class, so ensureEntry fires.
+        # The route should produce an empty attrset at the path, not a function.
+        expr = builtins.isAttrs igloo.services;
+        expected = true;
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- When a route with `adaptArgs` and `path` had no source modules (empty class), the `ensureEntry` placeholder emitted `(_: { imports = []; })` as the value at the target path
- This is a function, not an attrset, causing type errors like `perSystem.packages` receiving `<function>` instead of `{ name = drv; }`
- Fix: replace with a plain empty attrset `{ }`

## Root cause

`apply.nix:166` had `lib.setAttrByPath route.path (_: { imports = []; })` — the inner `_:` made the value a function. The intent was an empty placeholder, but `_: { imports = []; }` is a lambda, not an empty module.

## Test plan

- [x] `test-empty-route-not-function` — route with no source modules produces valid attrset
- [x] Full CI: 787/787 passing