### PR TITLE
feat: forward provides children onto nested aspects

### DIFF
--- a/nix/lib/aspects/types.nix
+++ b/nix/lib/aspects/types.nix
@@ -475,6 +475,10 @@ let
           classReg = den.classes or { };
           pipeReg = den.quirks or { };
           inherit (den.lib.aspects.fx.keyClassification) structuralKeysSet;
+          # Forward provides children onto the wrapper so
+          # aspect.child.monitoring resolves to aspect.child.provides.monitoring,
+          # matching mergeWithAspectMeta behavior for root aspects.
+          providesChildren = builtins.removeAttrs (merged.provides or { }) [ "_module" ];
           provider = (typeCfg.providerPrefix or [ ]) ++ [ keyName ];
           childKeys = builtins.filter (
             k: !(structuralKeysSet ? ${k}) && !(lib.hasPrefix "__" k) && !(classReg ? ${k}) && !(pipeReg ? ${k})
@@ -485,10 +489,12 @@ let
             includes = map (k: merged.${k}) childKeys;
           };
         in
-        merged
+        providesChildren
+        // merged
         // {
           __contentValues = flatDefs;
           __provider = provider;
+          __providesForwarded = builtins.attrNames providesChildren;
           _ = {
             __functor = _self: _args: syntheticAspect;
           };

--- a/templates/ci/modules/features/nested-provides-forwarding.nix
+++ b/templates/ci/modules/features/nested-provides-forwarding.nix
@@ -1,0 +1,113 @@
+{
+  denTest,
+  ...
+}:
+{
+  flake.tests.nested-provides-forwarding = {
+
+    # Provides children are forwarded onto nested aspects
+    test-nested-provides-access = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.group.sub = {
+          provides.monitoring.nixos.services.prometheus.enable = true;
+        };
+
+        # monitoring should be accessible directly on sub
+        den.aspects.igloo.includes = [
+          den.aspects.group.sub.monitoring
+        ];
+
+        expr = igloo.services.prometheus.enable;
+        expected = true;
+      }
+    );
+
+    # Self-provide still works on nested aspects
+    test-nested-self-provide = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.group.sub = {
+          provides.sub.nixos.services.openssh.enable = true;
+          nixos.networking.hostName = "sub-host";
+        };
+
+        den.aspects.igloo.includes = [ den.aspects.group.sub ];
+
+        expr = {
+          hostName = igloo.networking.hostName;
+          ssh = igloo.services.openssh.enable;
+        };
+        expected = {
+          hostName = "sub-host";
+          ssh = true;
+        };
+      }
+    );
+
+    # Direct freeform keys override forwarded provides children
+    test-nested-provides-direct-wins = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.group.sub = {
+          provides.svc.nixos.networking.hostName = "from-provides";
+          svc.nixos.networking.hostName = "from-direct";
+        };
+
+        den.aspects.igloo.includes = [ den.aspects.group.sub.svc ];
+
+        expr = igloo.networking.hostName;
+        expected = "from-direct";
+      }
+    );
+
+    # Provides forwarding with multiple children
+    test-nested-provides-multiple = denTest (
+      {
+        den,
+        igloo,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.aspects.group.sub = {
+          provides.monitoring.nixos.services.prometheus.enable = true;
+          provides.logging.nixos.services.journald.forwardToSyslog = true;
+        };
+
+        den.aspects.igloo.includes = [
+          den.aspects.group.sub.monitoring
+          den.aspects.group.sub.logging
+        ];
+
+        expr = {
+          prom = igloo.services.prometheus.enable;
+          journal = igloo.services.journald.forwardToSyslog;
+        };
+        expected = {
+          prom = true;
+          journal = true;
+        };
+      }
+    );
+  };
+}


### PR DESCRIPTION
## Summary
- `aspectContentType` now forwards `provides` children onto the content wrapper, matching `mergeWithAspectMeta` behavior for root aspects
- `den.aspects.parent.child.monitoring` now resolves to `den.aspects.parent.child.provides.monitoring`
- Sets `__providesForwarded` so the pipeline can distinguish forwarded keys from direct freeform keys

## Test plan
- [x] `test-nested-provides-access` — forwarded provides child accessible directly
- [x] `test-nested-self-provide` — self-provide still works on nested aspects
- [x] `test-nested-provides-direct-wins` — direct freeform keys override forwarded provides
- [x] `test-nested-provides-multiple` — multiple provides children forwarded
- [x] Full CI: 813/813 passing