### PR TITLE
fix: inline permission check in allow-ci job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,20 @@ jobs:
     needs: [non-draft]
     name: allow-ci
     runs-on: ubuntu-latest
-    if: ${{github.ref == 'refs/heads/main' || contains( github.event.pull_request.labels.*.name, 'allow-ci')}}
+    # Label check kept as fast-path; permission check runs when label is absent.
+    # auto-allow-ci adds the label via GITHUB_TOKEN which does not re-trigger
+    # workflows, so the label may not be present on the first run.
     steps:
-      - run: true
+      - name: Check access
+        if: ${{github.ref != 'refs/heads/main' && !contains( github.event.pull_request.labels.*.name, 'allow-ci')}}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          perm=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission --jq '.permission')
+          if [[ "$perm" != "admin" && "$perm" != "write" ]]; then
+            echo "::error::PR author does not have write access and PR is missing allow-ci label"
+            exit 1
+          fi
   noflake:
     needs: [allow-ci]
     name: noflake


### PR DESCRIPTION
## Summary

- **Root cause**: `auto-allow-ci` adds the `allow-ci` label via `GITHUB_TOKEN`, but actions using `GITHUB_TOKEN` [do not trigger new workflow runs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow). The `labeled` event never fires for `test.yml`, so `allow-ci` is always skipped on the first (and only) run.
- **Fix**: Inline the collaborator permission check directly into the `allow-ci` job. When the label isn't present, the job checks `collaborators/{user}/permission` via the API. The label is kept as a fast-path and manual override for external contributor PRs.

## Behavior matrix

| Context | Result |
|---------|--------|
| Push to main | Step skipped, job succeeds |
| PR with `allow-ci` label | Step skipped, job succeeds |
| PR without label, author has write/admin | Step runs, permission passes, job succeeds |
| PR without label, external contributor | Step runs, permission fails, downstream blocked |

## Test plan

- [ ] Open a collaborator PR without manually adding label → template checks should run
- [ ] Verify `allow-ci` label still works as manual override