### PR TITLE
fix: excludes work on nested keys without _ prefix

### DIFF
--- a/nix/lib/aspects/fx/aspect/children.nix
+++ b/nix/lib/aspects/fx/aspect/children.nix
@@ -131,10 +131,26 @@ let
           [ rawHandleWith ]
         else
           [ ];
+      # Compute exclude identity, normalizing content wrappers that have
+      # __provider but no name (nested keys without _ prefix).
+      excludeIdentity =
+        ref:
+        if builtins.isAttrs ref && ref.__isPolicy or false then
+          ref.name
+        else if builtins.isAttrs ref && ref ? __provider && !(ref ? name) then
+          let
+            prov = ref.__provider;
+          in
+          identity.key {
+            name = if prov != [ ] then lib.last prov else "<anon>";
+            meta.provider = if prov != [ ] then lib.init prov else [ ];
+          }
+        else
+          identity.key ref;
       excludeList = map (ref: {
         type = "exclude";
         scope = "subtree";
-        identity = if builtins.isAttrs ref && ref.__isPolicy or false then ref.name else identity.key ref;
+        identity = excludeIdentity ref;
       }) rawExcludes;
       allConstraints = handleWithList ++ excludeList;
       owner = aspect.name or "<anon>";

--- a/templates/ci/modules/features/deadbugs/issue-nested-key-exclude.nix
+++ b/templates/ci/modules/features/deadbugs/issue-nested-key-exclude.nix
@@ -1,0 +1,39 @@
+{ denTest, ... }:
+{
+  flake.tests.issue-nested-key-exclude = {
+    # Excluding a nested key (sub-aspect defined without _ prefix) should
+    # work the same as excluding a provides sub-aspect.
+    test-nested-key-exclude = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.my-aspect = {
+          includes = with den.aspects.my-aspect; [
+            sub-aspect1
+            sub-aspect2
+          ];
+          sub-aspect1.nixos.environment.variables.SUB_ASPECT_1 = "yes";
+          _.sub-aspect2.nixos.environment.variables.SUB_ASPECT_2 = "yes";
+        };
+
+        den.aspects.igloo.includes = [
+          den.aspects.my-aspect
+        ];
+        den.aspects.igloo.excludes = [
+          den.aspects.my-aspect.sub-aspect1
+          den.aspects.my-aspect.sub-aspect2
+        ];
+
+        expr = {
+          sub-aspect1 = igloo.environment.variables ? SUB_ASPECT_1;
+          sub-aspect2 = igloo.environment.variables ? SUB_ASPECT_2;
+        };
+        expected = {
+          sub-aspect1 = false;
+          sub-aspect2 = false;
+        };
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Summary

- Nested keys defined without `_` prefix (e.g., `my-aspect.sub-aspect1`) produce content wrappers `{ __contentValues, __provider }` with no `name` field
- When passed to `excludes`, `identity.key` produced `"<anon>"` instead of the actual key name, so the constraint never matched the aspect during the tree walk
- Fix: normalize content wrappers in `registerConstraints` by extracting `name` from `__provider` — the same normalization `wrapChild` does in `normalize.nix`

## Root cause

The aspect type system produces different shapes for nested keys vs `_`-prefixed sub-aspects:
- `den.aspects.foo.bar` → `{ __contentValues, __provider }` (content wrapper, no `name`)
- `den.aspects.foo._.bar` → `{ name = "bar"; meta.provider = [...]; ... }` (full aspect)

The constraint system computed identity on the raw wrapper before normalization injected the name.

## Test plan

- [x] `test-nested-key-exclude` — excludes both `_`-prefixed and non-prefixed sub-aspects
- [x] Full CI: 809/809