### PR TITLE
fix: deferred conditional guards drain at correct scope level (#540)

### DIFF
--- a/nix/lib/aspects/fx/handlers/compile-conditional.nix
+++ b/nix/lib/aspects/fx/handlers/compile-conditional.nix
@@ -1,7 +1,8 @@
 # Effect handler: compile-conditional
-# Evaluates guard against path-set, emits includes or tombstones.
-# Guards that fail are deferred for re-evaluation when the pathSet grows;
-# drain-conditionals resolves them at entity boundary.
+# Evaluates guards with exclude-aware hasAspect. Guards that fail are
+# deferred for re-evaluation when the pathSet grows (drain-conditionals).
+# Constraint registry is read eagerly — emitPolicyEffectsThen registers
+# excludes before processing includes, so guards see per-scope excludes.
 {
   lib,
   den,
@@ -27,25 +28,39 @@ let
       )
     ) (fx.pure [ ]) aspects;
 
-  # Check if an aspect identity is excluded in the current scope.
-  # Mirrors the constraint lookup in check-constraint (constraint.nix)
-  # but only checks for excludes, not substitutes or filters.
+  # Collect constraint registry entries from the current scope and all
+  # ancestor scopes via scopeParent. Normalizes ownerChain to [] so
+  # isExcludedInScope treats all collected entries as in-scope.
+  collectScopeConstraints =
+    scopedRegistry: scopeParentMap:
+    let
+      go =
+        scope: acc:
+        let
+          scopeEntries = scopedRegistry.${scope} or { };
+          # Normalize entries: clear ownerChain since scope ancestry
+          # already establishes relevance.
+          normalized = lib.mapAttrs (_: entries: map (e: e // { ownerChain = [ ]; }) entries) scopeEntries;
+          merged = lib.zipAttrsWith (_: builtins.concatLists) [
+            acc
+            normalized
+          ];
+          parent = scopeParentMap.${scope} or null;
+        in
+        if parent == null then merged else go parent merged;
+    in
+    go;
+
+  # Reuse constraint lookup from constraint.nix to avoid duplicating
+  # the prefix-matching logic (identity path splitting + prefix search).
+  inherit (import ./constraint.nix { inherit lib den; }) lookupEntries;
+
+  # Check if an aspect identity is excluded in a constraint registry.
   isExcludedInScope =
     { constraintRegistry, includesChain }:
     nodeIdentity:
     let
-      parts = lib.splitString "/" nodeIdentity;
-      prefixes = lib.genList (i: lib.concatStringsSep "/" (lib.take (i + 1) parts)) (
-        builtins.length parts - 1
-      );
-      exact = constraintRegistry.${nodeIdentity} or [ ];
-      allEntries =
-        if constraintRegistry == { } then
-          exact
-        else if builtins.length parts > 1 then
-          exact ++ builtins.concatMap (p: constraintRegistry.${p} or [ ]) prefixes
-        else
-          exact;
+      allEntries = lookupEntries constraintRegistry nodeIdentity;
       isAncestor = ownerChain: lib.take (builtins.length ownerChain) includesChain == ownerChain;
       inScope =
         entry:
@@ -81,8 +96,6 @@ let
 
   # Build guard context with entity-shaped stubs so predicates written as
   # ({ host, ... }: host.hasAspect ref) work without touching config.resolved.
-  # Uses scope handler keys to identify entity kinds without evaluating the
-  # handlers (which would force entity config and cycle).
   # Exclude-aware: consults the constraint registry to respect per-scope
   # policy excludes, so hasAspect returns false for excluded aspects.
   mkGuardCtx =
@@ -141,22 +154,33 @@ in
         condNode = param.aspect;
       in
       {
+        # Evaluate guard with exclude awareness. The constraint registry
+        # has already been populated by emitPolicyEffectsThen (which
+        # registers excludes before processing includes).
         resume = fx.bind (fx.send "get-path-set" null) (
           pathSet:
-          let
-            guardCtx = mkGuardCtx {
-              inherit pathSet;
-              scopeHandlers = condNode.__scopeHandlers or { };
-            };
-            pass = condNode.meta.guard guardCtx;
-          in
-          if pass then
-            emitIncludes {
-              __parentScopeHandlers = condNode.__scopeHandlers or null;
-              __parentCtxId = condNode.__ctxId or null;
-            } condNode.meta.aspects
-          else
-            deferConditional condNode
+          fx.bind fx.effects.state.get (
+            currentState:
+            let
+              scopedRegistry = (currentState.scopedConstraintRegistry or (_: { })) null;
+              scopeParentMap = (currentState.scopeParent or (_: { })) null;
+              constraintRegistry =
+                collectScopeConstraints scopedRegistry scopeParentMap currentState.currentScope
+                  { };
+              guardCtx = mkGuardCtx {
+                inherit pathSet constraintRegistry;
+                scopeHandlers = condNode.__scopeHandlers or { };
+              };
+              pass = condNode.meta.guard guardCtx;
+            in
+            if pass then
+              emitIncludes {
+                __parentScopeHandlers = condNode.__scopeHandlers or null;
+                __parentCtxId = condNode.__ctxId or null;
+              } condNode.meta.aspects
+            else
+              deferConditional condNode
+          )
         );
         inherit state;
       };
@@ -172,11 +196,11 @@ in
       };
   };
 
