### PR TITLE
fix: hm-host crash with standalone homes + homeManager forwarding

### DIFF
--- a/modules/aspects/batteries/home-manager.nix
+++ b/modules/aspects/batteries/home-manager.nix
@@ -6,9 +6,7 @@
   ...
 }:
 let
-  inherit (den.lib.home-env) makeHomeEnv mkDetectHost;
-
-  result = makeHomeEnv {
+  result = den.lib.home-env.makeHomeEnv {
     className = "homeManager";
     ctxName = "hm";
     optionPath = "home-manager";
@@ -20,32 +18,13 @@ let
         "users"
         user.userName
       ];
+    schemaIncludes = config.den.schema.hm-host.includes or [ ];
   };
-
-  # Bridge den.schema.hm-host includes into host resolution via policy.include.
-  # Guarded by policy.when — only fires when the host has homeManager users.
-  hmHostSchemaIncludes = config.den.schema.hm-host.includes or [ ];
-  hasHmUsers =
-    { host, ... }:
-    mkDetectHost {
-      className = "homeManager";
-      optionPath = "home-manager";
-    } { inherit host; };
-  hmHostBridge = den.lib.policy.when hasHmUsers (
-    den.lib.policy.mkPolicy "hm-host-schema" (
-      _: map (inc: den.lib.policy.include inc) hmHostSchemaIncludes
-    )
-  );
 
 in
 {
   den.schema.host.imports = [ result.hostConf ];
-  den.schema.host.includes = [
-    result.battery
-  ]
-  ++ lib.optionals (hmHostSchemaIncludes != [ ]) [
-    { includes = [ hmHostBridge ]; }
-  ];
+  den.schema.host.includes = [ result.battery ];
 
   den.schema.user.includes = [ result.userDetect ];
 

--- a/nix/lib/home-env.nix
+++ b/nix/lib/home-env.nix
@@ -68,6 +68,7 @@ let
       optionPath,
       getModule,
       forwardPathFn,
+      schemaIncludes ? [ ],
     }:
     let
       # Keyed module wrapper: the NixOS module system deduplicates imports
@@ -115,10 +116,13 @@ let
           let
             pairs = mkIntoClassUsers className { inherit host; };
             resolves = map (
-              pair: den.lib.policy.resolve.withIncludes [ userForward ] { user = pair.user; }
+              pair:
+              den.lib.policy.resolve.withIncludes ([ userForward ] ++ schemaIncludes) {
+                user = pair.user;
+              }
             ) pairs;
           in
-          resolves ++ classIncludes;
+          resolves ++ classIncludes ++ map (inc: den.lib.policy.include inc) schemaIncludes;
 
       # Complements the host-scope battery which only sees users
       # declared on host.users, not registry or policy-resolved users.

--- a/nix/lib/policy-effects.nix
+++ b/nix/lib/policy-effects.nix
@@ -244,6 +244,11 @@ in
           includes = [ ];
         };
       # Wrap a policy value with predicate gating (dispatch path).
+      # Pre-check the predicate's required args against ctx so the wrapper
+      # does not fire in contexts that would crash the predicate's
+      # destructuring pattern (e.g. { host, ... } in a home-only scope).
+      predicateArgs = if builtins.isFunction predicate then builtins.functionArgs predicate else { };
+      predicateRequiredArgs = builtins.filter (k: !predicateArgs.${k}) (builtins.attrNames predicateArgs);
       wrapAsPolicy =
         p:
         let
@@ -252,7 +257,9 @@ in
         {
           __isPolicy = true;
           inherit (inner) name;
-          fn = ctx: if predicate ctx then inner.fn ctx else [ ];
+          fn =
+            ctx:
+            if builtins.all (k: ctx ? ${k}) predicateRequiredArgs && predicate ctx then inner.fn ctx else [ ];
         };
       wrap =
         p: if p.__isPolicy or false || builtins.isFunction p then wrapAsPolicy p else wrapAsConditional p;

--- a/templates/ci/modules/features/deadbugs/hm-host-forward-hm-class.nix
+++ b/templates/ci/modules/features/deadbugs/hm-host-forward-hm-class.nix
@@ -1,0 +1,62 @@
+# Regression: schema.hm-host includes with homeManager class keys are not
+# forwarded into the home-manager config.  The nixos class works because it
+# emits directly at the host scope, but homeManager content is stranded at
+# the host scope with no route — it needs to enter user sub-scopes where
+# the userForward route carries it to home-manager.users.<name>.
+{ denTest, ... }:
+{
+  flake.tests.hm-host-forward-hm-class = {
+
+    # homeManager key in hm-host schema should reach user's HM config
+    test-hm-host-forwards-homemanager-class = denTest (
+      {
+        den,
+        igloo,
+        tuxHm,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+
+        den.schema.hm-host.includes = [
+          {
+            nixos.services.openssh.enable = true;
+            homeManager.programs.vim.enable = true;
+          }
+        ];
+
+        expr = {
+          ssh = igloo.services.openssh.enable;
+          vim = tuxHm.programs.vim.enable;
+        };
+        expected = {
+          ssh = true;
+          vim = true;
+        };
+      }
+    );
+
+    # Multiple users should each receive the homeManager content
+    test-hm-host-forwards-hm-to-all-users = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.hosts.x86_64-linux.igloo.users.pingu = { };
+
+        den.schema.hm-host.includes = [
+          { homeManager.programs.vim.enable = true; }
+        ];
+
+        expr = {
+          tux = igloo.home-manager.users.tux.programs.vim.enable;
+          pingu = igloo.home-manager.users.pingu.programs.vim.enable;
+        };
+        expected = {
+          tux = true;
+          pingu = true;
+        };
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/deadbugs/hm-host-standalone-crash.nix
+++ b/templates/ci/modules/features/deadbugs/hm-host-standalone-crash.nix
@@ -1,0 +1,52 @@
+# Regression: schema.hm-host crashes when a standalone home exists alongside
+# hosts with HM users.  The hmHostBridge policy's predicate (hasHmUsers)
+# destructures { host, ... } but policy.when lost the arg signature, causing
+# the policy to fire in contexts without host.
+{ denTest, ... }:
+{
+  flake.tests.hm-host-standalone-crash = {
+
+    # Core bug: standalone home + hm-host schema → crash
+    test-hm-host-with-standalone-home = denTest (
+      { den, igloo, ... }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.homes.x86_64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+
+        den.schema.hm-host.includes = [
+          { nixos.home-manager.useGlobalPkgs = true; }
+        ];
+
+        expr = igloo.home-manager.useGlobalPkgs;
+        expected = true;
+      }
+    );
+
+    # Standalone home should still resolve independently
+    test-standalone-home-unaffected = denTest (
+      {
+        config,
+        den,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.homes.x86_64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+        den.default.includes = [ den.provides.define-user ];
+
+        den.schema.hm-host.includes = [
+          { nixos.home-manager.useGlobalPkgs = true; }
+        ];
+        den.schema.home.includes = [
+          { homeManager.programs.home-manager.enable = true; }
+        ];
+
+        expr = config.flake.homeConfigurations.tux.config.programs.home-manager.enable;
+        expected = true;
+      }
+    );
+
+  };
+}

--- a/templates/ci/modules/features/deadbugs/policy-when-arg-safety.nix
+++ b/templates/ci/modules/features/deadbugs/policy-when-arg-safety.nix
@@ -47,5 +47,51 @@
       }
     );
 
