### PR TITLE
feat: ._ shorthand to include all child aspects

### DIFF
--- a/nix/lib/aspects/fx/aspect/normalize.nix
+++ b/nix/lib/aspects/fx/aspect/normalize.nix
@@ -26,6 +26,21 @@ let
     in
     if builtins.isFunction innerFn && isSubmoduleFn innerFn then
       normalizeModuleFn innerFn
+    # Synthetic provides: zero-arg functor returning an aspect-shaped value.
+    # Resolve immediately so the pipeline sees name/includes directly.
+    else if builtins.isFunction innerFn && innerArgs == { } && !(child ? __args) then
+      let
+        resolved = innerFn null;
+      in
+      if builtins.isAttrs resolved && resolved ? name && resolved ? includes then
+        resolved
+      else
+        child
+        // {
+          __fn = innerFn;
+          __args = { };
+          includes = child.includes or [ ];
+        }
     else
       child
       // {

--- a/nix/lib/aspects/fx/key-classification.nix
+++ b/nix/lib/aspects/fx/key-classification.nix
@@ -11,6 +11,7 @@ let
     "description"
     "meta"
     "includes"
+    "excludes"
     "provides"
     "policies"
     "into"

--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -93,6 +93,33 @@ let
       # provides-first so direct freeform keys on merged take priority.
       # __providesForwarded tells the pipeline to skip these during classification.
       providesChildren = builtins.removeAttrs (merged.provides or { }) [ "_module" ];
+      # Child aspect keys for synthetic provides: freeform keys that are
+      # not structural, internal, class, pipe, or forwarded-from-provides.
+      classReg = den.classes or { };
+      pipeReg = den.quirks or { };
+      inherit (den.lib.aspects.fx.keyClassification) structuralKeysSet;
+      forwardedSet = lib.genAttrs (builtins.attrNames providesChildren) (_: true);
+      aspectName =
+        merged.name
+          or (lib.concatStringsSep "." (map (x: if builtins.isString x then x else "<anon>") loc));
+      childKeys = builtins.filter (
+        k:
+        !(structuralKeysSet ? ${k})
+        && !(lib.hasPrefix "__" k)
+        && !(classReg ? ${k})
+        && !(pipeReg ? ${k})
+        && !(forwardedSet ? ${k})
+      ) (builtins.attrNames merged);
+      syntheticAspect = {
+        name = "${aspectName}._";
+        includes = map (k: merged.${k}) childKeys;
+      };
+      # __functor hides synthetic keys from attrValues while making _
+      # usable in includes lists. wrapFunctorChild extracts the thunk
+      # and compile-parametric resolves it to syntheticAspect.
+      syntheticProvides = providesChildren // {
+        __functor = _self: _args: syntheticAspect;
+      };
     in
     # __functor makes merged aspects callable (aspect { host = ...; }).
     # Explicit functors (e.g. den.batteries.forward) take priority.
@@ -101,6 +128,8 @@ let
     // {
       __functor = if originalFunctor != null then originalFunctor else resolveAspectWith;
       __providesForwarded = builtins.attrNames providesChildren;
+      provides = syntheticProvides;
+      _ = syntheticProvides;
     };
 
   aspectMeta =
@@ -159,8 +188,33 @@ let
         # aspect.child both work, matching mergeWithAspectMeta behavior.
         let
           providesChildren = builtins.removeAttrs (fn.provides or { }) [ "_module" ];
+          classReg = den.classes or { };
+          pipeReg = den.quirks or { };
+          inherit (den.lib.aspects.fx.keyClassification) structuralKeysSet;
+          forwardedSet = lib.genAttrs (builtins.attrNames providesChildren) (_: true);
+          result = providesChildren // fn;
+          aspectName = fn.name or (lib.last loc);
+          childKeys = builtins.filter (
+            k:
+            !(structuralKeysSet ? ${k})
+            && !(lib.hasPrefix "__" k)
+            && !(classReg ? ${k})
+            && !(pipeReg ? ${k})
+            && !(forwardedSet ? ${k})
+          ) (builtins.attrNames result);
+          syntheticAspect = {
+            name = "${aspectName}._";
+            includes = map (k: result.${k}) childKeys;
+          };
+          syntheticProvides = providesChildren // {
+            __functor = _self: _args: syntheticAspect;
+          };
         in
-        providesChildren // fn // { _ = fn.provides or { }; }
+        result
+        // {
+          provides = syntheticProvides;
+          _ = syntheticProvides;
+        }
       else
         let
           args = lib.functionArgs fn;

--- a/templates/ci/modules/features/include-children.nix
+++ b/templates/ci/modules/features/include-children.nix
@@ -113,6 +113,63 @@
       }
     );
 