-  # Re-evaluate deferred conditionals against the final pathSet and
-  # constraint registry. Iterates to fixed point: each pass re-reads
-  # state, evaluates remaining guards, and re-enqueues failures.
-  # Convergence: each pass that makes progress resolves ≥1 guard,
-  # strictly shrinking pending. No progress → cross-dependent → tombstone.
+  # Re-evaluate deferred conditionals with exclude-aware hasAspect.
+  # Uses scope-specific constraint registry (not flat) so per-scope
+  # excludes only affect their own scope.
+  # Fixed-point iteration: each pass re-reads state. Convergence
+  # guaranteed — each progressing pass resolves ≥1 guard.
   drainConditionalsHandler = {
     "drain-conditionals" =
       { param, state }:
@@ -194,7 +218,6 @@ in
         {
           resume =
             let
-              # Single pass: read pathSet + constraints, partition guards.
               drainPass =
                 pending: prevResults:
                 fx.bind (fx.send "get-path-set" null) (
@@ -202,8 +225,11 @@ in
                   fx.bind fx.effects.state.get (
                     currentState:
                     let
-                      constraintRegistry = currentState.flatConstraintRegistry or { };
-                      includesChain = ((currentState.scopedIncludesChain or (_: { })) null).${scope} or [ ];
+                      # Build scope-specific constraint registry from current
+                      # scope and ancestors — tux's excludes don't leak to pingu.
+                      scopedRegistry = (currentState.scopedConstraintRegistry or (_: { })) null;
+                      scopeParentMap = (currentState.scopeParent or (_: { })) null;
+                      constraintRegistry = collectScopeConstraints scopedRegistry scopeParentMap scope { };
                       len = builtins.length pending;
                       go =
                         idx: acc:
@@ -213,7 +239,7 @@ in
                           let
                             condNode = builtins.elemAt pending idx;
                             guardCtx = mkGuardCtx {
-                              inherit pathSet constraintRegistry includesChain;
+                              inherit pathSet constraintRegistry;
                               scopeHandlers = condNode.__scopeHandlers or { };
                             };
                             pass = condNode.meta.guard guardCtx;
@@ -253,10 +279,6 @@ in
                   )
                 );
 
-              # Fixed-point loop: iterate until no progress.
-              # Convergence guaranteed: each pass that makes progress resolves
-              # ≥1 guard, strictly shrinking pending. When no progress is made
-              # the remaining guards are cross-dependent — tombstone them.
               iterate =
                 pending: prevResults:
                 fx.bind (drainPass pending prevResults) (
@@ -272,7 +294,6 @@ in
                 );
             in
             iterate scopeDeferred [ ];
-          # Clear deferred conditionals for this scope.
           state = state // {
             scopedDeferredConditionals = _: allScoped // { ${scope} = [ ]; };
           };

--- a/nix/lib/aspects/fx/handlers/compile-conditional.nix
+++ b/nix/lib/aspects/fx/handlers/compile-conditional.nix
@@ -27,24 +27,74 @@ let
       )
     ) (fx.pure [ ]) aspects;
 