+    # Optional args in the predicate should not trigger the safety check —
+    # the policy should still fire when the optional arg is absent.
+    test-when-optional-args-still-fire = denTest (
+      {
+        den,
+        igloo,
+        config,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.homes.x86_64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+
+        den.schema.host.includes = [
+          {
+            includes = [
+              (den.lib.policy.when
+                (
+                  {
+                    host ? null,
+                    ...
+                  }:
+                  host != null
+                )
+                (
+                  den.lib.policy.mkPolicy "optional-arg-policy" (_: [
+                    (den.lib.policy.include { nixos.services.openssh.enable = true; })
+                  ])
+                )
+              )
+            ];
+          }
+        ];
+
+        expr = {
+          host-gets-policy = igloo.services.openssh.enable;
+          home-resolves = config.flake.homeConfigurations ? tux;
+        };
+        expected = {
+          host-gets-policy = true;
+          home-resolves = true;
+        };
+      }
+    );
+
   };
 }

--- a/templates/ci/modules/features/deadbugs/policy-when-arg-safety.nix
+++ b/templates/ci/modules/features/deadbugs/policy-when-arg-safety.nix
@@ -1,0 +1,51 @@
+# Regression: policy.when wraps the predicate in fn = ctx: if predicate ctx ...
+# which loses the predicate's argument signature.  resolveArgsSatisfied sees
+# the wrapper as accepting any context, so the policy fires in scopes where
+# the predicate's required args are missing → crash.
+#
+# The bug requires cross-scope dispatch: a host-scoped policy.when with
+# { host, ... } predicate is picked up during standalone home resolution
+# via late dispatch, firing in a context that lacks host.
+{ denTest, ... }:
+{
+  flake.tests.policy-when-arg-safety = {
+
+    # policy.when with { host, ... } predicate must not crash when a
+    # standalone home triggers cross-scope dispatch
+    test-when-strict-predicate-safe-with-standalone-home = denTest (
+      {
+        den,
+        igloo,
+        config,
+        ...
+      }:
+      {
+        den.hosts.x86_64-linux.igloo.users.tux = { };
+        den.homes.x86_64-linux.tux = { };
+        den.default.homeManager.home.stateVersion = "25.11";
+
+        den.schema.host.includes = [
+          {
+            includes = [
+              (den.lib.policy.when ({ host, ... }: host.name == "igloo") (
+                den.lib.policy.mkPolicy "guarded-host-policy" (_: [
+                  (den.lib.policy.include { nixos.services.openssh.enable = true; })
+                ])
+              ))
+            ];
+          }
+        ];
+
+        expr = {
+          host-gets-policy = igloo.services.openssh.enable;
+          home-resolves = config.flake.homeConfigurations ? tux;
+        };
+        expected = {
+          host-gets-policy = true;
+          home-resolves = true;
+        };
+      }
+    );
+
+  };
+}


### PR DESCRIPTION
## Summary

- **policy.when arg safety**: wrappers now pre-check the predicate's required args against the dispatch context before calling it. Prevents crash when `{ host, ... }` predicates dispatch in non-host contexts (e.g., standalone home resolution via late dispatch).
- **Fold hmHostBridge into makeHomeEnv**: added `schemaIncludes` parameter so the battery's `policyFn` includes schema content at both host scope (nixos/darwin keys) and user sub-scopes (homeManager keys route via `userForward`). Eliminates the separate bridge, `hasHmUsers`, and conditional host includes entry.

Fixes three user-reported issues:
1. `schema.hm-host` crashes when a standalone `den.homes` exists alongside hosts with HM users
2. `schema.hm-host` includes with `homeManager` class keys are silently dropped (nixos keys worked, homeManager didn't)
3. `policy.when` with strict predicates crashes in cross-scope dispatch contexts

## Test plan

- [ ] 6 new regression tests in `deadbugs/` (policy-when arg safety, standalone crash, homeManager forwarding)
- [ ] 829/829 existing CI tests pass
- [ ] `nix develop -c just ci` clean