### PR TITLE
feat: extend ._ shorthand to nested aspects

### DIFF
--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -470,11 +470,28 @@ let
           # Without provides, aspectContentType handles the merge, but the
           # wrapper must still be invocable like the providerType path.
           singleFn = builtins.length flatDefs == 1 && lib.isFunction (builtins.head flatDefs).value;
+          # Synthetic ._ for nested aspects — same semantics as root aspects.
+          # Collect forwarded child keys (exclude class, pipe, structural, internal).
+          classReg = den.classes or { };
+          pipeReg = den.quirks or { };
+          inherit (den.lib.aspects.fx.keyClassification) structuralKeysSet;
+          provider = (typeCfg.providerPrefix or [ ]) ++ [ keyName ];
+          childKeys = builtins.filter (
+            k: !(structuralKeysSet ? ${k}) && !(lib.hasPrefix "__" k) && !(classReg ? ${k}) && !(pipeReg ? ${k})
+          ) (builtins.attrNames merged);
+          aspectName = lib.concatStringsSep "." provider;
+          syntheticAspect = {
+            name = "${aspectName}._";
+            includes = map (k: merged.${k}) childKeys;
+          };
         in
         merged
         // {
           __contentValues = flatDefs;
-          __provider = (typeCfg.providerPrefix or [ ]) ++ [ keyName ];
+          __provider = provider;
+          _ = {
+            __functor = _self: _args: syntheticAspect;
+          };
         }
         // lib.optionalAttrs singleFn {
           __functor = _self: (builtins.head flatDefs).value;

--- a/templates/ci/modules/features/include-children.nix
+++ b/templates/ci/modules/features/include-children.nix
@@ -199,5 +199,146 @@
         };
       }
     );
+    # ._ works on nested (wrapped) aspects, not just root aspects
+    test-include-children-nested = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.top.mid.deep.nixos.services.openssh.enable = true;
+        den.aspects.top.mid.shallow.nixos.services.timesyncd.enable = true;
+
+        # mid._ should collect deep and shallow
+        den.aspects.igloo.includes = [ den.aspects.top.mid._ ];
+
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          time = igloo.services.timesyncd.enable;
+        };
+        expected = {
+          ssh = true;
+          time = true;
+        };
+      }
+    );
+
+    # Chained ._ at multiple nesting levels
+    test-include-children-nested-chained = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.infra.net.fw.nixos.networking.firewall.enable = true;
+        den.aspects.infra.net.dns.nixos.networking.nameservers = [ "1.1.1.1" ];
+
+        # top-level ._ includes net; net._ includes fw and dns
+        den.aspects.igloo.includes = [ den.aspects.infra.net._ ];
+
+        expr = {
+          fw = igloo.networking.firewall.enable;
+          dns = igloo.networking.nameservers;
+        };
+        expected = {
+          fw = true;
+          dns = [ "1.1.1.1" ];
+        };
+      }
+    );
+
+    # Nested ._ with mixed content: class keys + child aspects on same wrapper
+    test-include-children-nested-mixed = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        # sub has both a class key (nixos) and child aspects (a, b)
+        den.aspects.group.sub.nixos.networking.hostName = "from-sub";
+        den.aspects.group.sub.a.nixos.services.openssh.enable = true;
+        den.aspects.group.sub.b.nixos.services.timesyncd.enable = true;
+
+        # ._ should only include a and b, not the nixos class key
+        den.aspects.igloo.includes = [ den.aspects.group.sub._ ];
+
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          time = igloo.services.timesyncd.enable;
+          hostName = igloo.networking.hostName;
+        };
+        expected = {
+          ssh = true;
+          time = true;
+          hostName = "nixos"; # class key must not leak
+        };
+      }
+    );
+
+    # Nested ._ skips class keys, same as root ._
+    test-include-children-nested-skips-class-keys = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.group.sub = {
+          nixos.networking.hostName = "should-not-leak";
+          child.nixos.services.openssh.enable = true;
+        };
+
+        den.aspects.igloo.includes = [ den.aspects.group.sub._ ];
+
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          hostName = igloo.networking.hostName;
+        };
+        expected = {
+          ssh = true;
+          hostName = "nixos";
+        };
+      }
+    );
+    # Nested ._ with parametric child aspects
+    test-include-children-nested-parametric = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.group.sub.static.nixos.services.timesyncd.enable = true;
+        den.aspects.group.sub.dynamic =
+          { host, ... }:
+          {
+            nixos.services.openssh.enable = true;
+          };
+
+        den.aspects.igloo.includes = [ den.aspects.group.sub._ ];
+
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          time = igloo.services.timesyncd.enable;
+        };
+        expected = {
+          ssh = true;
+          time = true;
+        };
+      }
+    );
   };
 }

--- a/templates/ci/modules/features/include-children.nix
+++ b/templates/ci/modules/features/include-children.nix
@@ -311,6 +311,43 @@
         };
       }
     );
+
+    # Nested ._ excludes user-defined class keys
+    test-include-children-nested-custom-class = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.classes.os = {
+          description = "Custom OS class";
+          forwardTo = {
+            class = "nixos";
+            path = [ ];
+          };
+        };
+
+        # sub has a custom class key (os) and a child aspect (svc)
+        den.aspects.group.sub.os.networking.hostName = "from-os";
+        den.aspects.group.sub.svc.nixos.services.openssh.enable = true;
+
+        # ._ must include svc but not os
+        den.aspects.igloo.includes = [ den.aspects.group.sub._ ];
+
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          hostName = igloo.networking.hostName;
+        };
+        expected = {
+          ssh = true;
+          hostName = "nixos"; # os class key must not leak through ._
+        };
+      }
+    );
+
     # Nested ._ with parametric child aspects
     test-include-children-nested-parametric = denTest (
       {


### PR DESCRIPTION
## Summary
- Adds `._` synthesis to `aspectContentType`, matching the existing behavior on root aspects via `mergeWithAspectMeta`
- Nested aspects wrapped by `aspectContentType` now collect child keys (excluding class, pipe, structural, and internal keys) into a synthetic `._` with a zero-arg functor
- `den.aspects.top.mid._` now works the same as `den.aspects.top._`

## Test plan
- [x] `test-include-children-nested` — basic nested `._` with two children
- [x] `test-include-children-nested-chained` — `._` at deeper nesting levels
- [x] `test-include-children-nested-mixed` — class keys + child aspects on same wrapper
- [x] `test-include-children-nested-skips-class-keys` — class keys excluded from nested `._`
- [x] `test-include-children-nested-parametric` — parametric children resolve through nested `._`
- [x] All 12 include-children tests pass
- [x] Full CI: 813/813 passing