+  # Check if an aspect identity is excluded in the current scope.
+  # Mirrors the constraint lookup in check-constraint (constraint.nix)
+  # but only checks for excludes, not substitutes or filters.
+  isExcludedInScope =
+    { constraintRegistry, includesChain }:
+    nodeIdentity:
+    let
+      parts = lib.splitString "/" nodeIdentity;
+      prefixes = lib.genList (i: lib.concatStringsSep "/" (lib.take (i + 1) parts)) (
+        builtins.length parts - 1
+      );
+      exact = constraintRegistry.${nodeIdentity} or [ ];
+      allEntries =
+        if constraintRegistry == { } then
+          exact
+        else if builtins.length parts > 1 then
+          exact ++ builtins.concatMap (p: constraintRegistry.${p} or [ ]) prefixes
+        else
+          exact;
+      isAncestor = ownerChain: lib.take (builtins.length ownerChain) includesChain == ownerChain;
+      inScope =
+        entry:
+        entry.type == "exclude"
+        && ((entry.scope or "global") == "global" || isAncestor (entry.ownerChain or [ ]));
+    in
+    builtins.any inScope allEntries;
+
   # In-flight pathSet is not class-partitioned, so forClass approximates
   # as forAnyClass (may produce false positives across classes, never false
   # negatives). Accurate enough for guards — the pathSet reflects all
   # classes walked so far in the current resolution.
-  mkPipelineHasAspect = pathSet: {
-    __functor = _: ref: pathSet ? ${identity.key ref};
-    forClass = _: ref: pathSet ? ${identity.key ref};
-    forAnyClass = ref: pathSet ? ${identity.key ref};
+  mkPipelineHasAspect = pathSet: excludeCheck: {
+    __functor =
+      _: ref:
+      let
+        k = identity.key ref;
+      in
+      pathSet ? ${k} && !excludeCheck k;
+    forClass =
+      _: ref:
+      let
+        k = identity.key ref;
+      in
+      pathSet ? ${k} && !excludeCheck k;
+    forAnyClass =
+      ref:
+      let
+        k = identity.key ref;
+      in
+      pathSet ? ${k} && !excludeCheck k;
   };
 
   # Build guard context with entity-shaped stubs so predicates written as
   # ({ host, ... }: host.hasAspect ref) work without touching config.resolved.
   # Uses scope handler keys to identify entity kinds without evaluating the
   # handlers (which would force entity config and cycle).
+  # Exclude-aware: consults the constraint registry to respect per-scope
+  # policy excludes, so hasAspect returns false for excluded aspects.
   mkGuardCtx =
-    pathSet: scopeHandlers:
+    {
+      pathSet,
+      scopeHandlers,
+      constraintRegistry ? { },
+      includesChain ? [ ],
+    }:
     let
-      pipelineHasAspect = mkPipelineHasAspect pathSet;
+      excludeCheck = isExcludedInScope { inherit constraintRegistry includesChain; };
+      pipelineHasAspect = mkPipelineHasAspect pathSet excludeCheck;
       handlerKeys = builtins.attrNames scopeHandlers;
       entityKeys = builtins.filter (k: schemaEntityKindsSet ? ${k}) handlerKeys;
       entityStubs = lib.genAttrs entityKeys (_: {
@@ -52,7 +102,12 @@ let
       });
     in
     {
-      hasAspect = ref: pathSet ? ${identity.key ref};
+      hasAspect =
+        ref:
+        let
+          k = identity.key ref;
+        in
+        pathSet ? ${k} && !excludeCheck k;
     }
     // entityStubs;
 
@@ -89,7 +144,10 @@ in
         resume = fx.bind (fx.send "get-path-set" null) (
           pathSet:
           let
-            guardCtx = mkGuardCtx pathSet (condNode.__scopeHandlers or { });
+            guardCtx = mkGuardCtx {
+              inherit pathSet;
+              scopeHandlers = condNode.__scopeHandlers or { };
+            };
             pass = condNode.meta.guard guardCtx;
           in
           if pass then
@@ -114,8 +172,11 @@ in
       };
   };
 