+    # ._ does not expose synthetic name/includes to attrNames
+    test-include-children-attrvalues-compat = denTest (
+      {
+        den,
+        lib,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.parent = {
+          provides.a.nixos = { };
+          provides.b.nixos = { };
+          child.nixos = { };
+        };
+
+        # name and includes must not appear — they would break
+        # lib.attrValues patterns that expect only provides children.
+        expr = {
+          hasName = den.aspects.parent._ ? name;
+          hasIncludes = den.aspects.parent._ ? includes;
+        };
+        expected = {
+          hasName = false;
+          hasIncludes = false;
+        };
+      }
+    );
+
+    # ._ only includes immediate children, not grandchildren
+    test-include-children-no-grandchildren = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.top.mid.deep.nixos.services.openssh.enable = true;
+        den.aspects.top.sibling.nixos.services.timesyncd.enable = true;
+
+        den.aspects.igloo.includes = [ den.aspects.top._ ];
+
+        # mid and sibling are included but deep (grandchild) is not —
+        # mid must be explicitly included or have its own ._ for deep to resolve.
+        expr = {
+          time = igloo.services.timesyncd.enable;
+          ssh = igloo.services.openssh.enable or false;
+        };
+        expected = {
+          time = true;
+          ssh = false;
+        };
+      }
+    );
+
     # Parametric children resolve through ._
     test-include-children-parametric = denTest (
       {

--- a/templates/ci/modules/features/include-children.nix
+++ b/templates/ci/modules/features/include-children.nix
@@ -1,0 +1,146 @@
+{
+  denTest,
+  inputs,
+  ...
+}:
+{
+  flake.tests.include-children = {
+
+    # Basic: ._ includes all immediate child aspect keys
+    test-include-children-basic = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.servers.web.nixos.networking.hostName = "web-host";
+        den.aspects.servers.db.nixos.services.postgresql.enable = true;
+
+        den.aspects.igloo.includes = [ den.aspects.servers._ ];
+
+        expr = {
+          hostName = igloo.networking.hostName;
+          pg = igloo.services.postgresql.enable;
+        };
+        expected = {
+          hostName = "web-host";
+          pg = true;
+        };
+      }
+    );
+
+    # Empty: aspect with no freeform children — ._ is harmless
+    test-include-children-empty = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.empty = { };
+        den.aspects.igloo = {
+          nixos.networking.hostName = "still-here";
+          includes = [ den.aspects.empty._ ];
+        };
+
+        expr = igloo.networking.hostName;
+        expected = "still-here";
+      }
+    );
+
+    # Mixed: class keys on aspect are not included, only nested children
+    test-include-children-skips-class-keys = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.mixed = {
+          nixos.networking.hostName = "should-not-leak";
+          child.nixos.services.openssh.enable = true;
+        };
+
+        den.aspects.igloo.includes = [ den.aspects.mixed._ ];
+
+        # class key (nixos) must not leak — hostName stays at NixOS default
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          hostName = igloo.networking.hostName;
+        };
+        expected = {
+          ssh = true;
+          hostName = "nixos";
+        };
+      }
+    );
+
+    # Provides children remain accessible alongside synthetic aspect
+    test-include-children-with-provides = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.infra = {
+          provides.monitoring.nixos.services.prometheus.enable = true;
+          networking.nixos.networking.firewall.enable = true;
+        };
+
+        den.aspects.igloo.includes = [
+          den.aspects.infra._
+          den.aspects.infra._.monitoring
+        ];
+
+        expr = {
+          firewall = igloo.networking.firewall.enable;
+          prom = igloo.services.prometheus.enable;
+        };
+        expected = {
+          firewall = true;
+          prom = true;
+        };
+      }
+    );
+
+    # Parametric children resolve through ._
+    test-include-children-parametric = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.services.sshd =
+          { host, ... }:
+          {
+            nixos.services.openssh.enable = true;
+          };
+        den.aspects.services.ntp.nixos.services.timesyncd.enable = true;
+
+        den.aspects.igloo.includes = [ den.aspects.services._ ];
+
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          time = igloo.services.timesyncd.enable;
+        };
+        expected = {
+          ssh = true;
+          time = true;
+        };
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- `den.aspects.foo._` now acts as a synthetic aspect that auto-includes all immediate child aspect keys of `foo`
- Enables `includes = [ den.aspects.foo._ ]` instead of enumerating each child explicitly
- Synthetic keys hidden behind `__functor` so existing `lib.attrValues` patterns on `_` are unaffected
- Adds `excludes` to `structuralKeysSet` (pre-existing gap now surfaced)

## Implementation

**`types.nix`**: Both `mergeWithAspectMeta` and `mergeFunctions` compute child aspect keys (filtering out structural, class, pipe, forwarded, and `__`-prefixed keys) and build a synthetic aspect delivered via `__functor` on provides/_.

**`normalize.nix`**: `wrapFunctorChild` detects zero-arg functors returning aspect-shaped values and resolves them immediately.

**`key-classification.nix`**: Added `excludes` to `structuralKeysSet`.

## Test plan

- [x] 7 new tests in `include-children` suite (basic, empty, mixed, provides-coexistence, parametric, attrValues compat, no-grandchildren)
- [x] 801/801 full CI passes