-  # Re-evaluate deferred conditionals against the final pathSet.
-  # Called at entity boundary after the full tree walk completes.
+  # Re-evaluate deferred conditionals against the final pathSet and
+  # constraint registry. Iterates to fixed point: each pass re-reads
+  # state, evaluates remaining guards, and re-enqueues failures.
+  # Convergence: each pass that makes progress resolves ≥1 guard,
+  # strictly shrinking pending. No progress → cross-dependent → tombstone.
   drainConditionalsHandler = {
     "drain-conditionals" =
       { param, state }:
@@ -131,34 +192,86 @@ in
         }
       else
         {
-          resume = fx.bind (fx.send "get-path-set" null) (
-            pathSet:
+          resume =
             let
-              go =
-                idx: acc:
-                if idx >= builtins.length scopeDeferred then
-                  acc
-                else
-                  let
-                    condNode = builtins.elemAt scopeDeferred idx;
-                    guardCtx = mkGuardCtx pathSet (condNode.__scopeHandlers or { });
-                    pass = condNode.meta.guard guardCtx;
-                  in
-                  go (idx + 1) (
-                    fx.bind acc (
-                      prev:
-                      if pass then
-                        fx.bind (emitIncludes {
-                          __parentScopeHandlers = condNode.__scopeHandlers or null;
-                          __parentCtxId = condNode.__ctxId or null;
-                        } condNode.meta.aspects) (results: fx.pure (prev ++ results))
-                      else
-                        fx.bind (tombstoneAll condNode.meta.aspects) (tombstones: fx.pure (prev ++ tombstones))
+              # Single pass: read pathSet + constraints, partition guards.
+              drainPass =
+                pending: prevResults:
+                fx.bind (fx.send "get-path-set" null) (
+                  pathSet:
+                  fx.bind fx.effects.state.get (
+                    currentState:
+                    let
+                      constraintRegistry = currentState.flatConstraintRegistry or { };
+                      includesChain = ((currentState.scopedIncludesChain or (_: { })) null).${scope} or [ ];
+                      len = builtins.length pending;
+                      go =
+                        idx: acc:
+                        if idx >= len then
+                          acc
+                        else
+                          let
+                            condNode = builtins.elemAt pending idx;
+                            guardCtx = mkGuardCtx {
+                              inherit pathSet constraintRegistry includesChain;
+                              scopeHandlers = condNode.__scopeHandlers or { };
+                            };
+                            pass = condNode.meta.guard guardCtx;
+                          in
+                          go (idx + 1) (
+                            fx.bind acc (
+                              prev:
+                              if pass then
+                                fx.bind
+                                  (emitIncludes {
+                                    __parentScopeHandlers = condNode.__scopeHandlers or null;
+                                    __parentCtxId = condNode.__ctxId or null;
+                                  } condNode.meta.aspects)
+                                  (
+                                    results:
+                                    fx.pure {
+                                      emitted = prev.emitted ++ results;
+                                      failed = prev.failed;
+                                      progressed = true;
+                                    }
+                                  )
+                              else
+                                fx.pure {
+                                  inherit (prev) emitted progressed;
+                                  failed = prev.failed ++ [ condNode ];
+                                }
+                            )
+                          );
+                    in
+                    go 0 (
+                      fx.pure {
+                        emitted = prevResults;
+                        failed = [ ];
+                        progressed = false;
+                      }
                     )
-                  );
+                  )
+                );
+
+              # Fixed-point loop: iterate until no progress.
+              # Convergence guaranteed: each pass that makes progress resolves
+              # ≥1 guard, strictly shrinking pending. When no progress is made
+              # the remaining guards are cross-dependent — tombstone them.
+              iterate =
+                pending: prevResults:
+                fx.bind (drainPass pending prevResults) (
+                  result:
+                  if result.failed == [ ] then
+                    fx.pure result.emitted
+                  else if !result.progressed then
+                    fx.bind (tombstoneAll (builtins.concatMap (n: n.meta.aspects) result.failed)) (
+                      tombstones: fx.pure (result.emitted ++ tombstones)
+                    )
+                  else
+                    iterate result.failed result.emitted
+                );
             in
-            go 0 (fx.pure [ ])
-          );
+            iterate scopeDeferred [ ];
           # Clear deferred conditionals for this scope.
           state = state // {
             scopedDeferredConditionals = _: allScoped // { ${scope} = [ ]; };

--- a/nix/lib/aspects/fx/handlers/constraint.nix
+++ b/nix/lib/aspects/fx/handlers/constraint.nix
@@ -149,5 +149,5 @@ let
   };
 in
 {
-  inherit constraintRegistryHandler;
+  inherit constraintRegistryHandler lookupEntries;
 }

--- a/nix/lib/aspects/fx/handlers/resolve-children.nix
+++ b/nix/lib/aspects/fx/handlers/resolve-children.nix
@@ -61,23 +61,42 @@ in
         chainIdentity = param.chainIdentity;
       in
       {
-        resume = fx.bind (chainWrap chainIdentity isMeaningful (resolveChildSequence aspect)) (
-          allChildren:
-          # Re-evaluate deferred conditional guards now that the subtree
-          # has been walked and the pathSet is more complete.
-          fx.bind (fx.effects.hasHandler "drain-conditionals") (
-            hasDrain:
-            fx.bind (if hasDrain then fx.send "drain-conditionals" null else fx.pure [ ]) (
-              conditionalResults:
+        resume =
+          let
+            # Only drain deferred conditionals at entity-level aspects or
+            # root scope aspects. Draining inside nested aspects is premature
+            # — parent siblings haven't resolved yet.
+            isEntityRoot = aspect ? __entityKind;
+            maybeDrain =
+              allChildren:
+              fx.bind (fx.effects.hasHandler "drain-conditionals") (
+                hasDrain:
+                if !hasDrain then
+                  fx.pure allChildren
+                else if isEntityRoot then
+                  fx.bind (fx.send "drain-conditionals" null) (results: fx.pure (allChildren ++ results))
+                else
+                  fx.bind fx.effects.state.get (
+                    st:
+                    if st.currentScope == (st.rootScopeId or null) then
+                      fx.bind (fx.send "drain-conditionals" null) (results: fx.pure (allChildren ++ results))
+                    else
+                      fx.pure allChildren
+                  )
+              );
+          in
+          fx.bind (chainWrap chainIdentity isMeaningful (resolveChildSequence aspect)) (
+            allChildren:
+            fx.bind (maybeDrain allChildren) (
+              finalChildren:
               let
                 resolved = aspect // {
-                  includes = allChildren ++ conditionalResults;
+                  includes = finalChildren;
                 };
               in
               fx.bind (fx.send "resolve-complete" resolved) (_: fx.pure resolved)
             )
-          )
-        );
+          );
         inherit state;
       };
   };

--- a/templates/ci/modules/features/deadbugs/issue-540-conditional-first-include.nix
+++ b/templates/ci/modules/features/deadbugs/issue-540-conditional-first-include.nix
@@ -1,0 +1,148 @@
+{ denTest, ... }:
+{
+  flake.tests.issue-540-conditional-first-include = {
+    # Guard on an aspect included by a later sibling. The conditional is walked
+    # first, so the guard fails initially. Drain must wait until all siblings
+    # are resolved before re-evaluating.
+    test-conditional-before-dependency = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [
+          den.aspects.conditional
+          den.aspects.base
+        ];
+
+        den.aspects.base.includes = [
+          den.aspects.git
+        ];
+
+        den.aspects.conditional = {
+          includes = [
+            (den.lib.policy.when ({ host, ... }: host.hasAspect den.aspects.git) {
+              nixos.environment.variables.GIT_ENABLED = "true";
+            })
+          ];
+        };
+
+        den.aspects.git.nixos.programs.git.enable = true;
+
+        expr = igloo.environment.variables ? GIT_ENABLED;
+        expected = true;
+      }
+    );
+
+    # Same but via schema includes at the same level.
+    test-conditional-same-level-schema = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.schema.host.includes = [
+          den.aspects.conditional
+          den.aspects.base
+        ];
+
+        den.aspects.base.includes = [
+          den.aspects.git
+        ];
+
+        den.aspects.conditional = {
+          includes = [
+            (den.lib.policy.when ({ host, ... }: host.hasAspect den.aspects.git) {
+              nixos.environment.variables.GIT_ENABLED = "true";
+            })
+          ];
+        };
+
+        den.aspects.git.nixos.programs.git.enable = true;
+
+        expr = igloo.environment.variables ? GIT_ENABLED;
+        expected = true;
+      }
+    );
+
+    # Multiple guards with different dependencies resolve in the same drain.
+    # Tests that the fixed-point drain handles interleaved pass/fail correctly.
+    test-chained-guards = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [
+          den.aspects.base
+        ];
+
+        den.aspects.base.nixos.programs.git.enable = true;
+
+        # Guard B fires first (git is present), emits editor aspect.
+        den.schema.host.includes = [
+          (policy.when ({ host, ... }: host.hasAspect den.aspects.editor) {
+            nixos.environment.variables.EDITOR_CONFIGURED = "true";
+          })
+          (policy.when ({ host, ... }: host.hasAspect den.aspects.base) {
+            nixos.networking.hostName = "has-base";
+          })
+          den.aspects.editor
+        ];
+
+        den.aspects.editor.nixos.environment.variables.EDITOR = "vim";
+
+        expr = {
+          hasBase = igloo.networking.hostName;
+          editorConfigured = igloo.environment.variables ? EDITOR_CONFIGURED;
+        };
+        expected = {
+          hasBase = "has-base";
+          editorConfigured = true;
+        };
+      }
+    );
+
+    # True multi-pass convergence: Guard A depends on aspect X which only
+    # enters the pathSet because Guard B passed and emitted it.
+    # Pass 1: B passes (base in pathSet), emits tooling (which includes editor).
+    #         A fails (editor not yet in pathSet — emitIncludes runs after eval).
+    # Pass 2: A passes (editor now in pathSet from B's emission).
+    test-multi-pass-convergence = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.igloo.includes = [
+          den.aspects.base
+        ];
+
+        den.aspects.base.nixos.programs.git.enable = true;
+
+        # Guard A: depends on editor (not in pathSet until B emits tooling).
+        # Guard B: depends on base (in pathSet), emits tooling which includes editor.
+        den.schema.host.includes = [
+          (policy.when ({ host, ... }: host.hasAspect den.aspects.editor) {
+            nixos.environment.variables.EDITOR_CONFIGURED = "true";
+          })
+          (policy.when ({ host, ... }: host.hasAspect den.aspects.base) (policy.include den.aspects.tooling))
+        ];
+
+        den.aspects.tooling.includes = [ den.aspects.editor ];
+        den.aspects.editor.nixos.environment.variables.EDITOR = "vim";
+
+        expr = {
+          hasEditor = igloo.environment.variables ? EDITOR;
+          editorConfigured = igloo.environment.variables ? EDITOR_CONFIGURED;
+        };
+        expected = {
+          hasEditor = true;
+          editorConfigured = true;
+        };
+      }
+    );
+  };
+}

--- a/templates/ci/modules/features/deadbugs/issue-540-exclude-guard.nix
+++ b/templates/ci/modules/features/deadbugs/issue-540-exclude-guard.nix
@@ -1,0 +1,63 @@
+{ denTest, lib, ... }:
+{
+  flake.tests.issue-540-exclude-guard = {
+    # Known limitation: guards that pass eagerly don't see later excludes.
+    # starship is excluded for tux, but the guard fires before the exclude.
+    # Fixing this requires scope-aware drain timing — tracked separately.
+    test-exclude-does-not-suppress-eager-guard = denTest (
+      { den, igloo, ... }:
+      let
+        inherit (den.lib) policy;
+      in
+      {
+        den.hosts.x86_64-linux.igloo.users = {
+          tux = { };
+          pingu = { };
+        };
+
+        den.aspects.starship.homeManager.programs.starship.enable = true;
+        den.aspects.jujutsu = {
+          homeManager.programs.jujutsu.enable = true;
+          includes = [
+            (policy.when ({ user, ... }: user.hasAspect den.aspects.starship) (
+              policy.include {
+                homeManager.programs.starship.settings.custom.jj = {
+                  command = "prompt";
+                  when = true;
+                };
+              }
+            ))
+          ];
+        };
+
+        den.aspects.features.includes = [
+          den.aspects.starship
+          den.aspects.jujutsu
+        ];
+
+        den.aspects.igloo = {
+          includes = [ den.aspects.igloo.policies.to-users ];
+          policies.to-users =
+            { user, ... }:
+            [
+              (policy.include den.aspects.features)
+            ]
+            ++ lib.optional (user.userName == "tux") (policy.exclude den.aspects.starship);
+        };
+
+        expr = {
+          tux-starship = igloo.home-manager.users.tux.programs.starship.enable;
+          pingu-starship = igloo.home-manager.users.pingu.programs.starship.enable;
+          tux-jj = igloo.home-manager.users.tux.programs.starship.settings ? custom;
+          pingu-jj = igloo.home-manager.users.pingu.programs.starship.settings ? custom;
+        };
+        expected = {
+          tux-starship = false;
+          pingu-starship = true;
+          tux-jj = true; # ideally false, but eager guard doesn't see later exclude
+          pingu-jj = true;
+        };
+      }
+    );
+  };
+}

--- a/templates/ci/modules/features/deadbugs/issue-540-exclude-guard.nix
+++ b/templates/ci/modules/features/deadbugs/issue-540-exclude-guard.nix
@@ -1,10 +1,11 @@
 { denTest, lib, ... }:
 {
   flake.tests.issue-540-exclude-guard = {
-    # Known limitation: guards that pass eagerly don't see later excludes.
-    # starship is excluded for tux, but the guard fires before the exclude.
-    # Fixing this requires scope-aware drain timing — tracked separately.
-    test-exclude-does-not-suppress-eager-guard = denTest (
+    # Guard respects per-scope excludes: starship is excluded for tux
+    # via policy.exclude, so user.hasAspect starship returns false in
+    # tux's scope. Guards always defer and evaluate at drain time with
+    # scope-specific constraint awareness.
+    test-exclude-suppresses-guard = denTest (
       { den, igloo, ... }:
       let
         inherit (den.lib) policy;
@@ -54,7 +55,7 @@
         expected = {
           tux-starship = false;
           pingu-starship = true;
-          tux-jj = true; # ideally false, but eager guard doesn't see later exclude
+          tux-jj = false;
           pingu-jj = true;
         };
       }

--- a/templates/ci/modules/features/fx-compile-conditional.nix
+++ b/templates/ci/modules/features/fx-compile-conditional.nix
@@ -147,7 +147,8 @@
             // handlers.deferConditionalHandler
             // handlers.drainConditionalsHandler
             // identity.pathSetHandler
-            // stubs;
+            // stubs
+            // fx.effects.state.handler;
           inherit state;
         } comp;
         tombstones = result.value;
@@ -203,7 +204,8 @@
             // handlers.deferConditionalHandler
             // handlers.drainConditionalsHandler
             // identity.pathSetHandler
-            // stubs;
+            // stubs
+            // fx.effects.state.handler;
           inherit state;
         } comp;
       in

--- a/templates/ci/modules/features/fx-compile-conditional.nix
+++ b/templates/ci/modules/features/fx-compile-conditional.nix
@@ -92,7 +92,8 @@
             // handlers.chainHandler
             // identity.pathSetHandler
             // identity.collectPathsHandler
-            // stubs;
+            // stubs
+            // fx.effects.state.handler;
           inherit state;
         } comp;
       in
@@ -310,7 +311,8 @@
             // handlers.chainHandler
             // identity.pathSetHandler
             // identity.collectPathsHandler
-            // stubs;
+            // stubs
+            // fx.effects.state.handler;
           inherit state;
         } comp;
         child = builtins.head result.value;

--- a/templates/ci/modules/features/narrow-effects.nix
+++ b/templates/ci/modules/features/narrow-effects.nix
@@ -63,6 +63,7 @@ let
 
   defaultState = {
     currentScope = "__test";
+    rootScopeId = "__test";
     scopedIncludesChain = _: { };
     scopedConstraintRegistry = _: { };
     scopedConstraintFilters = _: { };


### PR DESCRIPTION
## Summary

- Fixes #540: `policy.when` with `hasAspect` failed when the conditional was the first include and its dependency was a later sibling
- `drain-conditionals` was firing inside every `resolve-children` call, including nested aspects — the guard re-evaluated before siblings were walked
- Now drains only at entity-level aspects (`__entityKind`) or root scope aspects (`currentScope == rootScopeId`)

## Root cause

The conditional's `resolve-children` drained deferred guards before the parent finished walking all siblings. The pathSet was incomplete, so the guard failed and tombstoned permanently.

## Test plan

- [x] `test-conditional-before-dependency` — conditional first, dependency second in aspect includes
- [x] `test-conditional-same-level-schema` — same pattern via schema includes
- [x] Full CI: 805/805 passing (including all prior #525/#530 tests)

Co-Authored-by: @fmway who provided amazing tests